### PR TITLE
Added weight support for StringToFsa and FsaToString

### DIFF
--- a/k2/csrc/host/dense_fsa.h
+++ b/k2/csrc/host/dense_fsa.h
@@ -4,6 +4,7 @@
  *
  * @copyright
  * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ *                      Guoguo Chen
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
@@ -108,8 +109,8 @@ struct DenseFsaVecMeta {
   int32_t num_segs;     // The number of segments
   int32_t max_seg_len;  // The largest number of frames (not counting the zero
                         // padding frame) in any segment
-  int32_t
-      num_symbols;  // the number of symbols (== num-cols in features matrix)
+  int32_t num_symbols;  // the number of symbols (== num-cols in features
+                        // matrix)
 
   int32_t seg_frame_index[];  // size equals num_segs + 1; look at the next
                               // element for the last-plus-one frame.

--- a/k2/csrc/host/fsa.h
+++ b/k2/csrc/host/fsa.h
@@ -2,6 +2,7 @@
 
 // Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
 //                                                   Haowen Qiu)
+//                      Guoguo Chen
 
 // See ../../LICENSE for clarification regarding multiple authors
 
@@ -79,9 +80,9 @@ struct ArcHash {
 };
 
 /*
-  struct Fsa is an unweighted finite-state acceptor (FSA) and is at the core of
-  operations on weighted FSA's and finite state transducers (FSTs).  Note: being
-  a final-state is represented by an arc with label == kFinalSymbol to
+  struct Fsa is a weighted finite-state acceptor (FSA) and is at the core of
+  operations on weighted finite state transducers (WFSTs). Note: being a
+  final-state is represented by an arc with label == kFinalSymbol to
   final_state.
 
   The start-state is always numbered zero and the final-state is always the

--- a/k2/csrc/host/fsa_util.cc
+++ b/k2/csrc/host/fsa_util.cc
@@ -79,7 +79,7 @@ int32_t StringToInt(const std::string &s, bool *is_ok = nullptr) {
                       is successful; false otherwise
   @return The converted float number.
  */
-int32_t StringToFloat(const std::string &s, bool *is_ok = nullptr) {
+float StringToFloat(const std::string &s, bool *is_ok = nullptr) {
   K2_CHECK_EQ(s.empty(), false);
 
   bool ok = false;
@@ -100,21 +100,6 @@ std::vector<int32_t> StringVectorToIntVector(
   for (const auto &s : in) {
     bool ok = false;
     auto n = StringToInt(s, &ok);
-    K2_CHECK(ok);
-    res.push_back(n);
-  }
-  return res;
-}
-
-/** Convert `std::vector<std::string>` to `std::vector<float>`.
- */
-std::vector<float> StringVectorToFloatVector(
-    const std::vector<std::string> &in) {
-  std::vector<float> res;
-  res.reserve(in.size());
-  for (const auto &s : in) {
-    bool ok = false;
-    auto n = StringToFloat(s, &ok);
     K2_CHECK(ok);
     res.push_back(n);
   }
@@ -279,15 +264,14 @@ void StringToFsa::ReadArcsFromString() {
 
     K2_CHECK_EQ(finished, false);
 
-    auto fields = StringVectorToFloatVector(splits);
-    auto num_fields = fields.size();
+    auto num_fields = splits.size();
     if (num_fields == 3u || num_fields == 4u) {
       Arc arc{};
-      arc.src_state = static_cast<int32_t>(fields[0]);
-      arc.dest_state = static_cast<int32_t>(fields[1]);
-      arc.label = static_cast<int32_t>(fields[2]);
+      arc.src_state = StringToInt(splits[0]);
+      arc.dest_state = StringToInt(splits[1]);
+      arc.label = StringToInt(splits[2]);
       if (num_fields == 4u) {
-        arc.weight = fields[3];
+        arc.weight = StringToFloat(splits[3]);
       }
 
       auto new_size = std::max(arc.src_state, arc.dest_state);
@@ -299,16 +283,16 @@ void StringToFsa::ReadArcsFromString() {
       // TODO(guoguo): the original code only supports one final state. Is it
       //               necessary to supports multiple final states?
       finished = true;
-      K2_CHECK_EQ(static_cast<int32_t>(fields[0]) + 1,
+      K2_CHECK_EQ(StringToInt(splits[0]) + 1,
                   static_cast<int32_t>(arcs_.size()));
       if (num_fields == 2u) {
         arcs_.resize(arcs_.size() + 1);
         // If the final state bears a weight, we convert that into an arc.
         Arc arc{};
-        arc.src_state = static_cast<int32_t>(fields[0]);
-        arc.dest_state = static_cast<int32_t>(fields[0]) + 1;
+        arc.src_state = StringToInt(splits[0]);
+        arc.dest_state = StringToInt(splits[0]) + 1;
         arc.label = k2host::kFinalSymbol;
-        arc.weight = fields[1];
+        arc.weight = StringToFloat(splits[1]);
         arcs_[arc.src_state].push_back(arc);
         ++num_arcs_;
       }

--- a/k2/csrc/host/fsa_util.cc
+++ b/k2/csrc/host/fsa_util.cc
@@ -75,7 +75,7 @@ int32_t StringToInt(const std::string &s, bool *is_ok = nullptr) {
 /** Convert a string to a float number.
 
   @param [in]   s     The input string.
-  @param [out]  is    If non-null, it is set to true when the conversion
+  @param [out]  is_ok If non-null, it is set to true when the conversion
                       is successful; false otherwise
   @return The converted float number.
  */
@@ -265,37 +265,22 @@ void StringToFsa::ReadArcsFromString() {
     K2_CHECK_EQ(finished, false);
 
     auto num_fields = splits.size();
-    if (num_fields == 3u || num_fields == 4u) {
+    if (num_fields == 4u) {
       Arc arc{};
       arc.src_state = StringToInt(splits[0]);
       arc.dest_state = StringToInt(splits[1]);
       arc.label = StringToInt(splits[2]);
-      if (num_fields == 4u) {
-        arc.weight = StringToFloat(splits[3]);
-      }
+      arc.weight = StringToFloat(splits[3]);
 
       auto new_size = std::max(arc.src_state, arc.dest_state);
       if (new_size >= arcs_.size()) arcs_.resize(new_size + 1);
 
       arcs_[arc.src_state].push_back(arc);
       ++num_arcs_;
-    } else if (num_fields == 1u || num_fields == 2u) {
-      // TODO(guoguo): the original code only supports one final state. Is it
-      //               necessary to supports multiple final states?
+    } else if (num_fields == 1u) {
       finished = true;
       K2_CHECK_EQ(StringToInt(splits[0]) + 1,
                   static_cast<int32_t>(arcs_.size()));
-      if (num_fields == 2u) {
-        arcs_.resize(arcs_.size() + 1);
-        // If the final state bears a weight, we convert that into an arc.
-        Arc arc{};
-        arc.src_state = StringToInt(splits[0]);
-        arc.dest_state = StringToInt(splits[0]) + 1;
-        arc.label = k2host::kFinalSymbol;
-        arc.weight = StringToFloat(splits[1]);
-        arcs_[arc.src_state].push_back(arc);
-        ++num_arcs_;
-      }
     } else {
       K2_LOG(FATAL) << "invalid line: " << line;
     }

--- a/k2/csrc/host/fsa_util.h
+++ b/k2/csrc/host/fsa_util.h
@@ -208,11 +208,10 @@ void CreateFsa(const std::vector<Arc> &arcs, Fsa *fsa,
   from_state  to_state  label  weight
   from_state  to_state  label  weight
   ... ...
-  final_state weight
+  final_state
 
-  Technically, K2's final_state does not bear a weight -- OpenFST's final-state
-  is represented by an arc with label == kFinalSymbol to the final_state in K2.
-  The implementation of StringToFsa takes care of both cases.
+  K2's final_state does not bear a weight -- OpenFST's final-state is
+  represented by an arc with label == kFinalSymbol to the final_state in K2.
 
   K2 requires that the final state has the largest state number. The above
   format requires the last line to be the final state, whose sole purpose is

--- a/k2/csrc/host/fsa_util_test.cc
+++ b/k2/csrc/host/fsa_util_test.cc
@@ -113,7 +113,7 @@ TEST(FsaUtil, StringToFsa) {
 2 6 1 -0.5
 2 4 2 -0.6
 5 0 1 -0.7
-6 -0.8
+6
 )";
   StringToFsa fsa_creator(s);
   Array2Size<int32_t> fsa_size;
@@ -125,17 +125,17 @@ TEST(FsaUtil, StringToFsa) {
 
   ASSERT_FALSE(IsEmpty(fsa));
 
-  ASSERT_EQ(fsa.size1, 8);
-  ASSERT_EQ(fsa.size2, 8);
+  ASSERT_EQ(fsa.size1, 7);
+  ASSERT_EQ(fsa.size2, 7);
 
   std::vector<int32_t> arc_indexes(fsa.indexes, fsa.indexes + fsa.size1 + 1);
   std::vector<Arc> arcs(fsa.data, fsa.data + fsa.size2);
 
-  EXPECT_THAT(arc_indexes, ::testing::ElementsAre(0, 2, 4, 6, 6, 6, 7, 8, 8));
+  EXPECT_THAT(arc_indexes, ::testing::ElementsAre(0, 2, 4, 6, 6, 6, 7, 7));
 
   std::vector<Arc> expected_arcs = {
       {0, 1, 2, -0.1}, {0, 2, 10, -0.2}, {1, 3, 3, -0.3}, {1, 6, 6, -0.4},
-      {2, 6, 1, -0.5}, {2, 4, 2, -0.6},  {5, 0, 1, -0.7}, {6, 7, -1, -0.8}
+      {2, 6, 1, -0.5}, {2, 4, 2, -0.6},  {5, 0, 1, -0.7},
   };
 
   auto n = static_cast<int32_t>(expected_arcs.size());


### PR DESCRIPTION
Things I did:
   * Added weight support to both StringToFsa and FsaToString
   * Removed GetArcWeights as it's not used in other places and doesn't seem to be necessary
   * Moved the actual string read work out of StringToFsa::GetSizes(). The previous implementation assumes that user first run StringToFsa::GetSizes() and then run StringToFsa::GetOutput(), but they are both public functions. Assumptions like this will make programming more complicated.

Things to discuss:
   * How general should the input string FSA be? I did add support for final state with weight (typical OpenFst style WFSA) and convert that to K2 style (final state without weight), but I didn't extend it to support multiple final states (since the original code doesn't support it). Do we have to support all WFSAs that can be generated by e.g., fstprint?
   * I read weight as is, no conversions between scores/costs whatsoever. Do we have to convert it between scores/costs, and also check if that's valid weight?