### PR TITLE
Test TopSort with random generated FSAs.

### DIFF
--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -47,6 +47,9 @@ endif()
 
 #---------------------------- Test K2 CUDA sources ----------------------------
 
+add_library(test_utils SHARED test_utils.cu)
+target_link_libraries(test_utils PUBLIC context)
+
 # please sort the source files alphabetically
 set(cuda_tests
   algorithms_test
@@ -77,6 +80,7 @@ function(k2_add_cuda_test name)
     fsa  # for code in k2/csrc/host
     gtest
     gtest_main
+    test_utils
   )
   add_test(NAME "Test.Cuda.${target_name}"
     COMMAND

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 #---------------------------- Test K2 CUDA sources ----------------------------
 
 add_library(test_utils SHARED test_utils.cu)
-target_link_libraries(test_utils PUBLIC context)
+target_link_libraries(test_utils PUBLIC context gtest)
 
 # please sort the source files alphabetically
 set(cuda_tests

--- a/k2/csrc/host/fsa_util.h
+++ b/k2/csrc/host/fsa_util.h
@@ -289,7 +289,7 @@ struct RandFsaOptions {
   bool allow_empty;
   bool acyclic;  // generate a cyclic fsa in a best effort manner if it's false
   int32_t seed;  // for random generator. Set it to non-zero for reproducibility
-  bool nonzero_weights;  // allow weights to be nonzero (default: fals)
+  bool nonzero_weights;  // allow weights to be nonzero (default: false)
 
   RandFsaOptions();
 };

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -774,7 +774,9 @@ RaggedShape Transpose(RaggedShape &src) {
   K2_CHECK_GT(src.NumAxes(), 2);
   int32_t src_dim0 = src.Dim0(), src_tot_size1 = src.TotSize(1);
   K2_CHECK_EQ(src_tot_size1 % src_dim0, 0)
-      << "Transpose(): all dims on axis 0 must be the same.";
+      << "Transpose(): all dims on axis 0 must be the same.\n"
+      << "src_tot_size1: " << src_tot_size1 << "\n"
+      << "src_dim0: " << src_dim0 << "\n";
   int32_t src_dim1 = src_tot_size1 / src_dim0;
   RaggedShape src_no_axis0 = RemoveAxis(src, 0);
   K2_CHECK_EQ(src_no_axis0.Dim0(), src_tot_size1);

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -94,9 +94,13 @@ Ragged<T> Stack(int32_t axis, int32_t num_srcs, Ragged<T> **src) {
   // context compatibility and num-axes compatibility.
   RaggedShape ans_shape = Stack(0, num_srcs, src_shapes.data());
   Array1<T> ans_values = Append(num_srcs, src_values.data());
-  Ragged<T> ans(ans_shape, ans_values);
-  if (axis == 1) ans = Transpose(ans);
-  return ans;
+  if (axis == 1) {
+    ans_shape = MakeTransposable(ans_shape);
+    Ragged<T> ans(ans_shape, ans_values);
+    return Transpose(ans);
+  }
+
+  return Ragged<T>(ans_shape, ans_values);
 }
 
 template <typename T>

--- a/k2/csrc/test_utils.cu
+++ b/k2/csrc/test_utils.cu
@@ -10,6 +10,7 @@
  */
 
 #include <algorithm>
+#include <cstdlib>
 #include <vector>
 
 #include "k2/csrc/fsa.h"
@@ -52,12 +53,11 @@ void ToNotTopSorted(Fsa *fsa) {
 
 Fsa GetRandFsa() {
   k2host::RandFsaOptions opts;
-  opts.num_syms = 20;
-  opts.num_states = 100;
-  opts.num_arcs = opts.num_states * 4;
+  opts.num_syms = 5 + rand() % 100;
+  opts.num_states = 10 + rand() % 2000;
+  opts.num_arcs = opts.num_states * 4 + rand() % 100;
   opts.allow_empty = false;
   opts.acyclic = true;
-  K2_CHECK_GT(opts.num_states, 2);
 
   k2host::RandFsaGenerator generator(opts);
   k2host::Array2Size<int32_t> fsa_size;

--- a/k2/csrc/test_utils.cu
+++ b/k2/csrc/test_utils.cu
@@ -1,0 +1,74 @@
+/**
+ * @brief
+ * test_utils
+ *
+ * @copyright
+ * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ */
+
+#include <algorithm>
+#include <vector>
+
+#include "k2/csrc/fsa.h"
+#include "k2/csrc/host/fsa_util.h"
+#include "k2/csrc/host_shim.h"
+#include "k2/csrc/test_utils.h"
+
+namespace k2 {
+
+void ToNotTopSorted(Fsa *fsa) {
+  K2_CHECK_EQ(fsa->Context()->GetDeviceType(), kCpu);
+
+  int32_t num_states = fsa->TotSize(0);
+  std::vector<int32_t> order(num_states);
+  std::iota(order.begin(), order.end(), 0);
+  std::random_shuffle(order.begin() + 1, order.end() - 1);
+
+  Array1<Arc> &arcs = fsa->values;
+  Arc *arcs_data = arcs.Data();
+  int32_t num_arcs = arcs.Dim();
+  for (int32_t i = 0; i != num_arcs; ++i) {
+    int32_t src_state = arcs_data[i].src_state;
+    int32_t dest_state = arcs_data[i].dest_state;
+    arcs_data[i].src_state = order[src_state];
+    arcs_data[i].dest_state = order[dest_state];
+  }
+
+  auto lambda_comp = [](const Arc &a, const Arc &b) -> bool {
+    return a.src_state < b.src_state;
+  };
+  std::sort(arcs_data, arcs_data + num_arcs, lambda_comp);
+  for (int32_t i = 0; i != num_arcs; ++i) {
+    arcs_data[i].score = i;
+  }
+
+  bool error = true;
+  *fsa = FsaFromArray1(arcs, &error);
+  K2_CHECK(!error);
+}
+
+Fsa GetRandFsa() {
+  k2host::RandFsaOptions opts;
+  opts.num_syms = 20;
+  opts.num_states = 100;
+  opts.num_arcs = opts.num_states * 4;
+  opts.allow_empty = false;
+  opts.acyclic = true;
+  K2_CHECK_GT(opts.num_states, 2);
+
+  k2host::RandFsaGenerator generator(opts);
+  k2host::Array2Size<int32_t> fsa_size;
+  generator.GetSizes(&fsa_size);
+  FsaCreator creator(fsa_size);
+  k2host::Fsa host_fsa = creator.GetHostFsa();
+  generator.GetOutput(&host_fsa);
+  Fsa ans = creator.GetFsa();
+  ToNotTopSorted(&ans);
+
+  return ans;
+}
+
+}  // namespace k2

--- a/k2/csrc/test_utils.h
+++ b/k2/csrc/test_utils.h
@@ -66,6 +66,9 @@ void CheckRowSplits(RaggedShape &shape,
   }
 }
 
+// Return a random acyclic FSA that is NOT topo sorted
+Fsa GetRandFsa();
+
 }  // namespace k2
 
 #endif  //  K2_CSRC_TEST_UTILS_H_

--- a/k2/csrc/top_sort_test.cu
+++ b/k2/csrc/top_sort_test.cu
@@ -131,7 +131,7 @@ TEST(TopSort, RandomSingleFsa) {
 }
 
 TEST(TopSort, RandomVectorOfFsas) {
-  int num_fsas = 4;
+  int num_fsas = 1 + rand() % 100;
   ContextPtr cpu = GetCpuContext();
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     std::vector<Fsa> fsas(num_fsas);

--- a/k2/csrc/top_sort_test.cu
+++ b/k2/csrc/top_sort_test.cu
@@ -106,11 +106,90 @@ TEST(TopSort, VectorOfFsas) {
 }
 
 TEST(TopSort, RandomSingleFsa) {
-  // TODO(fangjun)
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    Fsa fsa = GetRandFsa();
+    fsa = fsa.To(context);
+
+    int32_t gt = kFsaPropertiesTopSorted | kFsaPropertiesTopSortedAndAcyclic;
+    int32_t p = GetFsaBasicProperties(fsa);
+    EXPECT_NE(p & gt, gt);
+
+    Fsa sorted;
+    Array1<int32_t> arc_map;
+    TopSort(fsa, &sorted, &arc_map);
+
+    p = GetFsaBasicProperties(sorted);
+    EXPECT_EQ(p & gt, gt);
+
+    Array1<Arc> arcs = sorted.values.To(GetCpuContext());
+    arc_map = arc_map.To(GetCpuContext());
+    int32_t num_arcs = arcs.Dim();
+    for (int32_t i = 0; i != num_arcs; ++i) {
+      EXPECT_EQ(arcs[i].score, arc_map[i]);
+    }
+  }
 }
 
 TEST(TopSort, RandomVectorOfFsas) {
-  // TODO(fangjun)
+  int num_fsas = 4;
+  ContextPtr cpu = GetCpuContext();
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    std::vector<Fsa> fsas(num_fsas);
+    for (int32_t i = 0; i != num_fsas; ++i) {
+      fsas[i] = GetRandFsa();
+    }
+
+    int32_t offset = fsas[0].TotSize(1);
+    for (int32_t i = 1; i != num_fsas; ++i) {
+      Array1<Arc> &arcs = fsas[i].values;
+      Arc *arcs_data = arcs.Data();
+      int32_t num_arcs = arcs.Dim();
+      EXPECT_GT(num_arcs, 1);
+      for (int32_t k = 0; k != num_arcs; ++k) {
+        arcs_data[k].score += offset;
+      }
+      offset += num_arcs;
+    }
+
+    std::vector<Fsa *> fsa_array(num_fsas);
+    for (int32_t i = 0; i != num_fsas; ++i) {
+      fsa_array[i] = &fsas[i];
+    }
+
+    FsaVec fsa_vec = CreateFsaVec(num_fsas, &fsa_array[0]);
+    fsa_vec = fsa_vec.To(context);
+
+    int32_t gt = kFsaPropertiesTopSorted | kFsaPropertiesTopSortedAndAcyclic;
+    Array1<int32_t> properties;
+    int32_t p;
+    GetFsaVecBasicProperties(fsa_vec, &properties, &p);
+
+    EXPECT_NE(p & gt, gt);
+    properties = properties.To(cpu);
+    for (int32_t i = 0; i != num_fsas; ++i) {
+      EXPECT_NE(properties[i] & gt, gt);
+    }
+
+    FsaVec sorted;
+    Array1<int32_t> arc_map;
+    TopSort(fsa_vec, &sorted, &arc_map);
+
+    GetFsaVecBasicProperties(sorted, &properties, &p);
+
+    EXPECT_EQ(p & gt, gt);
+    properties = properties.To(cpu);
+    for (int32_t i = 0; i != num_fsas; ++i) {
+      EXPECT_EQ(properties[i] & gt, gt);
+    }
+
+    Array1<Arc> arcs = sorted.values.To(cpu);
+    arc_map = arc_map.To(cpu);
+
+    int32_t num_arcs = sorted.TotSize(2);
+    for (int32_t i = 0; i != num_arcs; ++i) {
+      EXPECT_EQ(arcs[i].score, arc_map[i]);
+    }
+  }
 }
 
 }  // namespace k2

--- a/k2/csrc/utils.h
+++ b/k2/csrc/utils.h
@@ -493,7 +493,7 @@ __host__ __forceinline__ bool AtomicDecAndCompareZero(int32_t *i) {
    is an error if it becomes less than zero).
 */
 __host__ __device__ __forceinline__ bool AtomicDecAndCompareZero(int32_t *i) {
-#ifdef CUDA_ARCH
+#ifdef __CUDA_ARCH__
   int32_t old = atomicAdd(i, -1);
   K2_CHECK_GT(old, 0);
   return old == 1;


### PR DESCRIPTION
It seems that there are bugs in TopSort.

The unittest fails most of the time for random FSAs.  Test logs are given below:

```
/root/k2/build$ ./bin/cu_top_sort_test --gtest_filter="*Random*Of*"
Running main() from /root/k2/build/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = *Random*Of*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from TopSort
[ RUN      ] TopSort.RandomVectorOfFsas
[F] /root/k2/k2/csrc/ragged_ops.cu:Transpose:776 Check failed: src_tot_size1 % src_dim0 == 0 (5 vs. 0) Transpose(): all dims on axis 0 must be the same.
src_tot_size1: 74
src_dim0: 23

Aborted (core dumped)
/root/k2/build$ ./bin/cu_top_sort_test --gtest_filter="*Random*Of*"
Running main() from /root/k2/build/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = *Random*Of*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from TopSort
[ RUN      ] TopSort.RandomVectorOfFsas
[F] /root/k2/k2/csrc/ragged_ops.cu:Transpose:776 Check failed: src_tot_size1 % src_dim0 == 0 (3 vs. 0) Transpose(): all dims on axis 0 must be the same.
src_tot_size1: 63
src_dim0: 20

Aborted (core dumped)
/root/k2/build$ ./bin/cu_top_sort_test --gtest_filter="*Random*Of*"
Running main() from /root/k2/build/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = *Random*Of*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from TopSort
[ RUN      ] TopSort.RandomVectorOfFsas
[       OK ] TopSort.RandomVectorOfFsas (29884 ms)
[----------] 1 test from TopSort (29884 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (29884 ms total)
[  PASSED  ] 1 test.
```