### PR TITLE
Reorder Fsas in TopSort tests and fixed some other issues

### DIFF
--- a/k2/csrc/array.h
+++ b/k2/csrc/array.h
@@ -113,12 +113,14 @@ class Array1 {
 
      @param [in] start  First element to cover, 0 <= start <= Dim();
                         If start == Dim(), it just returns an empty array.
-     @param [in] end    One-past-the-last element to cover
+     @param [in] end    One-past-the-last element to cover,
+                        start <= end <= Dim().
   */
   Array1<T> Arange(int32_t start, int32_t end) const {
     K2_CHECK_GE(start, 0);
+    K2_CHECK_LE(start, dim_);
     K2_CHECK_GE(end, start);
-    K2_CHECK_LE(start + end, Dim());
+    K2_CHECK_LE(end, dim_);
     return Array1(end - start, region_, byte_offset_ + start * ElementSize());
   }
 
@@ -446,16 +448,17 @@ class Array2 {
     Returns an Array2 containing a subset of rows of *this, aliasing the
     same data.  (c.f. arange in PyTorch).
 
-     @param [in] start  First element of output, 0 <= start < Dim()
-     @param [in] end    First element that *should not* be included.
+     @param [in] start  First row of output, 0 <= start < Dim0()
+     @param [in] end    One-past-the-last row that *should not* be included.
      @param [in] inc    Increment in original array each time index
                         increases.  Require inc > 0.
   */
   Array2<T> RowArange(int32_t start, int32_t end, int32_t inc = 1) const {
     K2_CHECK_GT(inc, 0);
     K2_CHECK_GE(start, 0);
+    K2_CHECK_LT(start, dim0_);
     K2_CHECK_GE(end, start);
-    K2_CHECK_LE(start + end, dim0_);
+    K2_CHECK_LE(end, dim0_);
     int32_t num_rows = (end - start) / inc;
     return Array2<T>(num_rows, dim1_, elem_stride0_ * inc,
                      byte_offset_ + elem_stride0_ * start * ElementSize(),

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1526,14 +1526,12 @@ template Array1<float> GetTotScores(FsaVec &fsas,
 template Array1<double> GetTotScores(FsaVec &fsas,
                                      const Array1<double> &forward_scores);
 
-Fsa RandomFsa(bool acyclic /*=true*/, bool epsilon_free /*=true*/,
-              int32_t max_symbol /*=50*/, int32_t min_num_arcs /*=0*/,
-              int32_t max_num_arcs /*=1000*/) {
+Fsa RandomFsa(bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
+              int32_t min_num_arcs /*=0*/, int32_t max_num_arcs /*=1000*/) {
   ContextPtr c = GetCpuContext();
   K2_CHECK_GE(min_num_arcs, 0);
   K2_CHECK_GE(max_num_arcs, min_num_arcs);
   K2_CHECK_GE(max_symbol, 0);
-  if (epsilon_free) K2_CHECK_GE(max_symbol, 1);
   RaggedShape shape =
       RandomRaggedShape(false, 2, 2, min_num_arcs, max_num_arcs);
   int32_t dim0 = shape.Dim0();
@@ -1569,10 +1567,7 @@ Fsa RandomFsa(bool acyclic /*=true*/, bool epsilon_free /*=true*/,
     int32_t curr_state = row_ids1[i];
     int32_t dest_state = acyclic ? RandInt(curr_state + 1, final_state)
                                  : RandInt(start_state, final_state);
-    int32_t symbol =
-        dest_state == final_state
-            ? -1
-            : (epsilon_free ? RandInt(1, max_symbol) : RandInt(0, max_symbol));
+    int32_t symbol = dest_state == final_state ? -1 : RandInt(0, max_symbol);
     float score = dis_score(gen);
     arcs[i] = Arc(curr_state, dest_state, symbol, score);
   }
@@ -1580,16 +1575,15 @@ Fsa RandomFsa(bool acyclic /*=true*/, bool epsilon_free /*=true*/,
 }
 
 FsaVec RandomFsaVec(int32_t min_num_fsas /*=1*/, int32_t max_num_fsas /*=1000*/,
-                    bool acyclic /*=true*/, bool epsilon_free /*=true*/,
-                    int32_t max_symbol /*=50*/, int32_t min_num_arcs /*=0*/,
+                    bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
+                    int32_t min_num_arcs /*=0*/,
                     int32_t max_num_arcs /*=1000*/) {
   K2_CHECK_GE(min_num_fsas, 0);
   K2_CHECK_GE(max_num_fsas, min_num_fsas);
   int32_t num_fsas = RandInt(min_num_fsas, max_num_fsas);
   std::vector<Fsa> fsas(num_fsas);
   for (int32_t i = 0; i != num_fsas; ++i) {
-    fsas[i] = RandomFsa(acyclic, epsilon_free, max_symbol, min_num_arcs,
-                        max_num_arcs);
+    fsas[i] = RandomFsa(acyclic, max_symbol, min_num_arcs, max_num_arcs);
   }
   return Stack(0, num_fsas, fsas.data());
 }

--- a/k2/csrc/fsa_utils.h
+++ b/k2/csrc/fsa_utils.h
@@ -336,19 +336,14 @@ FsaVec ConvertDenseToFsaVec(DenseFsaVec &src);
   Return a random Fsa, with a CPU context. Intended for testing.
 
      @param [in] acyclic     If true, generated Fsa will be acyclic.
-     @param [in] epsilon_free If true, generated Fsa will epsilone-free, i.e.
-                              there's no arc with label==0.
      @param [in] max_symbol  Maximum symbol on arcs. Generated arcs' symbols
                              will be in range [-1,max_symbol], note -1 is
                              kFinalSymbol; must be at least 0;
-                             If epsilon_free is true, max_symbol must be
-                             at least 1;
      @param [in] min_num_arcs Minimum number of arcs; must be at least 0.
      @param [in] max_num_arcs Maximum number of arcs; must be >= min_num_arcs.
  */
-Fsa RandomFsa(bool acyclic = true, bool epsilon_free = true,
-              int32_t max_symbol = 50, int32_t min_num_arcs = 0,
-              int32_t max_num_arcs = 1000);
+Fsa RandomFsa(bool acyclic = true, int32_t max_symbol = 50,
+              int32_t min_num_arcs = 0, int32_t max_num_arcs = 1000);
 /*
   Return a random FsaVec, with a CPU context. Intended for testing.
 
@@ -357,22 +352,17 @@ Fsa RandomFsa(bool acyclic = true, bool epsilon_free = true,
      @param [in] max_num_fsas Maximum number of fsas we'll generated in the
                               returned FsaVec; must be >= min_num_fsas.
      @param [in] acyclic     If true, generated Fsas will be acyclic.
-     @param [in] epsilon_free If true, generated Fsa will epsilone-free, i.e.
-                              there's no arc with label==0.
      @param [in] max_symbol  Maximum symbol on arcs. Generated arcs' symbols
                              will be in range [-1,max_symbol], note -1 is
                              kFinalSymbol; must be at least 0;
-                             If epsilon_free is true, max_symbol must be
-                             at least 1;
      @param [in] min_num_arcs Minimum number of arcs in each Fsa;
                               must be at least 0.
      @param [in] max_num_arcs Maximum number of arcs in each Fsa;
                               must be >= min_num_arcs.
  */
 FsaVec RandomFsaVec(int32_t min_num_fsas = 1, int32_t max_num_fsas = 1000,
-                    bool acyclic = true, bool epsilon_free = true,
-                    int32_t max_symbol = 50, int32_t min_num_arcs = 0,
-                    int32_t max_num_arcs = 1000);
+                    bool acyclic = true, int32_t max_symbol = 50,
+                    int32_t min_num_arcs = 0, int32_t max_num_arcs = 1000);
 
 /*
   Return a randomly generated DenseFsaVec.  It will have -infinities in the

--- a/k2/csrc/intersect_test.cu
+++ b/k2/csrc/intersect_test.cu
@@ -161,9 +161,8 @@ TEST(Intersect, TwoFsas) {
 TEST(Intersect, RandomSingle) {
   for (int32_t i = 0; i < 10; i++) {
     int32_t max_symbol = 10, min_num_arcs = 0, max_num_arcs = 10;
-    bool acyclic = false, epsilon_free = false;
-    Fsa fsa = RandomFsa(acyclic, epsilon_free, max_symbol, min_num_arcs,
-                        max_num_arcs);
+    bool acyclic = false;
+    Fsa fsa = RandomFsa(acyclic, max_symbol, min_num_arcs, max_num_arcs);
     ArcSort(&fsa);
 
     int32_t min_num_fsas = 1, max_num_fsas = 1, min_frames = 0, max_frames = 10,


### PR DESCRIPTION
- Reorder states in TopSort tests and randomly add some self-loops.
- Fixed a small bug in `Array.Arange`
- Remvoed parameter `epsilon_free` in `RandomFsa(Vec)` as now we don't require epsilon-free input Fsas for `intersection`.
- Top-sort the composed path in `IsRandEquivalent` (the WFST version) as we may get non-top-sorted output if both inputs are non-epsilon-free.