### PR TITLE
implement PytorchContext.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,10 @@ endif()
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
-include(googletest)
 include(pybind11)
+include(torch)
 include(cub)
+include(googletest)
+
 
 add_subdirectory(k2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BUILD_SHARED_LIBS "Whether to build shared or static lib" ON)
+option(USE_PYTORCH "Whether to build with PyTorch" ON)
+
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
@@ -94,7 +96,9 @@ enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(pybind11)
-include(torch)
+if(USE_PYTORCH)
+  include(torch)
+endif()
 include(cub)
 include(googletest)
 

--- a/cmake/torch.cmake
+++ b/cmake/torch.cmake
@@ -1,0 +1,14 @@
+
+# PYTHON_EXECUTABLE is set by pybind11.cmake
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c "import os; import torch; print(os.path.dirname(torch.__file__))"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE TORCH_DIR
+)
+
+list(APPEND CMAKE_PREFIX_PATH "${TORCH_DIR}")
+find_package(Torch REQUIRED)
+
+# set the global CMAKE_CXX_FLAGS so that
+# k2 uses the same abi flag as PyTorch
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -6,24 +6,35 @@ add_subdirectory(host)
 
 #---------------------------- Build K2 CUDA sources ----------------------------
 
+# please keep it sorted
+set(context_srcs
+  array_ops.cu
+  compose.cu
+  context.cu
+  dtype.cu
+  fsa.cu
+  fsa_algo.cu
+  math.cu
+  ragged.cu
+  tensor.cu
+  utils.cu
+)
+
+if(USE_PYTORCH)
+  list(APPEND context_srcs pytorch_context.cu)
+else()
+  list(APPEND context_srcs default_context.cu)
+endif()
+
 # the target
-add_library(context STATIC
-    array_ops.cu
-    compose.cu
-    context.cu
-    dtype.cu
-    fsa.cu
-    fsa_algo.cu
-    math.cu
-    ragged.cu
-    tensor.cu
-    utils.cu
-    )
+add_library(context STATIC ${context_srcs})
 set_target_properties(context PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 # lib deps
 target_link_libraries(context PUBLIC cub)
-target_link_libraries(context PUBLIC ${TORCH_LIBRARIES})
+if(USE_PYTORCH)
+  target_link_libraries(context PUBLIC ${TORCH_LIBRARIES})
+endif()
 
 #---------------------------- Test K2 CUDA sources ----------------------------
 

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -23,6 +23,7 @@ set_target_properties(context PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 # lib deps
 target_link_libraries(context PUBLIC cub)
+target_link_libraries(context PUBLIC ${TORCH_LIBRARIES})
 
 #---------------------------- Test K2 CUDA sources ----------------------------
 

--- a/k2/csrc/context.cu
+++ b/k2/csrc/context.cu
@@ -14,6 +14,7 @@
 
 #include "k2/csrc/context.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/pytorch_context.h"
 
 namespace k2 {
 
@@ -101,7 +102,7 @@ class CudaContext : public Context {
 ContextPtr GetCpuContext() { return std::make_shared<CpuContext>(); }
 
 ContextPtr GetCudaContext(int32_t gpu_id /*= -1*/) {
-  return std::make_shared<CudaContext>(gpu_id);
+  return std::make_shared<PytorchContext>(gpu_id);
 }
 
 RegionPtr NewRegion(ContextPtr &context, std::size_t num_bytes) {

--- a/k2/csrc/context.cu
+++ b/k2/csrc/context.cu
@@ -3,107 +3,16 @@
  * context
  *
  * @copyright
- * Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+ * Copyright (c)  2020  Mobvoi AI Lab, Beijing, China (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (author: Haowen Qiu)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
  */
 
-#include <cstdlib>
-
 #include "k2/csrc/context.h"
-#include "k2/csrc/log.h"
-#include "k2/csrc/pytorch_context.h"
 
 namespace k2 {
-
-static constexpr std::size_t kAlignment = 64;
-
-// TODO(haowen): most of implementations below should be updated later.
-class CpuContext : public Context {
- public:
-  ContextPtr GetCpuContext() override { return nullptr; }
-  ContextPtr GetPinnedContext() override { return nullptr; }
-  DeviceType GetDeviceType() const override { return kCpu; }
-
-  void *Allocate(std::size_t bytes, void **deleter_context) override {
-    void *p = nullptr;
-    if (bytes) {
-      int32_t ret = posix_memalign(&p, kAlignment, bytes);
-      K2_CHECK_EQ(ret, 0);
-    }
-    if (deleter_context) *deleter_context = nullptr;
-    return p;
-  }
-
-  bool IsCompatible(const Context &other) const override {
-    return other.GetDeviceType() == kCpu;
-  }
-
-  void Deallocate(void *data, void * /*deleter_context*/) override {
-    free(data);
-  }
-};
-
-class CudaContext : public Context {
- public:
-  explicit CudaContext(int32_t gpu_id) : gpu_id_(gpu_id) {
-    if (gpu_id_ != -1) {
-      auto ret = cudaSetDevice(gpu_id_);
-      K2_CHECK_CUDA_ERROR(ret);
-    }
-    // TODO(haowen): choose one from available GPUs if gpu_id == -1?
-    // and handle GPU ids from multiple machines.
-    auto ret = cudaStreamCreate(&stream_);
-    K2_CHECK_CUDA_ERROR(ret);
-  }
-  ContextPtr GetCpuContext() override { return nullptr; }
-  ContextPtr GetPinnedContext() override { return nullptr; }
-  DeviceType GetDeviceType() const override { return kCuda; }
-  int32_t GetDeviceId() const override { return gpu_id_; }
-
-  void *Allocate(std::size_t bytes, void **deleter_context) override {
-    void *p = nullptr;
-    if (bytes) {
-      auto ret = cudaMalloc(&p, bytes);
-      K2_CHECK_CUDA_ERROR(ret);
-    }
-    if (deleter_context) *deleter_context = nullptr;
-    return p;
-  }
-
-  bool IsCompatible(const Context &other) const override {
-    return other.GetDeviceType() == kCuda && other.GetDeviceId() == gpu_id_;
-  }
-
-  void Deallocate(void *data, void * /*deleter_context*/) override {
-    auto ret = cudaFree(data);
-    K2_CHECK_CUDA_ERROR(ret);
-  }
-
-  cudaStream_t GetCudaStream() const override { return stream_; }
-
-  void Sync() const override {
-    auto ret = cudaStreamSynchronize(stream_);
-    K2_CHECK_CUDA_ERROR(ret);
-  }
-
-  ~CudaContext() {
-    auto ret = cudaStreamDestroy(stream_);
-    K2_CHECK_CUDA_ERROR(ret);
-  }
-
- private:
-  int32_t gpu_id_;
-  cudaStream_t stream_;
-};
-
-ContextPtr GetCpuContext() { return std::make_shared<CpuContext>(); }
-
-ContextPtr GetCudaContext(int32_t gpu_id /*= -1*/) {
-  return std::make_shared<PytorchContext>(gpu_id);
-}
 
 RegionPtr NewRegion(ContextPtr &context, std::size_t num_bytes) {
   // .. fairly straightforward.  Sets bytes_used to num_bytes, caller can

--- a/k2/csrc/default_context.cu
+++ b/k2/csrc/default_context.cu
@@ -1,0 +1,107 @@
+/**
+ * @brief
+ * default_context
+ *
+ * @copyright
+ * Copyright (c)  2020  Mobvoi AI Lab, Beijing, China (authors: Fangjun Kuang)
+ *                      Xiaomi Corporation (author: Haowen Qiu)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ */
+
+#include <cstdlib>
+
+#include "k2/csrc/context.h"
+#include "k2/csrc/log.h"
+
+namespace k2 {
+
+static constexpr std::size_t kAlignment = 64;
+
+// TODO(haowen): most of implementations below should be updated later.
+class CpuContext : public Context {
+ public:
+  ContextPtr GetCpuContext() override { return nullptr; }
+  ContextPtr GetPinnedContext() override { return nullptr; }
+  DeviceType GetDeviceType() const override { return kCpu; }
+
+  void *Allocate(std::size_t bytes, void **deleter_context) override {
+    void *p = nullptr;
+    if (bytes) {
+      int32_t ret = posix_memalign(&p, kAlignment, bytes);
+      K2_CHECK_EQ(ret, 0);
+    }
+    if (deleter_context) *deleter_context = nullptr;
+    return p;
+  }
+
+  bool IsCompatible(const Context &other) const override {
+    return other.GetDeviceType() == kCpu;
+  }
+
+  void Deallocate(void *data, void * /*deleter_context*/) override {
+    free(data);
+  }
+};
+
+class CudaContext : public Context {
+ public:
+  explicit CudaContext(int32_t gpu_id) : gpu_id_(gpu_id) {
+    if (gpu_id_ != -1) {
+      auto ret = cudaSetDevice(gpu_id_);
+      K2_CHECK_CUDA_ERROR(ret);
+    }
+    // TODO(haowen): choose one from available GPUs if gpu_id == -1?
+    // and handle GPU ids from multiple machines.
+    auto ret = cudaStreamCreate(&stream_);
+    K2_CHECK_CUDA_ERROR(ret);
+  }
+  ContextPtr GetCpuContext() override { return nullptr; }
+  ContextPtr GetPinnedContext() override { return nullptr; }
+  DeviceType GetDeviceType() const override { return kCuda; }
+  int32_t GetDeviceId() const override { return gpu_id_; }
+
+  void *Allocate(std::size_t bytes, void **deleter_context) override {
+    void *p = nullptr;
+    if (bytes) {
+      auto ret = cudaMalloc(&p, bytes);
+      K2_CHECK_CUDA_ERROR(ret);
+    }
+    if (deleter_context) *deleter_context = nullptr;
+    return p;
+  }
+
+  bool IsCompatible(const Context &other) const override {
+    return other.GetDeviceType() == kCuda && other.GetDeviceId() == gpu_id_;
+  }
+
+  void Deallocate(void *data, void * /*deleter_context*/) override {
+    auto ret = cudaFree(data);
+    K2_CHECK_CUDA_ERROR(ret);
+  }
+
+  cudaStream_t GetCudaStream() const override { return stream_; }
+
+  void Sync() const override {
+    auto ret = cudaStreamSynchronize(stream_);
+    K2_CHECK_CUDA_ERROR(ret);
+  }
+
+  ~CudaContext() {
+    auto ret = cudaStreamDestroy(stream_);
+    K2_CHECK_CUDA_ERROR(ret);
+  }
+
+ private:
+  int32_t gpu_id_;
+  cudaStream_t stream_;
+};
+
+ContextPtr GetCpuContext() { return std::make_shared<CpuContext>(); }
+
+ContextPtr GetCudaContext(int32_t gpu_id /*= -1*/) {
+  return std::make_shared<CudaContext>(gpu_id);
+}
+
+}  // namespace k2

--- a/k2/csrc/pytorch_context.cu
+++ b/k2/csrc/pytorch_context.cu
@@ -9,7 +9,8 @@
  * See LICENSE for clarification regarding multiple authors
  */
 
-#include "k2/csrc/log.h"
+#include <memory>
+
 #include "k2/csrc/pytorch_context.h"
 
 namespace k2 {

--- a/k2/csrc/pytorch_context.cu
+++ b/k2/csrc/pytorch_context.cu
@@ -1,0 +1,24 @@
+/**
+ * @brief
+ * pytorch_context
+ *
+ * @copyright
+ * Copyright (c)  2020  Mobvoi AI Lab, Beijing, China (authors: Fangjun Kuang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ */
+
+#include "k2/csrc/log.h"
+#include "k2/csrc/pytorch_context.h"
+
+namespace k2 {
+
+ContextPtr GetCpuContext() { return std::make_shared<PytorchContext>(-1); }
+
+ContextPtr GetCudaContext(int32_t gpu_id /*= -1*/) {
+  if (gpu_id < 0) gpu_id = 0;  // TODO(fangjun): select a device
+  return std::make_shared<PytorchContext>(gpu_id);
+}
+
+}  // namespace k2

--- a/k2/csrc/pytorch_context.h
+++ b/k2/csrc/pytorch_context.h
@@ -2,11 +2,9 @@
  * @brief
  * pytorch_context
  *
- * @todo
- * must include Torch headers.
- *
  * @copyright
  * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ *                      Fangjun Kuang (csukuangfj@gmail.com)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
@@ -15,10 +13,62 @@
 #ifndef K2_CSRC_PYTORCH_CONTEXT_H_
 #define K2_CSRC_PYTORCH_CONTEXT_H_
 
+#include "c10/cuda/CUDACachingAllocator.h"
 #include "k2/csrc/context.h"
+#include "k2/csrc/log.h"
+#include "torch/torch.h"
+
+namespace k2 {
 
 class PytorchContext : public Context {
-  // ...
+ public:
+  explicit PytorchContext(int32_t gpu_id) : gpu_id_(gpu_id) {
+    if (gpu_id < 0) gpu_id_ = 0;  // TODO(fangjun): select a gpu
+    auto ret = cudaSetDevice(gpu_id_);
+    K2_CHECK_CUDA_ERROR(ret);
+    // TODO(fangjun): invoke init only once
+    c10::cuda::CUDACachingAllocator::init(gpu_id_ + 1);
+
+    allocator_ = c10::cuda::CUDACachingAllocator::get();
+    K2_CHECK(allocator_->raw_deleter() != nullptr);
+  }
+
+  ContextPtr GetCpuContext() override { return nullptr; }
+
+  ContextPtr GetPinnedContext() override { return nullptr; }
+
+  DeviceType GetDeviceType() const override { return kCuda; }
+
+  int32_t GetDeviceId() const override { return gpu_id_; }
+
+  cudaStream_t GetCudaStream() const override {
+    return c10::cuda::getCurrentCUDAStream(gpu_id_);
+  }
+
+  void *Allocate(std::size_t bytes, void **deleter_context) override {
+    void *p = allocator_->raw_allocate(bytes);
+    if (deleter_context) *deleter_context = nullptr;
+    return p;
+  }
+
+  void Deallocate(void *data, void * /*deleter_context*/) override {
+    allocator_->raw_deallocate(data);
+  }
+
+  bool IsCompatible(const Context &other) const override {
+    return other.GetDeviceType() == kCuda && other.GetDeviceId() == gpu_id_;
+  }
+
+  void Sync() const override {
+    auto ret = cudaStreamSynchronize(GetCudaStream());
+    K2_CHECK_CUDA_ERROR(ret);
+  }
+
+ private:
+  torch::Allocator *allocator_;  // NOT owned here
+  int32_t gpu_id_;
 };
+
+}  // namespace k2
 
 #endif  // K2_CSRC_PYTORCH_CONTEXT_H_


### PR DESCRIPTION
Make PytorchContext the default cuda context.

The [colab notebook][1] shows that all cuda related test cases are passed.

[1]: https://colab.research.google.com/drive/1qbHUhNZUX7AYEpqnZyf29Lrz2IPHBGlX?usp=sharing#scrollTo=Gl6iGTSVAgMh