### PR TITLE
add readthedocs documentation status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
 [![GitHub Actions Status](https://github.com/danpovey/k2/workflows/build/badge.svg)](https://github.com/danpovey/k2/actions)
+[![Documentation Status](https://readthedocs.org/projects/k2/badge/?version=latest)](https://k2.readthedocs.io/en/latest/?badge=latest)
+
 
 
 # k2


### PR DESCRIPTION
The documentation setup is working.

> From Dan
> https://github.com/k2-fsa/k2/issues/109#issuecomment-686278990
>
> Ah OK I see.
Source here, for instance.
https://raw.githubusercontent.com/rwth-i6/returnn/master/docs/index.rst
I think that is a good approach.  Meixu, are you interested in setting up
some kind of stub that I could edit when I have time?

@danpovey  You can add more documentation when you have time. `readthedocs` will rebuild the master whenever
there is a new commit.