### PR TITLE
Refactored FSA reading code

### DIFF
--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -99,7 +99,7 @@ static void SplitStringToVector(const std::string &in, const char *delim,
   }
 }
 
-/* Create an acceptor from a stream, assuming the acceptor is in the K2 format:
+/* Create an acceptor from a stream, assuming the acceptor is in the k2 format:
 
    src_state1 dest_state1 label1 score1
    src_state2 dest_state2 label2 score2
@@ -143,8 +143,8 @@ static Fsa K2AcceptorFromStream(std::istringstream &is) {
       finished = true;               // set finish
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
-                    << "\nK2 acceptor expects a line with 1 (final_state) or "
-                    << "4 (src_state dest_state label score) fields";
+                    << "\nk2 acceptor expects a line with 1 (final_state) or "
+                       "4 (src_state dest_state label score) fields";
     }
   }
 
@@ -209,8 +209,8 @@ static Fsa K2TransducerFromStream(std::istringstream &is,
       finished = true;               // set finish
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
-                    << "\nK2 transducer expects a line with 1 (final_state) or "
-                    << "5 (src_state dest_state label aux_label score) fields";
+                    << "\nk2 transducer expects a line with 1 (final_state) or "
+                       "5 (src_state dest_state label aux_label score) fields";
     }
   }
 
@@ -246,7 +246,7 @@ static Fsa K2TransducerFromStream(std::istringstream &is,
 
    @return It returns an Fsa on CPU.
 */
-static Fsa OpenFSTAcceptorFromStream(std::istringstream &is) {
+static Fsa OpenFstAcceptorFromStream(std::istringstream &is) {
   std::vector<Arc> arcs;
   std::vector<std::vector<Arc>> state_to_arcs;            // indexed by states
   std::vector<std::string> splits;
@@ -298,8 +298,8 @@ static Fsa OpenFSTAcceptorFromStream(std::istringstream &is) {
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
                     << "\nOpenFST acceptor expects a line with 1 (final_state),"
-                    << " 2 (final_state score), 3 (src_state dest_state label) "
-                    << "or 4 (src_state dest_state label score) fields.";
+                       " 2 (final_state score), 3 (src_state dest_state label) "
+                       "or 4 (src_state dest_state label score) fields.";
     }
   }
 
@@ -308,7 +308,7 @@ static Fsa OpenFSTAcceptorFromStream(std::istringstream &is) {
 
   // Post processing on final states. We may have multiple final states with
   // weights associated with them for OpenFST style FSTs. We will have to add a
-  // super final state, and convert that into the K2 format (final state with no
+  // super final state, and convert that into the k2 format (final state with no
   // weight).
   if (original_final_states.size() > 0) {
     K2_CHECK_EQ(original_final_states.size(), original_final_weights.size());
@@ -363,7 +363,7 @@ static Fsa OpenFSTAcceptorFromStream(std::istringstream &is) {
 
    @return It returns an Fsa on CPU.
 */
-static Fsa OpenFSTTransducerFromStream(std::istringstream &is,
+static Fsa OpenFstTransducerFromStream(std::istringstream &is,
                                        Array1<int32_t> *aux_labels) {
   K2_CHECK(aux_labels != nullptr);
 
@@ -431,9 +431,9 @@ static Fsa OpenFSTTransducerFromStream(std::istringstream &is,
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
                     << "\nOpenFST transducer expects a line with "
-                    << "1 (final_state), 2 (final_state score), "
-                    << "4 (src_state dest_state label aux_label) or "
-                    << "5 (src_state dest_state label aux_label score) fields.";
+                       "1 (final_state), 2 (final_state score), "
+                       "4 (src_state dest_state label aux_label) or "
+                       "5 (src_state dest_state label aux_label score) fields.";
     }
   }
 
@@ -442,7 +442,7 @@ static Fsa OpenFSTTransducerFromStream(std::istringstream &is,
 
   // Post processing on final states. We may have multiple final states with
   // weights associated with them for OpenFST style FSTs. We will have to add a
-  // super final state, and convert that into the K2 format (final state with no
+  // super final state, and convert that into the k2 format (final state with no
   // weight).
   if (original_final_states.size() > 0) {
     K2_CHECK_EQ(original_final_states.size(), original_final_weights.size());
@@ -501,9 +501,9 @@ Fsa FsaFromString(const std::string &s, bool openfst /*= false*/,
   else if (openfst == false && aux_labels != nullptr)
     return K2TransducerFromStream(is, aux_labels);
   else if (openfst == true && aux_labels == nullptr)
-    return OpenFSTAcceptorFromStream(is);
+    return OpenFstAcceptorFromStream(is);
   else if (openfst == true && aux_labels != nullptr)
-    return OpenFSTTransducerFromStream(is, aux_labels);
+    return OpenFstTransducerFromStream(is, aux_labels);
 
   return Fsa();  // unreachable code
 }

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -210,7 +210,7 @@ static Fsa K2TransducerFromStream(std::istringstream &is,
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
                     << "\nK2 transducer expects a line with 1 (final_state) or "
-                    << "4 (src_state dest_state label aux_label score) fields";
+                    << "5 (src_state dest_state label aux_label score) fields";
     }
   }
 

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -99,75 +99,56 @@ static void SplitStringToVector(const std::string &in, const char *delim,
   }
 }
 
-// Create an acceptor from a stream.
-static Fsa AcceptorFromStream(std::string first_line, std::istringstream &is,
-                              bool openfst) {
+/* Create an acceptor from a stream, assuming the acceptor is in the K2 format:
+
+   src_state1 dest_state1 label1 score1
+   src_state2 dest_state2 label2 score2
+   ... ...
+   final_state
+
+   The source states will be in non-descending order, and the final state does
+   not bear a cost/score -- we put the cost/score on the arc that connects to
+   the final state and set its label to -1.
+
+   @param [in]  is    The input stream that contains the acceptor.
+
+   @return It returns an Fsa on CPU.
+*/
+static Fsa K2AcceptorFromStream(std::istringstream &is) {
   std::vector<Arc> arcs;
-  std::string line = std::move(first_line);
   std::vector<std::string> splits;
+  std::string line;
 
-  float scale = 1;
-  if (openfst) scale = -1;
-
-  int32_t max_state = -1;
-  std::vector<int32_t> original_final_states;
-  std::vector<float> original_final_weights;
-  do {
+  bool finished = false;  // when the final state is read, set it to true.
+  while (std::getline(is, line)) {
     SplitStringToVector(line, kDelim,
                         &splits);  // splits is cleared in the function
     if (splits.empty()) continue;  // this is an empty line
 
-    auto num_fields = splits.size();
+    K2_CHECK_EQ(finished, false);
 
+    auto num_fields = splits.size();
     if (num_fields == 4u) {
       //   0            1          2      3
-      // src_state  dest_state  symbol  score
+      // src_state  dest_state   label  score
       int32_t src_state = StringToInt(splits[0]);
       int32_t dest_state = StringToInt(splits[1]);
       int32_t symbol = StringToInt(splits[2]);
-      float score = scale * StringToFloat(splits[3]);
+      float score = StringToFloat(splits[3]);
       arcs.emplace_back(src_state, dest_state, symbol, score);
-      max_state = std::max(max_state, std::max(src_state, dest_state));
-    } else if (num_fields == 2u) {
-      //   0            1
-      // final_state  score
-      // In this case, openfst is true. There could be multiple final states, so
-      // we first have to collect all the final states, and then work out the
-      // super final state.
-      K2_CHECK(openfst) << "Invalid line: " << line
-                        << "\nFinal state with weight detected in K2 format";
-      original_final_states.push_back(StringToInt(splits[0]));
-      original_final_weights.push_back(StringToFloat(splits[1]));
-      max_state = std::max(max_state, original_final_states.back());
     } else if (num_fields == 1u) {
       //   0
       // final_state
       (void)StringToInt(splits[0]);  // this is a final state
-      break;                         // finish reading
+      finished = true;               // set finish
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
-                    << "\nIt expects a line with 1, 2 or 4 fields";
+                    << "\nK2 acceptor expects a line with 1 (final_state) or "
+                    << "4 (src_state dest_state label score) fields";
     }
-  } while (std::getline(is, line));
+  }
 
-  // Post processing on final states. When openfst is true, we may have multiple
-  // final states with weights associated with them. We will have to add a super
-  // final state, and convert that into the K2 format (final state with no
-  // weight).
-  if (original_final_states.size() > 0) {
-    K2_CHECK_EQ(openfst, true);
-    K2_CHECK_EQ(original_final_states.size(), original_final_weights.size());
-    int32_t super_final_state = max_state + 1;
-    for (std::size_t i = 0; i != original_final_states.size(); ++i) {
-      arcs.emplace_back(original_final_states[i], super_final_state,
-                        -1,  // kFinalSymbol
-                        scale * original_final_weights[i]);
-    }
-  }
-  if (openfst) {
-    // Sort arcs so that source states are in non-decreasing order.
-    std::sort(arcs.begin(), arcs.end());
-  }
+  K2_CHECK_EQ(finished, true) << "The last line should be the final state";
 
   bool error = true;
   Array1<Arc> array(GetCpuContext(), arcs);
@@ -177,101 +158,323 @@ static Fsa AcceptorFromStream(std::string first_line, std::istringstream &is,
   return fsa;
 }
 
-static Fsa TransducerFromStream(std::string first_line, std::istringstream &is,
-                                bool openfst, Array1<int32_t> *aux_labels) {
+/* Create a transducer from a stream, assuming the transducer is in the K2
+   format:
+
+   src_state1 dest_state1 label1 aux_label1 score1
+   src_state2 dest_state2 label2 aux_label2 score2
+   ... ...
+   final_state
+
+   The source states will be in non-descending order, and the final state does
+   not bear a cost/score -- we put the cost/score on the arc that connects to
+   the final state and set its label to -1.
+
+   @param [in]  is    The input stream that contains the transducer.
+
+   @return It returns an Fsa on CPU.
+*/
+static Fsa K2TransducerFromStream(std::istringstream &is,
+                                  Array1<int32_t> *aux_labels) {
   K2_CHECK(aux_labels != nullptr);
 
-  std::vector<int32_t> state_aux_labels;
+  std::vector<int32_t> aux_labels_internal;
   std::vector<Arc> arcs;
-  std::string line = std::move(first_line);
   std::vector<std::string> splits;
+  std::string line;
 
-  float scale = 1;
-  if (openfst) scale = -1;
+  bool finished = false;  // when the final state is read, set it to true.
+  while (std::getline(is, line)) {
+    SplitStringToVector(line, kDelim,
+                        &splits);  // splits is cleared in the function
+    if (splits.empty()) continue;  // this is an empty line
+
+    K2_CHECK_EQ(finished, false);
+
+    auto num_fields = splits.size();
+    if (num_fields == 5u) {
+      //   0           1         2         3        4
+      // src_state  dest_state label   aux_label  score
+      int32_t src_state = StringToInt(splits[0]);
+      int32_t dest_state = StringToInt(splits[1]);
+      int32_t symbol = StringToInt(splits[2]);
+      int32_t aux_label = StringToInt(splits[3]);
+      float score = StringToFloat(splits[4]);
+      arcs.emplace_back(src_state, dest_state, symbol, score);
+      aux_labels_internal.push_back(aux_label);
+    } else if (num_fields == 1u) {
+      //   0
+      // final_state
+      (void)StringToInt(splits[0]);
+      finished = true;               // set finish
+    } else {
+      K2_LOG(FATAL) << "Invalid line: " << line
+                    << "\nK2 transducer expects a line with 1 (final_state) or "
+                    << "4 (src_state dest_state label aux_label score) fields";
+    }
+  }
+
+  K2_CHECK_EQ(finished, true) << "The last line should be the final state";
+
+  auto cpu_context = GetCpuContext();
+  *aux_labels = Array1<int32_t>(cpu_context, aux_labels_internal);
+  Array1<Arc> array(cpu_context, arcs);
+
+  bool error = true;
+  auto fsa = FsaFromArray1(array, &error);
+  K2_CHECK_EQ(error, false);
+
+  return fsa;
+}
+
+/* Create an acceptor from a stream, assuming the acceptor is in the OpenFST
+   format:
+
+   src_state1 dest_state1 label1 score1
+   src_state2 dest_state2 label2 score2
+   ... ...
+   final_state final_score
+
+   We will negate the cost/score when we read them in. Also note, OpenFST may
+   omit the cost/score if it is 0.0.
+
+   If there are multiple final states, we will create a super final state, and
+   create arcs from the old final states to the new super final state, with the
+   (negated) old final state cost/score as its cost/score, and -1 as its label.
+
+   @param [in]  is    The input stream that contains the acceptor.
+
+   @return It returns an Fsa on CPU.
+*/
+static Fsa OpenFSTAcceptorFromStream(std::istringstream &is) {
+  std::vector<Arc> arcs;
+  std::vector<std::vector<Arc>> state_to_arcs;            // indexed by states
+  std::vector<std::string> splits;
+  std::string line;
 
   int32_t max_state = -1;
+  int32_t num_arcs = 0;
   std::vector<int32_t> original_final_states;
   std::vector<float> original_final_weights;
-  do {
+  while (std::getline(is, line)) {
     SplitStringToVector(line, kDelim,
                         &splits);  // splits is cleared in the function
     if (splits.empty()) continue;  // this is an empty line
 
     auto num_fields = splits.size();
-    if (num_fields == 5u) {
+    if (num_fields == 3u || num_fields == 4u) {
+      //   0            1          2
+      // src_state  dest_state   label
+      //
+      // or
+      //
+      //   0            1          2      3
+      // src_state  dest_state   label  score
+      int32_t src_state = StringToInt(splits[0]);
+      int32_t dest_state = StringToInt(splits[1]);
+      int32_t symbol = StringToInt(splits[2]);
+      float score = 0.0f;
+      if (num_fields == 4u)
+        score = -1.0f * StringToFloat(splits[3]);
+
+      // Add the arc to "state_to_arcs".
+      ++num_arcs;
+      max_state = std::max(max_state, std::max(src_state, dest_state));
+      if (static_cast<int32_t>(state_to_arcs.size()) <= src_state)
+        state_to_arcs.resize(src_state + 1);
+      state_to_arcs[src_state].emplace_back(src_state, dest_state, symbol,
+                                            score);
+    } else if (num_fields == 1u || num_fields == 2u) {
+      //   0            1
+      // final_state  score
+      float score = 0.0f;
+      if (num_fields == 2u)
+        score = StringToFloat(splits[1]);
+      original_final_states.push_back(StringToInt(splits[0]));
+      original_final_weights.push_back(score);
+      max_state = std::max(max_state, original_final_states.back());
+    } else {
+      K2_LOG(FATAL) << "Invalid line: " << line
+                    << "\nOpenFST acceptor expects a line with 1 (final_state),"
+                    << " 2 (final_state score), 3 (src_state dest_state label) "
+                    << "or 4 (src_state dest_state label score) fields.";
+    }
+  }
+
+  // Post processing on final states. We may have multiple final states with
+  // weights associated with them for OpenFST style FSTs. We will have to add a
+  // super final state, and convert that into the K2 format (final state with no
+  // weight).
+  if (original_final_states.size() > 0) {
+    K2_CHECK_EQ(original_final_states.size(), original_final_weights.size());
+    int32_t super_final_state = max_state + 1;
+    state_to_arcs.resize(super_final_state);
+    for (std::size_t i = 0; i != original_final_states.size(); ++i) {
+      state_to_arcs[original_final_states[i]].emplace_back(
+          original_final_states[i], super_final_state,
+          -1,  // kFinalSymbol
+          -1.0f * original_final_weights[i]);
+      ++num_arcs;
+    }
+  }
+
+  // Move arcs from "state_to_arcs" to "arcs".
+  std::size_t arc_index = 0;
+  arcs.resize(num_arcs);
+  for (std::size_t s = 0; s < state_to_arcs.size(); ++s) {
+    for (std::size_t a = 0; a < state_to_arcs[s].size(); ++a) {
+      K2_CHECK_GT(num_arcs, arc_index);
+      arcs[arc_index] = state_to_arcs[s][a];
+      ++arc_index;
+    }
+  }
+  K2_CHECK_EQ(num_arcs, static_cast<int32_t>(arc_index));
+  state_to_arcs.resize(0);
+
+  bool error = true;
+  Array1<Arc> array(GetCpuContext(), arcs);
+  auto fsa = FsaFromArray1(array, &error);
+  K2_CHECK_EQ(error, false);
+
+  return fsa;
+}
+
+/* Create a transducer from a stream, assuming the transducer is in the OpenFST
+   format:
+
+   src_state1 dest_state1 label1 aux_label1 score1
+   src_state2 dest_state2 label2 aux_label2 score2
+   ... ...
+   final_state final_score
+
+   We will negate the cost/score when we read them in. Also note, OpenFST may
+   omit the cost/score if it is 0.0.
+
+   If there are multiple final states, we will create a super final state, and
+   create arcs from the old final states to the new super final state, with the
+   (negated) old final state cost/score as its cost/score, -1 as its label and 0
+   as its aux_label.
+
+   @param [in]  is    The input stream that contains the transducer.
+
+   @return It returns an Fsa on CPU.
+*/
+static Fsa OpenFSTTransducerFromStream(std::istringstream &is,
+                                       Array1<int32_t> *aux_labels) {
+  K2_CHECK(aux_labels != nullptr);
+
+  std::vector<std::vector<int32_t>> state_to_aux_labels;  // indexed by states
+  std::vector<std::vector<Arc>> state_to_arcs;            // indexed by states
+  std::vector<int32_t> aux_labels_internal;
+  std::vector<Arc> arcs;
+  std::vector<std::string> splits;
+  std::string line;
+
+  int32_t max_state = -1;
+  int32_t num_arcs = 0;
+  std::vector<int32_t> original_final_states;
+  std::vector<float> original_final_weights;
+  while (std::getline(is, line)) {
+    SplitStringToVector(line, kDelim,
+                        &splits);  // splits is cleared in the function
+    if (splits.empty()) continue;  // this is an empty line
+
+    auto num_fields = splits.size();
+    if (num_fields == 4u || num_fields == 5u) {
+      //   0           1         2         3
+      // src_state  dest_state label   aux_label
+      //
+      // or
+      //
       //   0           1         2         3        4
-      // src_state  dest_state  symbol  aux_label score
+      // src_state  dest_state label   aux_label  score
       int32_t src_state = StringToInt(splits[0]);
       int32_t dest_state = StringToInt(splits[1]);
       int32_t symbol = StringToInt(splits[2]);
       int32_t aux_label = StringToInt(splits[3]);
-      float score = scale * StringToFloat(splits[4]);
-      arcs.emplace_back(src_state, dest_state, symbol, score);
-      state_aux_labels.push_back(aux_label);
+      float score = 0.0f;
+      if (num_fields == 5u)
+        score = -1.0f * StringToFloat(splits[4]);
+
+      // Add the arc to "state_to_arcs", and aux_label to "state_to_aux_labels"
+      ++num_arcs;
       max_state = std::max(max_state, std::max(src_state, dest_state));
-    } else if (num_fields == 2u) {
-      //   0            1
-      // final_state  score
-      // In this case, openfst is true. There could be multiple final states, so
-      // we first have to collect all the final states, and then work out the
-      // super final state.
-      K2_CHECK(openfst) << "Invalid line: " << line
-                        << "\nFinal state with weight detected in K2 format";
-      original_final_states.push_back(StringToInt(splits[0]));
-      original_final_weights.push_back(StringToFloat(splits[1]));
-      max_state = std::max(max_state, original_final_states.back());
-    } else if (num_fields == 1u) {
+      if (static_cast<int32_t>(state_to_arcs.size()) <= src_state) {
+        state_to_arcs.resize(src_state + 1);
+        state_to_aux_labels.resize(src_state + 1);
+      }
+      state_to_arcs[src_state].emplace_back(src_state, dest_state, symbol,
+                                            score);
+      state_to_aux_labels[src_state].push_back(aux_label);
+    } else if (num_fields == 1u || num_fields == 2u) {
       //   0
       // final_state
-      (void)StringToInt(splits[0]);
-      break;  // finish reading
+      //
+      // or
+      //
+      //   0            1
+      // final_state  score
+      // There could be multiple final states, so we first have to collect all
+      // the final states, and then work out the super final state.
+      float score = 0.0f;
+      if (num_fields == 2u)
+        score = StringToFloat(splits[1]);
+      original_final_states.push_back(StringToInt(splits[0]));
+      original_final_weights.push_back(score);
+      max_state = std::max(max_state, original_final_states.back());
     } else {
       K2_LOG(FATAL) << "Invalid line: " << line
-                    << "\nIt expects a line with 1, 2 or 5 fields";
+                    << "\nOpenFST transducer expects a line with "
+                    << "1 (final_state), 2 (final_state score), "
+                    << "4 (src_state dest_state label aux_label) or "
+                    << "5 (src_state dest_state label aux_label score) fields.";
     }
-  } while (std::getline(is, line));
+  }
 
-  // Post processing on final states. When openfst is true, we may have multiple
-  // final states with weights associated with them. We will have to add a super
-  // final state, and convert that into the K2 format (final state with no
+  // Post processing on final states. We may have multiple final states with
+  // weights associated with them for OpenFST style FSTs. We will have to add a
+  // super final state, and convert that into the K2 format (final state with no
   // weight).
   if (original_final_states.size() > 0) {
-    K2_CHECK_EQ(openfst, true);
     K2_CHECK_EQ(original_final_states.size(), original_final_weights.size());
     int32_t super_final_state = max_state + 1;
+    state_to_arcs.resize(super_final_state);
+    state_to_aux_labels.resize(super_final_state);
     for (std::size_t i = 0; i != original_final_states.size(); ++i) {
-      arcs.emplace_back(original_final_states[i], super_final_state,
-                        -1,  // kFinalSymbol
-                        scale * original_final_weights[i]);
+      state_to_arcs[original_final_states[i]].emplace_back(
+          original_final_states[i], super_final_state,
+          -1,  // kFinalSymbol
+          -1.0f * original_final_weights[i]);
       // TODO(guoguo) We are not sure yet what to put as the auxiliary label for
       //              arcs entering the super final state. The only real choices
       //              are kEpsilon or kFinalSymbol. We are using kEpsilon for
       //              now.
-      state_aux_labels.push_back(0);  // kEpsilon
+      state_to_aux_labels[original_final_states[i]].push_back(0); // kEpsilon
+      ++num_arcs;
     }
   }
 
-  if (openfst) {
-    // Sort arcs so that source states are in non-decreasing order. We have to
-    // do this simultaneously for both arcs and auxiliary labels. The following
-    // implementation makes a pair of (Arc, AuxLabel) for sorting.
-    // TODO(guoguo) Optimize this when necessary.
-    std::vector<std::pair<Arc, int32_t>> arcs_and_aux_labels;
-    K2_CHECK_EQ(state_aux_labels.size(), arcs.size());
-    arcs_and_aux_labels.resize(arcs.size());
-    for (std::size_t i = 0; i < arcs.size(); ++i) {
-      arcs_and_aux_labels[i] = std::make_pair(arcs[i], state_aux_labels[i]);
-    }
-    // Default pair comparison should work for us.
-    std::sort(arcs_and_aux_labels.begin(), arcs_and_aux_labels.end());
-    for (std::size_t i = 0; i < arcs.size(); ++i) {
-      arcs[i] = arcs_and_aux_labels[i].first;
-      state_aux_labels[i] = arcs_and_aux_labels[i].second;
+  // Move arcs from "state_to_arcs" to "arcs", and aux_labels from
+  // "state_to_aux_labels" to "aux_labels_internal"
+  std::size_t arc_index = 0;
+  arcs.resize(num_arcs);
+  aux_labels_internal.resize(num_arcs);
+  K2_CHECK_EQ(state_to_arcs.size(), state_to_aux_labels.size());
+  for (std::size_t s = 0; s < state_to_arcs.size(); ++s) {
+    K2_CHECK_EQ(state_to_arcs[s].size(), state_to_aux_labels[s].size());
+    for (std::size_t a = 0; a < state_to_arcs[s].size(); ++a) {
+      K2_CHECK_GT(num_arcs, arc_index);
+      arcs[arc_index] = state_to_arcs[s][a];
+      aux_labels_internal[arc_index] = state_to_aux_labels[s][a];
+      ++arc_index;
     }
   }
+  K2_CHECK_EQ(num_arcs, static_cast<int32_t>(arc_index));
+  state_to_arcs.resize(0);
+  state_to_aux_labels.resize(0);
 
   auto cpu_context = GetCpuContext();
-  *aux_labels = Array1<int32_t>(cpu_context, state_aux_labels);
+  *aux_labels = Array1<int32_t>(cpu_context, aux_labels_internal);
   Array1<Arc> array(cpu_context, arcs);
 
   bool error = true;
@@ -284,21 +487,16 @@ static Fsa TransducerFromStream(std::string first_line, std::istringstream &is,
 Fsa FsaFromString(const std::string &s, bool openfst /*= false*/,
                   Array1<int32_t> *aux_labels /*= nullptr*/) {
   std::istringstream is(s);
-  std::string line;
-  std::getline(is, line);
   K2_CHECK(is);
 
-  std::vector<std::string> splits;
-  SplitStringToVector(line, kDelim, &splits);
-  auto num_fields = splits.size();
-  if (num_fields == 4u)
-    return AcceptorFromStream(std::move(line), is, openfst);
-  else if (num_fields == 5u)
-    return TransducerFromStream(std::move(line), is, openfst, aux_labels);
-
-  K2_LOG(FATAL) << "Expected number of fields: 4 or 5."
-                << "Actual: " << num_fields << "\n"
-                << "First line is: " << line;
+  if (openfst == false && aux_labels == nullptr)
+    return K2AcceptorFromStream(is);
+  else if (openfst == false && aux_labels != nullptr)
+    return K2TransducerFromStream(is, aux_labels);
+  else if (openfst == true && aux_labels == nullptr)
+    return OpenFSTAcceptorFromStream(is);
+  else if (openfst == true && aux_labels != nullptr)
+    return OpenFSTTransducerFromStream(is, aux_labels);
 
   return Fsa();  // unreachable code
 }

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -449,7 +449,7 @@ static Fsa OpenFSTTransducerFromStream(std::istringstream &is,
       //              arcs entering the super final state. The only real choices
       //              are kEpsilon or kFinalSymbol. We are using kEpsilon for
       //              now.
-      state_to_aux_labels[original_final_states[i]].push_back(0); // kEpsilon
+      state_to_aux_labels[original_final_states[i]].push_back(0);  // kEpsilon
       ++num_arcs;
     }
   }

--- a/k2/csrc/fsa_utils.h
+++ b/k2/csrc/fsa_utils.h
@@ -59,8 +59,10 @@ namespace k2 {
                     scores, so we negate them as we read. We will also allow
                     multiple final states with weights associated with them.
   @param [out]  aux_labels
-                    Used only when it is a transducer. It is allocated
-                    inside the function and will contain aux_label of each arc.
+                    If NULL, we treat the input as an acceptor; otherwise we
+                    treat the input as an transducer, and store the
+                    corresponding output labels to it. It is allocated inside
+                    the function and will contain aux_label of each arc.
                     Note that it is allocated on CPU if needed.
 
   @return It returns an Fsa on CPU.

--- a/k2/csrc/fsa_utils.h
+++ b/k2/csrc/fsa_utils.h
@@ -39,7 +39,7 @@ namespace k2 {
 
       final_state
 
-  This is because final state in K2 does not bear a cost. Instead, we put the
+  This is because final state in k2 does not bear a cost. Instead, we put the
   cost on the arc that connects to the final state, and set its label to -1.
   When `openfst` is true, we expect the more generic OpenFst sytle final state
   format :

--- a/k2/csrc/fsa_utils_test.cu
+++ b/k2/csrc/fsa_utils_test.cu
@@ -24,7 +24,7 @@ bool operator==(const Arc &a, const Arc &b) {
 }
 // clang-format on
 
-TEST(FsaFromString, Acceptor) {
+TEST(FsaFromString, K2Acceptor) {
   // src_state dst_state label cost
   std::string s = R"(0 1 2   -1.2
     0 2  10 -2.2
@@ -82,8 +82,8 @@ TEST(FsaFromString, OpenFstAcceptor) {
     EXPECT_EQ((fsa[{0, 1}]), (Arc{0, 2, 10, 2.2f}));
     EXPECT_EQ((fsa[{0, 2}]), (Arc{1, 3, 3, 3.2f}));
     EXPECT_EQ((fsa[{0, 3}]), (Arc{1, 6, 4, 4.2f}));
-    EXPECT_EQ((fsa[{0, 4}]), (Arc{2, 4, 2, 6.2f}));
-    EXPECT_EQ((fsa[{0, 5}]), (Arc{2, 6, 5, 5.2f}));
+    EXPECT_EQ((fsa[{0, 4}]), (Arc{2, 6, 5, 5.2f}));
+    EXPECT_EQ((fsa[{0, 5}]), (Arc{2, 4, 2, 6.2f}));
     EXPECT_EQ((fsa[{0, 6}]), (Arc{3, 6, 7, 7.2f}));
     EXPECT_EQ((fsa[{0, 7}]), (Arc{5, 7, 1, 8.2f}));
     EXPECT_EQ((fsa[{0, 8}]), (Arc{6, 8, -1, 1.2f}));
@@ -91,42 +91,41 @@ TEST(FsaFromString, OpenFstAcceptor) {
   }
 }
 
-TEST(FsaFromString, Transducer) {
+TEST(FsaFromString, K2Transducer) {
   // src_state dst_state label aux_label cost
   std::string s = R"(0 1 2 22  -1.2
     0 2  10 100 -2.2
     1 3  3  33  -3.2
     1 6 -1  16  -4.2
-    3 6 -1  36  -7.2
     2 6 -1  26  -5.2
     2 4  2  22  -6.2
+    3 6 -1  36  -7.2
     5 0  1  50  -8.2
     6
   )";
 
   {
-    // openfst format, negate the scores
     Array1<int32_t> aux_labels;
-    auto fsa = FsaFromString(s, true, &aux_labels);
+    auto fsa = FsaFromString(s, false, &aux_labels);
     EXPECT_EQ(fsa.Context()->GetDeviceType(), kCpu);
     EXPECT_EQ(aux_labels.Context()->GetDeviceType(), kCpu);
 
     EXPECT_EQ(fsa.NumAxes(), 2);
     EXPECT_EQ(fsa.shape.Dim0(), 7);         // there are 7 states
     EXPECT_EQ(fsa.shape.NumElements(), 8);  // there are 8 arcs
-    EXPECT_EQ((fsa[{0, 0}]), (Arc{0, 1, 2, 1.2f}));
-    EXPECT_EQ((fsa[{0, 1}]), (Arc{0, 2, 10, 2.2f}));
-    EXPECT_EQ((fsa[{0, 2}]), (Arc{1, 6, -1, 4.2f}));
-    EXPECT_EQ((fsa[{0, 3}]), (Arc{1, 3, 3, 3.2f}));
-    EXPECT_EQ((fsa[{0, 4}]), (Arc{2, 6, -1, 5.2f}));
-    EXPECT_EQ((fsa[{0, 5}]), (Arc{2, 4, 2, 6.2f}));
-    EXPECT_EQ((fsa[{0, 6}]), (Arc{3, 6, -1, 7.2f}));
-    EXPECT_EQ((fsa[{0, 7}]), (Arc{5, 0, 1, 8.2f}));
+    EXPECT_EQ((fsa[{0, 0}]), (Arc{0, 1, 2, -1.2f}));
+    EXPECT_EQ((fsa[{0, 1}]), (Arc{0, 2, 10, -2.2f}));
+    EXPECT_EQ((fsa[{0, 2}]), (Arc{1, 3, 3, -3.2f}));
+    EXPECT_EQ((fsa[{0, 3}]), (Arc{1, 6, -1, -4.2f}));
+    EXPECT_EQ((fsa[{0, 4}]), (Arc{2, 6, -1, -5.2f}));
+    EXPECT_EQ((fsa[{0, 5}]), (Arc{2, 4, 2, -6.2f}));
+    EXPECT_EQ((fsa[{0, 6}]), (Arc{3, 6, -1, -7.2f}));
+    EXPECT_EQ((fsa[{0, 7}]), (Arc{5, 0, 1, -8.2f}));
 
     EXPECT_EQ(aux_labels[0], 22);
     EXPECT_EQ(aux_labels[1], 100);
-    EXPECT_EQ(aux_labels[2], 16);
-    EXPECT_EQ(aux_labels[3], 33);
+    EXPECT_EQ(aux_labels[2], 33);
+    EXPECT_EQ(aux_labels[3], 16);
     EXPECT_EQ(aux_labels[4], 26);
     EXPECT_EQ(aux_labels[5], 22);
     EXPECT_EQ(aux_labels[6], 36);
@@ -161,8 +160,8 @@ TEST(FsaFromString, OpenFstTransducer) {
     EXPECT_EQ((fsa[{0, 1}]), (Arc{0, 2, 10, 2.2f}));
     EXPECT_EQ((fsa[{0, 2}]), (Arc{1, 3, 3, 3.2f}));
     EXPECT_EQ((fsa[{0, 3}]), (Arc{1, 6, 4, 4.2f}));
-    EXPECT_EQ((fsa[{0, 4}]), (Arc{2, 4, 2, 6.2f}));
-    EXPECT_EQ((fsa[{0, 5}]), (Arc{2, 6, 5, 5.2f}));
+    EXPECT_EQ((fsa[{0, 4}]), (Arc{2, 6, 5, 5.2f}));
+    EXPECT_EQ((fsa[{0, 5}]), (Arc{2, 4, 2, 6.2f}));
     EXPECT_EQ((fsa[{0, 6}]), (Arc{3, 6, 7, 7.2f}));
     EXPECT_EQ((fsa[{0, 7}]), (Arc{5, 7, 1, 8.2f}));
     EXPECT_EQ((fsa[{0, 8}]), (Arc{6, 8, -1, 1.2f}));
@@ -172,8 +171,8 @@ TEST(FsaFromString, OpenFstTransducer) {
     EXPECT_EQ(aux_labels[1], 100);
     EXPECT_EQ(aux_labels[2], 33);
     EXPECT_EQ(aux_labels[3], 16);
-    EXPECT_EQ(aux_labels[4], 22);
-    EXPECT_EQ(aux_labels[5], 26);
+    EXPECT_EQ(aux_labels[4], 26);
+    EXPECT_EQ(aux_labels[5], 22);
     EXPECT_EQ(aux_labels[6], 36);
     EXPECT_EQ(aux_labels[7], 50);
     EXPECT_EQ(aux_labels[8], 0);

--- a/k2/python/csrc/torch/fsa.cu
+++ b/k2/python/csrc/torch/fsa.cu
@@ -3,6 +3,7 @@
  *
  * @copyright
  * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ *                      Guoguo Chen
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
@@ -40,27 +41,27 @@ static void PybindFsaUtil(py::module &m) {
 
   m.def(
       "_fsa_to_str",
-      [](Fsa &fsa, bool negate_scores = false,
+      [](Fsa &fsa, bool openfst = false,
          torch::optional<torch::Tensor> aux_labels = {}) -> std::string {
         Array1<int32_t> array;
         if (aux_labels.has_value())
           array = FromTensor<int32_t>(aux_labels.value());
-        return FsaToString(fsa, negate_scores, aux_labels ? &array : nullptr);
+        return FsaToString(fsa, openfst, aux_labels ? &array : nullptr);
       },
-      py::arg("fsa"), py::arg("negate_scores") = false,
+      py::arg("fsa"), py::arg("openfst") = false,
       py::arg("aux_labels") = py::none());
 
   m.def(
       "_fsa_from_str",
-      [](const std::string &s, bool negate_scores = false)
+      [](const std::string &s, bool acceptor = true, bool openfst = false)
           -> std::pair<Fsa, torch::optional<torch::Tensor>> {
         Array1<int32_t> aux_labels;
-        Fsa fsa = FsaFromString(s, negate_scores, &aux_labels);
+        Fsa fsa = FsaFromString(s, openfst, acceptor ? nullptr : &aux_labels);
         torch::optional<torch::Tensor> tensor;
         if (aux_labels.Dim() > 0) tensor = ToTensor(aux_labels);
         return std::make_pair(fsa, tensor);
       },
-      py::arg("s"), py::arg("negate_scores") = false,
+      py::arg("s"), py::arg("acceptor") = true, py::arg("openfst") = false,
       "It returns a tuple with two elements. Element 0 is the FSA; element 1 "
       "is a 1-D tensor of dtype torch.int32 containing the aux_labels if the "
       "returned FSA is a transducer; element 1 is None if the "

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -55,7 +55,7 @@ class Fsa(object):
         fsa: _Fsa
         aux_labels: Optional[torch.Tensor]
 
-        # Figure out acceptor/transducer for K2 fsa.
+        # Figure out acceptor/transducer for k2 fsa.
         acceptor = True
         line = s.strip().split('\n', 1)[0]
         fields = line.strip().split()

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1,4 +1,5 @@
 # Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+#                      Guoguo Chen
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
@@ -18,7 +19,7 @@ from graphviz import Digraph
 
 class Fsa(object):
 
-    def __init__(self, s: str, openfst: bool = False):
+    def __init__(self, s: str, acceptor: bool = True, openfst: bool = False):
         '''Create an Fsa from a string.
 
         The given string `s` consists of lines with the following format:
@@ -50,6 +51,9 @@ class Fsa(object):
         Args:
           s:
             The input string. Refer to the above comment for its format.
+          acceptor:
+            Optional. If true, interpret the input string as an acceptor,
+            otherwise, interpret it as a transducer.
           openfst:
             Optional. If true, the string form has the weights as costs,
             not scores, so we negate as we read.
@@ -57,7 +61,7 @@ class Fsa(object):
         fsa: _Fsa
         aux_labels: Optional[torch.Tensor]
 
-        fsa, aux_labels = _fsa_from_str(s, openfst)
+        fsa, aux_labels = _fsa_from_str(s, acceptor, openfst)
 
         self._fsa = fsa
         self._aux_labels = aux_labels

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+#                Guoguo Chen
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
@@ -102,7 +103,7 @@ class TestFsa(unittest.TestCase):
             5 0  1  50  -8.2
             6
         '''
-        fsa = k2.Fsa(_remove_leading_spaces(s))
+        fsa = k2.Fsa(_remove_leading_spaces(s), acceptor=False)
         assert fsa.aux_labels.dtype == torch.int32
         assert fsa.aux_labels.device.type == 'cpu'
         assert torch.allclose(
@@ -161,7 +162,7 @@ class TestFsa(unittest.TestCase):
             2 3 -1 0 3.5
             3
         '''
-        fsa = k2.Fsa(_remove_leading_spaces(rules))
+        fsa = k2.Fsa(_remove_leading_spaces(rules), acceptor=False)
         fsa.set_isymbol(isym)
         fsa.set_osymbol(osym)
         dot = fsa.to_dot()

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -16,6 +16,7 @@ import torch
 
 import _k2  # for test only, users should not import it.
 
+
 def _remove_leading_spaces(s: str) -> str:
     lines = [line.strip() for line in s.split('\n') if line.strip()]
     return '\n'.join(lines)

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -51,20 +51,6 @@ class TestFsa(unittest.TestCase):
         assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
             fsa.to_str())
 
-        expected_str = '''
-            0 1 2 1.2
-            0 2 10 2.2
-            1 6 -1 3.2
-            1 3 3 4.2
-            2 6 -1 5.2
-            2 4 2 6.2
-            3 6 -1 7.2
-            5 0 1 8.2
-            6
-        '''
-        assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
-            fsa.to_str(openfst=True))
-
         arcs = fsa.arcs
         assert isinstance(arcs, torch.Tensor)
         assert arcs.dtype == torch.int32
@@ -91,6 +77,65 @@ class TestFsa(unittest.TestCase):
             arcs[1],
             torch.tensor([0, 2, 10], dtype=torch.int32, device=arcs.device))
 
+    def test_acceptor_from_openfst(self):
+        s = '''
+            0 1 2 -1.2
+            0 2  10 -2.2
+            1 6  1  -3.2
+            1 3  3  -4.2
+            2 6  2  -5.2
+            2 4  2  -6.2
+            3 6  3  -7.2
+            5 0  1  -8.2
+            7
+            6 -9.2
+        '''
+
+        fsa = k2.Fsa.from_openfst(_remove_leading_spaces(s), acceptor=True)
+
+        expected_str = '''
+            0 1 2 -1.2
+            0 2 10 -2.2
+            1 6 1 -3.2
+            1 3 3 -4.2
+            2 6 2 -5.2
+            2 4 2 -6.2
+            3 6 3 -7.2
+            5 0 1 -8.2
+            6 8 -1 -9.2
+            7 8 -1 -0
+            8
+        '''
+        assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
+            fsa.to_str(openfst=True))
+
+        arcs = fsa.arcs
+        assert isinstance(arcs, torch.Tensor)
+        assert arcs.dtype == torch.int32
+        assert arcs.device.type == 'cpu'
+        assert arcs.shape == (10, 3), 'there should be 10 arcs'
+        assert torch.allclose(arcs[0],
+                              torch.tensor([0, 1, 2], dtype=torch.int32))
+
+        assert torch.allclose(
+            fsa.weights,
+            torch.tensor(
+                [1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2, 0],
+                dtype=torch.float32))
+
+        fsa = fsa.to('cuda')
+        arcs[0][0] += 10
+        assert arcs[0][0] == 10, 'arcs should still be accessible'
+
+        arcs = fsa.arcs
+        assert arcs.dtype == torch.int32
+        assert arcs.device.type == 'cuda'
+        assert arcs.device.index == 0
+        assert arcs.shape == (10, 3), 'there should be 10 arcs'
+        assert torch.allclose(
+            arcs[1],
+            torch.tensor([0, 2, 10], dtype=torch.int32, device=arcs.device))
+
     def test_transducer_from_str(self):
         s = '''
             0 1 2 22  -1.2
@@ -103,7 +148,7 @@ class TestFsa(unittest.TestCase):
             5 0  1  50  -8.2
             6
         '''
-        fsa = k2.Fsa(_remove_leading_spaces(s), acceptor=False)
+        fsa = k2.Fsa(_remove_leading_spaces(s))
         assert fsa.aux_labels.dtype == torch.int32
         assert fsa.aux_labels.device.type == 'cpu'
         assert torch.allclose(
@@ -124,16 +169,39 @@ class TestFsa(unittest.TestCase):
         assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
             fsa.to_str())
 
-        expected_str = '''
-            0 1 2 22 1.2
-            0 2 10 100 2.2
-            1 6 -1 16 4.2
-            1 3 3 33 3.2
-            2 6 -1 26 5.2
-            2 4 2 22 6.2
-            3 6 -1 36 7.2
-            5 0 1 50 8.2
+    def test_transducer_from_openfst(self):
+        s = '''
+            0 1 2 22  -1.2
+            0 2  10 100 -2.2
+            1 6  1  16  -4.2
+            1 3  3  33  -3.2
+            2 6  2  26  -5.2
+            2 4  2  22  -6.2
+            3 6  3  36  -7.2
+            5 0  1  50  -8.2
+            7 -9.2
             6
+        '''
+        fsa = k2.Fsa.from_openfst(_remove_leading_spaces(s), acceptor=False)
+        assert fsa.aux_labels.dtype == torch.int32
+        assert fsa.aux_labels.device.type == 'cpu'
+        assert torch.allclose(
+            fsa.aux_labels,
+            torch.tensor([22, 100, 16, 33, 26, 22, 36, 50, 0, 0],
+                         dtype=torch.int32))
+
+        expected_str = '''
+            0 1 2 22 -1.2
+            0 2 10 100 -2.2
+            1 6 1 16 -4.2
+            1 3 3 33 -3.2
+            2 6 2 26 -5.2
+            2 4 2 22 -6.2
+            3 6 3 36 -7.2
+            5 0 1 50 -8.2
+            6 8 -1 0 -0
+            7 8 -1 0 -9.2
+            8
         '''
         assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
             fsa.to_str(openfst=True))
@@ -162,7 +230,7 @@ class TestFsa(unittest.TestCase):
             2 3 -1 0 3.5
             3
         '''
-        fsa = k2.Fsa(_remove_leading_spaces(rules), acceptor=False)
+        fsa = k2.Fsa(_remove_leading_spaces(rules))
         fsa.set_isymbol(isym)
         fsa.set_osymbol(osym)
         dot = fsa.to_dot()

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -14,6 +14,7 @@ import unittest
 import k2
 import torch
 
+import _k2  # for test only, users should not import it.
 
 def _remove_leading_spaces(s: str) -> str:
     lines = [line.strip() for line in s.split('\n') if line.strip()]
@@ -21,6 +22,59 @@ def _remove_leading_spaces(s: str) -> str:
 
 
 class TestFsa(unittest.TestCase):
+
+    def test_acceptor_from_tensor(self):
+        fsa_tensor = torch.tensor(
+            [[0, 1, 2, _k2._float_as_int(-1.2)],
+             [0, 2, 10, _k2._float_as_int(-2.2)],
+             [1, 6, -1, _k2._float_as_int(-3.2)],
+             [1, 3, 3, _k2._float_as_int(-4.2)],
+             [2, 6, -1, _k2._float_as_int(-5.2)],
+             [2, 4, 2, _k2._float_as_int(-6.2)],
+             [3, 6, -1, _k2._float_as_int(-7.2)],
+             [5, 0, 1, _k2._float_as_int(-8.2)]], dtype=torch.int32)
+
+        fsa = k2.Fsa(fsa_tensor)
+
+        expected_str = '''
+            0 1 2 -1.2
+            0 2 10 -2.2
+            1 6 -1 -3.2
+            1 3 3 -4.2
+            2 6 -1 -5.2
+            2 4 2 -6.2
+            3 6 -1 -7.2
+            5 0 1 -8.2
+            6
+        '''
+        assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
+            fsa.to_str())
+
+        arcs = fsa.arcs
+        assert isinstance(arcs, torch.Tensor)
+        assert arcs.dtype == torch.int32
+        assert arcs.device.type == 'cpu'
+        assert arcs.shape == (8, 3), 'there should be 8 arcs'
+        assert torch.allclose(arcs[0],
+                              torch.tensor([0, 1, 2], dtype=torch.int32))
+
+        assert torch.allclose(
+            fsa.weights,
+            torch.tensor([-1.2, -2.2, -3.2, -4.2, -5.2, -6.2, -7.2, -8.2],
+                         dtype=torch.float32))
+
+        fsa = fsa.to('cuda')
+        arcs[0][0] += 10
+        assert arcs[0][0] == 10, 'arcs should still be accessible'
+
+        arcs = fsa.arcs
+        assert arcs.dtype == torch.int32
+        assert arcs.device.type == 'cuda'
+        assert arcs.device.index == 0
+        assert arcs.shape == (8, 3), 'there should be 8 arcs'
+        assert torch.allclose(
+            arcs[1],
+            torch.tensor([0, 2, 10], dtype=torch.int32, device=arcs.device))
 
     def test_acceptor_from_str(self):
         s = '''
@@ -35,7 +89,7 @@ class TestFsa(unittest.TestCase):
             6
         '''
 
-        fsa = k2.Fsa(_remove_leading_spaces(s))
+        fsa = k2.Fsa.from_str(_remove_leading_spaces(s))
 
         expected_str = '''
             0 1 2 -1.2
@@ -136,6 +190,42 @@ class TestFsa(unittest.TestCase):
             arcs[1],
             torch.tensor([0, 2, 10], dtype=torch.int32, device=arcs.device))
 
+    def test_transducer_from_tensor(self):
+        device_id = 0
+        device = torch.device('cuda', device_id)
+        fsa_tensor = torch.tensor(
+            [[0, 1, 2, _k2._float_as_int(-1.2)],
+             [0, 2, 10, _k2._float_as_int(-2.2)],
+             [1, 6, -1, _k2._float_as_int(-4.2)],
+             [1, 3, 3, _k2._float_as_int(-3.2)],
+             [2, 6, -1, _k2._float_as_int(-5.2)],
+             [2, 4, 2, _k2._float_as_int(-6.2)],
+             [3, 6, -1, _k2._float_as_int(-7.2)],
+             [5, 0, 1, _k2._float_as_int(-8.2)]], dtype=torch.int32).to(device)
+        aux_labels_tensor = torch.tensor(
+            [22, 100, 16, 33, 26, 22, 36, 50], dtype=torch.int32).to(device)
+        fsa = k2.Fsa(fsa_tensor, aux_labels_tensor)
+        assert fsa.aux_labels.dtype == torch.int32
+        assert fsa.aux_labels.device.type == 'cuda'
+        assert torch.allclose(
+            fsa.aux_labels,
+            torch.tensor([22, 100, 16, 33, 26, 22, 36, 50],
+                         dtype=torch.int32).to(device))
+
+        expected_str = '''
+            0 1 2 22 -1.2
+            0 2 10 100 -2.2
+            1 6 -1 16 -4.2
+            1 3 3 33 -3.2
+            2 6 -1 26 -5.2
+            2 4 2 22 -6.2
+            3 6 -1 36 -7.2
+            5 0 1 50 -8.2
+            6
+        '''
+        assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
+            fsa.to('cpu').to_str())    # String IO supported on CPU only
+
     def test_transducer_from_str(self):
         s = '''
             0 1 2 22  -1.2
@@ -148,7 +238,7 @@ class TestFsa(unittest.TestCase):
             5 0  1  50  -8.2
             6
         '''
-        fsa = k2.Fsa(_remove_leading_spaces(s))
+        fsa = k2.Fsa.from_str(_remove_leading_spaces(s))
         assert fsa.aux_labels.dtype == torch.int32
         assert fsa.aux_labels.device.type == 'cpu'
         assert torch.allclose(
@@ -230,7 +320,7 @@ class TestFsa(unittest.TestCase):
             2 3 -1 0 3.5
             3
         '''
-        fsa = k2.Fsa(_remove_leading_spaces(rules))
+        fsa = k2.Fsa.from_str(_remove_leading_spaces(rules))
         fsa.set_isymbol(isym)
         fsa.set_osymbol(osym)
         dot = fsa.to_dot()


### PR DESCRIPTION
This is WIP because I still have to test some real FSTs, e.g., lexicon.fst from Kaldi.

- [x] Separated reading code for K2 and OpenFST
- [x] Removed sorting but does not require source states in non-descending order for OpenFST style FSTs
- [x] Support omitted weights in OpenFST (treat it as 0.0f)
- [x] Test this for a real lexicon fst

@csukuangfj I added one argument `acceptor` (default true) for the Python fsa initialization OpenFST style WFSTs can have 1, 2, 4, 5 fields, which makes it difficult to figure acceptor/transducer automatically. Also, asking users to explicitly set acceptor/transducer may lead to less coding errors. But let me know your thoughts. 