### PR TITLE
Added a note in INSTALL regarding the cmake version

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,3 +7,8 @@ The installation instructions are
 
 You can run tests with
     make test
+
+Note: The current installation only works with certain versions of cmake, e.g.,
+      it works with cmake v3.18.0, but it does not work with cmake v3.16.3. We
+      have not done a thorough test on this yet. Try to use v3.18.0 if you get
+      issues running the installation.


### PR DESCRIPTION
I started by using cmake v3.16.3, and I got error message `nvcc fatal : Unknown option '-Wall'`. Somehow cmake was passing the cxx flags to the cuda flags. The issue was fixed after upgrading to cmake v3.18.0. I added a note in the INSTALL file that we haven't tested all version of cmake and people should probably start with cmake v3.18.0.

At some point we may want to improve the installation process by (my two cents):
* Write dependency documentation (in INSTALL?). Add requirements.txt for Python dependencies.
* Let users choose their own Python environment. For now, cmake automatically picks up the Python environment. This is not ideal for Python developers as people may have a lot of different environments (through virtual environment), and the one picked up by cmake may or may not work.