### PR TITLE
Fixed some bugs in TopSort(GPU) and change the implementenation of host TopSort

### DIFF
--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -3,7 +3,7 @@
  * compose
  *
  * @copyright
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
@@ -18,7 +18,7 @@
 namespace k2 {
 
 /*
-  This version of Connect() works for a single FSA.
+  This version of Connect() works for both Fsa and FsaVec.
     @param [in] src  Source FSA
     @param [out] dest   Destination; at exit will be equivalent to `src`
                      but will have no states that are unreachable or which
@@ -32,9 +32,6 @@ namespace k2 {
             does not imply that `dest` is nonempty.
 
    CAUTION: for now this only works for CPU.
-
-   This works for both Fsa and FsaVec!
-
  */
 bool Connect(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map = nullptr);
 
@@ -74,6 +71,29 @@ void ArcSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map = nullptr);
   where the procedure is repeated until no vertices are left."
 */
 void TopSort(FsaVec &src, FsaVec *dest, Array1<int32_t> *arc_map = nullptr);
+
+/*
+  Same with `TopSort` above, but only works for CPU. It's just a wrapper of
+  `TopSorter` in host/topsort.h. We use it for test purpose, users should never
+  call this function in production code. Instead, you should call the version
+  above.
+      @param [in] src  Input Fsa or FsaVec
+      @param [out] dest  Output Fsa or FsaVec.  At exit, its states will be
+                      top-sorted.  (However, if `src` contained cycles other
+                      than self-loops, it won't contain all of the states
+                      in the input; this can be detected by the user directly
+                      by looking at the number of states.
+      @param [out] arc_map  If not nullptr, at exit a map from arc-indexes in
+                      `dest` to their source arc-indexes in `src` will have
+                       been assigned to this location.
+      @return Returns true on success (i.e. the output will be topsorted).
+            The only failure condition is when the input had cycles that were
+            not self loops. Noted we may remove those states in the
+            input Fsa which are not accessible or co-accessible.
+            Caution: true return status does not imply that the returned FSA
+            is nonempty.
+ */
+bool HostTopSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map = nullptr);
 
 /*
   compose/intersect array of FSAs (multiple streams decoding or training in

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1515,12 +1515,14 @@ template Array1<float> GetTotScores(FsaVec &fsas,
 template Array1<double> GetTotScores(FsaVec &fsas,
                                      const Array1<double> &forward_scores);
 
-Fsa RandomFsa(bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
-              int32_t min_num_arcs /*=0*/, int32_t max_num_arcs /*=1000*/) {
+Fsa RandomFsa(bool acyclic /*=true*/, bool epsilon_free /*=true*/,
+              int32_t max_symbol /*=50*/, int32_t min_num_arcs /*=0*/,
+              int32_t max_num_arcs /*=1000*/) {
   ContextPtr c = GetCpuContext();
   K2_CHECK_GE(min_num_arcs, 0);
   K2_CHECK_GE(max_num_arcs, min_num_arcs);
   K2_CHECK_GE(max_symbol, 0);
+  if (epsilon_free) K2_CHECK_GE(max_symbol, 1);
   RaggedShape shape =
       RandomRaggedShape(false, 2, 2, min_num_arcs, max_num_arcs);
   int32_t dim0 = shape.Dim0();
@@ -1556,7 +1558,10 @@ Fsa RandomFsa(bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
     int32_t curr_state = row_ids1[i];
     int32_t dest_state = acyclic ? RandInt(curr_state + 1, final_state)
                                  : RandInt(start_state, final_state);
-    int32_t symbol = dest_state == final_state ? -1 : RandInt(0, max_symbol);
+    int32_t symbol =
+        dest_state == final_state
+            ? -1
+            : (epsilon_free ? RandInt(1, max_symbol) : RandInt(0, max_symbol));
     float score = dis_score(gen);
     arcs[i] = Arc(curr_state, dest_state, symbol, score);
   }
@@ -1564,15 +1569,16 @@ Fsa RandomFsa(bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
 }
 
 FsaVec RandomFsaVec(int32_t min_num_fsas /*=1*/, int32_t max_num_fsas /*=1000*/,
-                    bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
-                    int32_t min_num_arcs /*=0*/,
+                    bool acyclic /*=true*/, bool epsilon_free /*=true*/,
+                    int32_t max_symbol /*=50*/, int32_t min_num_arcs /*=0*/,
                     int32_t max_num_arcs /*=1000*/) {
   K2_CHECK_GE(min_num_fsas, 0);
   K2_CHECK_GE(max_num_fsas, min_num_fsas);
   int32_t num_fsas = RandInt(min_num_fsas, max_num_fsas);
   std::vector<Fsa> fsas(num_fsas);
   for (int32_t i = 0; i != num_fsas; ++i) {
-    fsas[i] = RandomFsa(acyclic, max_symbol, min_num_arcs, max_num_arcs);
+    fsas[i] = RandomFsa(acyclic, epsilon_free, max_symbol, min_num_arcs,
+                        max_num_arcs);
   }
   return Stack(0, num_fsas, fsas.data());
 }

--- a/k2/csrc/fsa_utils.h
+++ b/k2/csrc/fsa_utils.h
@@ -329,14 +329,19 @@ FsaVec ConvertDenseToFsaVec(DenseFsaVec &src);
   Return a random Fsa, with a CPU context. Intended for testing.
 
      @param [in] acyclic     If true, generated Fsa will be acyclic.
+     @param [in] epsilon_free If true, generated Fsa will epsilone-free, i.e.
+                              there's no arc with label==0.
      @param [in] max_symbol  Maximum symbol on arcs. Generated arcs' symbols
                              will be in range [-1,max_symbol], note -1 is
                              kFinalSymbol; must be at least 0;
+                             If epsilon_free is true, max_symbol must be
+                             at least 1;
      @param [in] min_num_arcs Minimum number of arcs; must be at least 0.
      @param [in] max_num_arcs Maximum number of arcs; must be >= min_num_arcs.
  */
-Fsa RandomFsa(bool acyclic = true, int32_t max_symbol = 50,
-              int32_t min_num_arcs = 0, int32_t max_num_arcs = 1000);
+Fsa RandomFsa(bool acyclic = true, bool epsilon_free = true,
+              int32_t max_symbol = 50, int32_t min_num_arcs = 0,
+              int32_t max_num_arcs = 1000);
 /*
   Return a random FsaVec, with a CPU context. Intended for testing.
 
@@ -345,17 +350,22 @@ Fsa RandomFsa(bool acyclic = true, int32_t max_symbol = 50,
      @param [in] max_num_fsas Maximum number of fsas we'll generated in the
                               returned FsaVec; must be >= min_num_fsas.
      @param [in] acyclic     If true, generated Fsas will be acyclic.
+     @param [in] epsilon_free If true, generated Fsa will epsilone-free, i.e.
+                              there's no arc with label==0.
      @param [in] max_symbol  Maximum symbol on arcs. Generated arcs' symbols
                              will be in range [-1,max_symbol], note -1 is
-                             kFinalSymbol; must be at least 0.
+                             kFinalSymbol; must be at least 0;
+                             If epsilon_free is true, max_symbol must be
+                             at least 1;
      @param [in] min_num_arcs Minimum number of arcs in each Fsa;
                               must be at least 0.
      @param [in] max_num_arcs Maximum number of arcs in each Fsa;
                               must be >= min_num_arcs.
  */
 FsaVec RandomFsaVec(int32_t min_num_fsas = 1, int32_t max_num_fsas = 1000,
-                    bool acyclic = true, int32_t max_symbol = 50,
-                    int32_t min_num_arcs = 0, int32_t max_num_arcs = 1000);
+                    bool acyclic = true, bool epsilon_free = true,
+                    int32_t max_symbol = 50, int32_t min_num_arcs = 0,
+                    int32_t max_num_arcs = 1000);
 
 }  // namespace k2
 

--- a/k2/csrc/fsa_utils_test.cu
+++ b/k2/csrc/fsa_utils_test.cu
@@ -747,8 +747,7 @@ TEST_F(StatesBatchSuiteTest, TestBackwardScores) {
   {
     // random case
     for (int32_t i = 0; i != 2; ++i) {
-      // for (auto &context : {GetCpuContext(), GetCudaContext()}) {
-      for (auto &context : {GetCpuContext()}) {
+      for (auto &context : {GetCpuContext(), GetCudaContext()}) {
         FsaVec random_fsas = RandomFsaVec();
         FsaVec fsa_vec = random_fsas.To(context);
         int32_t num_fsas = fsa_vec.Dim0(), num_states = fsa_vec.TotSize(1),
@@ -772,8 +771,6 @@ TEST_F(StatesBatchSuiteTest, TestBackwardScores) {
               GetBackwardScores<float>(cpu_fsa_vec, nullptr, false);
           CheckArrayData(scores, cpu_scores);
         }
-        // TODO(haowen): will get -nan in below tests, may be related to use
-        // infinity
         {
           // max with tot_scores provided
           Array1<float> forward_scores = GetForwardScores<float>(

--- a/k2/csrc/host/topsort.h
+++ b/k2/csrc/host/topsort.h
@@ -41,32 +41,33 @@ class TopSorter {
 
   /*
     Finish the operation and output the top-sorted FSA to `fsa_out` and
-    state mapping information to `state_map` (if provided).
-    @param [out]  fsa_out Output fsa. It is set to empty if the input fsa is not
-                          acyclic or is not connected; otherwise it contains the
-                          top-sorted fsa.
+    arc mapping information to `arc_map` (if provided).
+    @param [out]  fsa_out Output fsa. It is set to empty if the input fsa had
+                          cycles other than self-loops; otherwise it contains
+                          the top-sorted fsa.
                           Must be initialized; search for 'initialized
                           definition' in class Array2 in array.h for meaning.
-    @param [out]  state_map   If non-NULL, Maps from state indexes in the output
-                              fsa to state indexes in input fsa.
+    @param [out]  arc_map If non-NULL, Maps from arc indexes in the output
+                              fsa to arc indexes in input fsa.
                               If non-NULL, at entry it must be allocated with
-                              size num-states of `fsa_out`,
-                              e.g. `fsa_out->size1`.
-
-    @return true if the input fsa is acyclic and connected,
-            or if the input is empty; return false otherwise.
+                              size num-arcs of `fsa_out`,
+                              e.g. `fsa_out->size2`.
+    @return Returns true on success (i.e. the output will be topsorted).
+            The only failure condition is when the input had cycles that were
+            not self loops. Noted we may remove those states in the
+            input Fsa which are not accessible or co-accessible.
+            Caution: true return status does not imply that the returned FSA
+            is nonempty.
    */
-  bool GetOutput(Fsa *fsa_out, int32_t *state_map = nullptr);
+  bool GetOutput(Fsa *fsa_out, int32_t *arc_map = nullptr);
 
  private:
   const Fsa &fsa_in_;
 
-  bool is_connected_;  // if the input FSA is connected
-  bool is_acyclic_;    // if the input FSA is acyclic
-  // map order to state.
-  // state 0 has the largest order, i.e., num_states - 1
-  // final_state has the least order, i.e., 0
-  std::vector<int32_t> order_;
+  bool is_acyclic_;  // if the input FSA is acyclic (may have self-loops)
+  std::vector<int32_t> arc_indexes_;  // arc_index of fsa_out
+  std::vector<Arc> arcs_;             // arcs of fsa_out
+  std::vector<int32_t> arc_map_;
 };
 
 }  // namespace k2host

--- a/k2/csrc/host/topsort_test.cc
+++ b/k2/csrc/host/topsort_test.cc
@@ -39,14 +39,13 @@ TEST(TopSortTest, TopSort) {
 
     FsaCreator fsa_creator_out(fsa_size);
     auto &top_sorted = fsa_creator_out.GetFsa();
-    std::vector<int32_t> state_map(fsa_size.size1);
-    bool status = sorter.GetOutput(&top_sorted, state_map.data());
+    std::vector<int32_t> arc_map(fsa_size.size2);
+    bool status = sorter.GetOutput(&top_sorted, arc_map.data());
 
     EXPECT_TRUE(status);
     EXPECT_TRUE(IsEmpty(top_sorted));
-    EXPECT_TRUE(state_map.empty());
+    EXPECT_TRUE(arc_map.empty());
   }
-
   {
     // case 2: non-connected fsa (not co-accessible)
     std::vector<Arc> arcs = {{0, 2, -1, 0}, {1, 2, -1, 0}, {1, 2, 0, 0}};
@@ -56,14 +55,17 @@ TEST(TopSortTest, TopSort) {
     Array2Size<int32_t> fsa_size;
     sorter.GetSizes(&fsa_size);
 
+    EXPECT_EQ(fsa_size.size1, 2);
+    EXPECT_EQ(fsa_size.size2, 1);
+
     FsaCreator fsa_creator_out(fsa_size);
     auto &top_sorted = fsa_creator_out.GetFsa();
-    std::vector<int32_t> state_map(fsa_size.size1);
-    bool status = sorter.GetOutput(&top_sorted, state_map.data());
+    std::vector<int32_t> arc_map(fsa_size.size2);
+    bool status = sorter.GetOutput(&top_sorted, arc_map.data());
 
-    EXPECT_FALSE(status);
-    EXPECT_TRUE(IsEmpty(top_sorted));
-    EXPECT_TRUE(state_map.empty());
+    ASSERT_FALSE(IsEmpty(top_sorted));
+    EXPECT_TRUE(IsTopSorted(top_sorted));
+    EXPECT_THAT(arc_map, ::testing::ElementsAre(0));
   }
 
   {
@@ -79,14 +81,17 @@ TEST(TopSortTest, TopSort) {
     Array2Size<int32_t> fsa_size;
     sorter.GetSizes(&fsa_size);
 
+    EXPECT_EQ(fsa_size.size1, 2);
+    EXPECT_EQ(fsa_size.size2, 1);
+
     FsaCreator fsa_creator_out(fsa_size);
     auto &top_sorted = fsa_creator_out.GetFsa();
-    std::vector<int32_t> state_map(fsa_size.size1);
-    bool status = sorter.GetOutput(&top_sorted, state_map.data());
+    std::vector<int32_t> arc_map(fsa_size.size2);
+    bool status = sorter.GetOutput(&top_sorted, arc_map.data());
 
-    EXPECT_FALSE(status);
-    EXPECT_TRUE(IsEmpty(top_sorted));
-    EXPECT_TRUE(state_map.empty());
+    ASSERT_FALSE(IsEmpty(top_sorted));
+    EXPECT_TRUE(IsTopSorted(top_sorted));
+    EXPECT_THAT(arc_map, ::testing::ElementsAre(0));
   }
 
   {
@@ -103,13 +108,13 @@ TEST(TopSortTest, TopSort) {
 
     FsaCreator fsa_creator_out(fsa_size);
     auto &top_sorted = fsa_creator_out.GetFsa();
-    std::vector<int32_t> state_map(fsa_size.size1);
-    bool status = sorter.GetOutput(&top_sorted, state_map.data());
+    std::vector<int32_t> arc_map(fsa_size.size2);
+    bool status = sorter.GetOutput(&top_sorted, arc_map.data());
 
     ASSERT_EQ(top_sorted.NumStates(), fsa.NumStates());
 
-    ASSERT_FALSE(state_map.empty());
-    EXPECT_THAT(state_map, ::testing::ElementsAre(0, 4, 5, 2, 3, 1, 6));
+    ASSERT_FALSE(arc_map.empty());
+    EXPECT_THAT(arc_map, ::testing::ElementsAre(0, 1, 6, 7, 3, 4, 5, 2));
 
     ASSERT_FALSE(IsEmpty(top_sorted));
     EXPECT_TRUE(IsTopSorted(top_sorted));

--- a/k2/csrc/host_shim.cu
+++ b/k2/csrc/host_shim.cu
@@ -191,7 +191,7 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, std::size_t npath /*= 100*/) {
   return k2host::IsRandEquivalent(host_fsa_a, host_fsa_b, npath);
 }
 
-bool IsRandEquivalent(Fsa &a, Fsa &b, bool top_sorted, bool log_semiring,
+bool IsRandEquivalent(Fsa &a, Fsa &b, bool log_semiring,
                       float beam /*=k2host::kFloatInfinity*/,
                       float delta /*=1e-6*/, std::size_t npath /*= 100*/) {
   K2_CHECK_EQ(a.NumAxes(), 2);
@@ -202,10 +202,10 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, bool top_sorted, bool log_semiring,
   k2host::Fsa host_fsa_b = FsaToHostFsa(b);
   if (log_semiring) {
     return k2host::IsRandEquivalent<k2host::kLogSumWeight>(
-        host_fsa_a, host_fsa_b, beam, delta, top_sorted, npath);
+        host_fsa_a, host_fsa_b, beam, delta, true, npath);
   } else {
     return k2host::IsRandEquivalent<k2host::kMaxWeight>(
-        host_fsa_a, host_fsa_b, beam, delta, top_sorted, npath);
+        host_fsa_a, host_fsa_b, beam, delta, true, npath);
   }
 }
 

--- a/k2/csrc/host_shim.h
+++ b/k2/csrc/host_shim.h
@@ -282,12 +282,9 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, std::size_t npath = 100);
   exists in the other one and the sum of weights along that path are the same.
 
   @param [in]  a          One of the FSAs to be checked the equivalence.
-                          Must have NumAxes() == 2 and on CPU.
+                          Must be top-sorted and have NumAxes() == 2 and on CPU.
   @param [in]  b          The other FSA to be checked the equivalence.
-                          Must have NumAxes() == 2 and on CPU.
-  @param [in]  top_sorted The user may set this to true if both `a` and `b` are
-                          topologically sorted; this makes this function faster.
-                          Otherwise it must be set to false.
+                          Must be top-sorted and have NumAxes() == 2 and on CPU.
   @param [in]  log_semiring If true, the algorithm will only check paths
                           within `beam` of the log-sum probs over
                           all pahts;
@@ -314,7 +311,7 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, std::size_t npath = 100);
   @param [in]  npath      The number of paths will be generated to check the
                           equivalence of `a` and `b`
  */
-bool IsRandEquivalent(Fsa &a, Fsa &b, bool top_sorted, bool log_semiring,
+bool IsRandEquivalent(Fsa &a, Fsa &b, bool log_semiring,
                       float beam = k2host::kFloatInfinity, float delta = 1e-6,
                       std::size_t npath = 100);
 

--- a/k2/python/host/csrc/fsa_algo.cc
+++ b/k2/python/host/csrc/fsa_algo.cc
@@ -53,11 +53,11 @@ void PyBindTopSort(py::module &m) {
       .def(
           "get_output",
           [](PyClass &self, k2host::Fsa *fsa_out,
-             k2host::Array1<int32_t *> *state_map = nullptr) -> bool {
-            return self.GetOutput(
-                fsa_out, state_map == nullptr ? nullptr : state_map->data);
+             k2host::Array1<int32_t *> *arc_map = nullptr) -> bool {
+            return self.GetOutput(fsa_out,
+                                  arc_map == nullptr ? nullptr : arc_map->data);
           },
-          py::arg("fsa_out"), py::arg("state_map").none(true));
+          py::arg("fsa_out"), py::arg("arc_map").none(true));
 }
 
 void PyBindConnect(py::module &m) {

--- a/k2/python/host/k2host/fsa_algo.py
+++ b/k2/python/host/k2host/fsa_algo.py
@@ -50,10 +50,10 @@ class TopSorter(_TopSorter):
     def get_sizes(self, array_size: IntArray2Size) -> None:
         return super().get_sizes(array_size)
 
-    def get_output(self, fsa_out: Fsa, state_map: IntArray1 = None) -> bool:
+    def get_output(self, fsa_out: Fsa, arc_map: IntArray1 = None) -> bool:
         return super().get_output(
             fsa_out.get_base(),
-            state_map.get_base() if state_map is not None else None)
+            arc_map.get_base() if arc_map is not None else None)
 
 
 class Connection(_Connection):

--- a/k2/python/host/tests/topsort_test.py
+++ b/k2/python/host/tests/topsort_test.py
@@ -26,11 +26,11 @@ class TestTopSorter(unittest.TestCase):
         array_size = k2host.IntArray2Size()
         sorter.get_sizes(array_size)
         fsa_out = k2host.Fsa.create_fsa_with_size(array_size)
-        state_map = k2host.IntArray1.create_array_with_size(array_size.size1)
-        status = sorter.get_output(fsa_out, state_map)
+        arc_map = k2host.IntArray1.create_array_with_size(array_size.size2)
+        status = sorter.get_output(fsa_out, arc_map)
         self.assertTrue(status)
         self.assertTrue(k2host.is_empty(fsa_out))
-        self.assertTrue(state_map.empty())
+        self.assertTrue(arc_map.empty())
 
         # test without arc_map
         sorter.get_output(fsa_out)
@@ -49,11 +49,12 @@ class TestTopSorter(unittest.TestCase):
         array_size = k2host.IntArray2Size()
         sorter.get_sizes(array_size)
         fsa_out = k2host.Fsa.create_fsa_with_size(array_size)
-        state_map = k2host.IntArray1.create_array_with_size(array_size.size1)
-        status = sorter.get_output(fsa_out, state_map)
-        self.assertFalse(status)
-        self.assertTrue(k2host.is_empty(fsa_out))
-        self.assertTrue(state_map.empty())
+        arc_map = k2host.IntArray1.create_array_with_size(array_size.size2)
+        status = sorter.get_output(fsa_out, arc_map)
+        self.assertTrue(status)
+        self.assertFalse(k2host.is_empty(fsa_out))
+        expected_arc_map = torch.IntTensor([0])
+        self.assertTrue(torch.equal(arc_map.data, expected_arc_map))
 
     def test_case_3(self):
         # non-connected fsa (not accessible)
@@ -68,11 +69,12 @@ class TestTopSorter(unittest.TestCase):
         array_size = k2host.IntArray2Size()
         sorter.get_sizes(array_size)
         fsa_out = k2host.Fsa.create_fsa_with_size(array_size)
-        state_map = k2host.IntArray1.create_array_with_size(array_size.size1)
-        status = sorter.get_output(fsa_out, state_map)
-        self.assertFalse(status)
-        self.assertTrue(k2host.is_empty(fsa_out))
-        self.assertTrue(state_map.empty())
+        arc_map = k2host.IntArray1.create_array_with_size(array_size.size2)
+        status = sorter.get_output(fsa_out, arc_map)
+        self.assertTrue(status)
+        self.assertFalse(k2host.is_empty(fsa_out))
+        expected_arc_map = torch.IntTensor([0])
+        self.assertTrue(torch.equal(arc_map.data, expected_arc_map))
 
     def test_case_4(self):
         # connected fsa
@@ -92,18 +94,18 @@ class TestTopSorter(unittest.TestCase):
         array_size = k2host.IntArray2Size()
         sorter.get_sizes(array_size)
         fsa_out = k2host.Fsa.create_fsa_with_size(array_size)
-        state_map = k2host.IntArray1.create_array_with_size(array_size.size1)
-        status = sorter.get_output(fsa_out, state_map)
+        arc_map = k2host.IntArray1.create_array_with_size(array_size.size2)
+        status = sorter.get_output(fsa_out, arc_map)
         self.assertTrue(status)
         expected_arc_indexes = torch.IntTensor([0, 2, 3, 4, 5, 7, 8, 8])
         expected_arcs = torch.IntTensor([[0, 1, 40, 0], [0, 3, 20, 0],
                                          [1, 2, 50, 0], [2, 3, 8, 0],
                                          [3, 4, 30, 0], [4, 6, -1, 0],
                                          [4, 5, 10, 0], [5, 6, -1, 0]])
-        expected_state_map = torch.IntTensor([0, 4, 5, 2, 3, 1, 6])
+        expected_arc_map = torch.IntTensor([0, 1, 6, 7, 3, 4, 5, 2])
         self.assertTrue(torch.equal(fsa_out.indexes, expected_arc_indexes))
         self.assertTrue(torch.equal(fsa_out.data, expected_arcs))
-        self.assertTrue(torch.equal(state_map.data, expected_state_map))
+        self.assertTrue(torch.equal(arc_map.data, expected_arc_map))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fixed some bugs in TopSort(GPU version), but there are still some bugs, will look into later (mege now to avoid future conflicts)
- Our origninal version of host TopSort requires the input Fsa connected which is not necessary, re-implemented it by removing this requirement.
- Added parameter `epsilon_free` in `RandomFsa(Vec)` as we need (at least one of) input Fsas of `Intersect` be epsilon-free (as I will call `IsRandEquivalent` in random tests which calls host `Intersect` internally)
