### PR TITLE
release k2 as a pip package.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ statistics=true
 max-line-length=80
 exclude =
   .git,
+  setup.py,
   build,
   k2/python/host
 

--- a/scripts/build_pip.sh
+++ b/scripts/build_pip.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Steps to build a pip package:
+#
+# (1)
+#    pip install wheel twine
+#    sudo apt-get install chrpath
+#
+# (2)
+#    cd /path/to/k2
+#    mkdir build
+#    cd build
+#    cmake -DCMAKE_BUILD_TYPE=Release ..
+#    make -j _k2
+#
+# It will generate 3 files in the folder `lib`:
+#   libcontext.so
+#   libfsa.so
+#   _k2.cpython-3?m-x86_64-linux-gnu.so, where ? depends on your python version.
+#
+# Please delete other files inside `lib`; otherwise, they will be copied to
+# the final `whl`!
+#
+# (3)
+#    cd /path/to/k2
+#    ./scripts/build_pip.sh
+#
+# (4) You will find the `whl` file in the `dist` directory.
+#
+# (5) Upload the generated `whl` file to pypi. Example:
+#
+#     twine upload dist/k2-0.0.1-py36-none-any.whl
+#
+#   Enter your username and password!
+#
+# (6) Done.
+
+if ! command -v chrpath > /dev/null 2>&1; then
+  echo "Please install chrpath  first"
+  exit 1
+fi
+
+cur_dir=$(cd $(dirname $BASH_SOURCE) && pwd)
+k2_dir=$(cd $cur_dir/.. && pwd)
+build_dir=$k2_dir/build
+
+cd $k2_dir
+
+if [ ! -d $build_dir/lib ]; then
+  echo "Please run: "
+  echo "  mkdir $build_dir"
+  echo "  cd $build_dir"
+  echo "  cmake .."
+  echo "  make -j _k2 "
+  echo "before running this script"
+  exit 1
+fi
+
+for lib in $build_dir/lib/*.so; do
+  chrpath -r '$ORIGIN' $lib
+done
+
+tag=$(python -c "import sys; print(sys.version[:3].replace('.', ''))")
+
+python3 setup.py bdist_wheel --python-tag py$tag

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+import setuptools
+
+
+def get_long_description():
+    with open('README.md', 'r') as f:
+        long_description = f.read()
+        return long_description
+
+
+version = '0.0.1'
+description = 'FSA/FST algorithms, intended to (eventually) be interoperable with PyTorch and similar'
+
+setuptools.setup(
+    python_requires='>=3.6',
+    name='k2',
+    version=version,
+    author='Daniel Povey',
+    author_email='dpovey@gmail.com',
+    description=description,
+    keywords='k2, FSA, FST',
+    long_description=get_long_description(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/k2-fsa/k2',
+    package_dir={'': 'k2/python'},
+    packages=['k2'],
+    install_requires=['torch', 'graphviz'],
+    data_files=[('', ['LICENSE'])],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: C++',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        'Operating System :: OS Independent',
+    ],
+)


### PR DESCRIPTION
I've uploaded a pip package `k2-fsa` to  [pypi][1], which can be installed with

```bash
pip install k2-fsa==0.0.3
```
A demo is provided in [this colab notebook][2]

If @danpovey  you feel that this approach for building pip packages is fine, I'll rename the package to `k2` and
delete `k2-fsa` from pypi.

Note that it is built for Python 3.6 only.

CAUTION: the version 0.0.5 is for building documentation. Please do not install it.

[2]: https://colab.research.google.com/drive/1lOQdSuJYnSPbSbIn4EAPFDQFqZt4GMHx?usp=sharing
[1]: https://pypi.org/project/k2-fsa/