### PR TITLE
Implement backprop for log-seming in Python

### DIFF
--- a/k2/csrc/context.h
+++ b/k2/csrc/context.h
@@ -453,6 +453,7 @@ class ParallelRunner {
   void Finish();
 
   ~ParallelRunner() { Finish(); }
+
  private:
   ContextPtr c_;
   std::vector<cudaStream_t> streams_;

--- a/k2/csrc/fsa.h
+++ b/k2/csrc/fsa.h
@@ -156,12 +156,13 @@ struct DenseFsaVec {
   // NOTE: our notion of "arc-index" / arc_idx is an index into scores.Data().
   int32_t NumArcs() const { return scores.Dim0() * scores.Dim1(); }
 
-  DenseFsaVec() {}
+  DenseFsaVec() = default;
   DenseFsaVec(const RaggedShape &shape, const Array2<float> &scores)
       : shape(shape), scores(scores) {
+    K2_CHECK(IsCompatible(shape, scores));
     K2_CHECK_EQ(shape.NumElements(), scores.Dim0());
   }
-  ContextPtr Context() const { return shape.Context(); }
+  ContextPtr &Context() const { return shape.Context(); }
   DenseFsaVec To(ContextPtr c) const {
     return DenseFsaVec(shape.To(c), scores.To(c));
   }

--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -414,7 +414,8 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
     ParallelRunner pr(c);
     {
       With w(pr.NewStream());
-      auto lambda_copy_data = [=] __host__ __device__ (int32_t arc_idx01) -> void {
+      auto lambda_copy_data =
+          [=] __host__ __device__(int32_t arc_idx01) -> void {
         int32_t state_idx0 = old_row_ids1_data[arc_idx01],
         new_arc_idx01 = arc_idx01 + 1 + state_idx0;
         // the "+1" above is because we put the self-loop first.
@@ -427,11 +428,12 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
     }
     {
       With w(pr.NewStream());
-      auto lambda_set_new_data = [=] __host__ __device__ (int32_t state_idx0) -> void {
+      auto lambda_set_new_data =
+          [=] __host__ __device__(int32_t state_idx0) -> void {
         int32_t old_arc_idx0x = old_row_splits1_data[state_idx0],
         new_arc_idx0x = old_arc_idx0x + state_idx0;
         new_row_splits1_data[state_idx0] = new_arc_idx0x;
-        if (state_idx0 + 1 < num_states) { // not final-state
+        if (state_idx0 + 1 < num_states) {        // not final-state
           int32_t new_arc_idx01 = new_arc_idx0x;  // the 1st arc is the loop
           new_row_ids1_data[new_arc_idx01] = state_idx0;
           new_arcs_data[new_arc_idx01] = Arc(state_idx0, state_idx0, 0, 0.0);
@@ -446,10 +448,10 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
       Eval(c, num_states, lambda_set_new_data);
     }
     pr.Finish();
-    *dest = Ragged<Arc>(RaggedShape2(&new_row_splits, &new_row_ids, new_num_arcs),
-                        new_arcs);
+    *dest = Ragged<Arc>(
+        RaggedShape2(&new_row_splits, &new_row_ids, new_num_arcs), new_arcs);
   } else {
-    K2_CHECK(src.NumAxes() == 3);
+    K2_CHECK_EQ(src.NumAxes(), 3);
     // Get a vector saying, for each FSA, whether it's nonempty.
     int32_t num_fsas = src.Dim0(),
         num_states = src.TotSize(1),
@@ -461,7 +463,8 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
     }
     Array1<int32_t> fsa_nonempty(c, num_fsas + 1);
     int32_t *fsa_nonempty_data = fsa_nonempty.Data();
-    auto lambda_set_fsa_nonempty = [=] __host__ __device__ (int32_t fsa_idx0) -> void {
+    auto lambda_set_fsa_nonempty =
+        [=] __host__ __device__(int32_t fsa_idx0) -> void {
       fsa_nonempty_data[fsa_idx0] = (old_row_splits1_data[fsa_idx0+1] >
                                      old_row_splits1_data[fsa_idx0]);
     };
@@ -470,8 +473,9 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
     const int32_t *old_row_splits2_data = src.RowSplits(2).Data(),
         *old_row_ids2_data = src.RowIds(2).Data();
     int32_t num_nonempty_fsas = fsa_nonempty.Back(),
-        new_num_arcs = old_num_arcs + num_states - num_nonempty_fsas;
-    // we subtract `num_nonempty_fsas` because final-states don't get a self-loop.
+            new_num_arcs = old_num_arcs + num_states - num_nonempty_fsas;
+    // we subtract `num_nonempty_fsas` because final-states don't get a
+    // self-loop.
 
     Array1<int32_t> new_row_splits2(c, num_states + 1),
         new_row_ids2(c, new_num_arcs);
@@ -490,7 +494,8 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
     ParallelRunner pr(c);
     {
       With w(pr.NewStream());
-      auto lambda_copy_data = [=] __host__ __device__ (int32_t arc_idx012) -> void {
+      auto lambda_copy_data =
+          [=] __host__ __device__(int32_t arc_idx012) -> void {
         int32_t state_idx01 = old_row_ids2_data[arc_idx012],
            fsa_idx0 = old_row_ids1_data[state_idx01],
            fsa_idx0_mod = fsa_idx0_mod_data[fsa_idx0],
@@ -506,7 +511,8 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
     }
     {
       With w(pr.NewStream());
-      auto lambda_set_new_data = [=] __host__ __device__ (int32_t state_idx01) -> void {
+      auto lambda_set_new_data =
+          [=] __host__ __device__(int32_t state_idx01) -> void {
         int32_t
           fsa_idx0 = old_row_ids1_data[state_idx01],
           fsa_idx0_mod = fsa_idx0_mod_data[fsa_idx0],

--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -306,26 +306,9 @@ void ArcSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*= nullptr*/) {
 // forward-pass algorithm is already at least linear-time in the length
 // of this path. But we can consider it for the future.
 Ragged<int32_t> ShortestPath(FsaVec &fsas,
-                             Array1<float> *total_scores /*= nullptr*/,
-                             Array1<int32_t> *entering_arcs /*= nullptr*/) {
+                             const Array1<int32_t> &entering_arcs) {
   K2_CHECK_EQ(fsas.NumAxes(), 3);
-  Ragged<int32_t> state_batches = GetStateBatches(fsas, true);
-  Array1<int32_t> dest_states = GetDestStates(fsas, true);
-  Ragged<int32_t> incoming_arcs = GetIncomingArcs(fsas, dest_states);
-  Ragged<int32_t> entering_arc_batches =
-      GetEnteringArcIndexBatches(fsas, incoming_arcs, state_batches);
-
-  bool log_semiring = false;
-  Array1<int32_t> tmp_entering_arcs;
-  Array1<float> forward_scores =
-      GetForwardScores<float>(fsas, state_batches, entering_arc_batches,
-                              log_semiring, &tmp_entering_arcs);
-  if (total_scores != nullptr)
-    *total_scores = GetTotScores<float>(fsas, forward_scores);
-
-  if (entering_arcs != nullptr) *entering_arcs = tmp_entering_arcs;
-
-  const int32_t *entering_arcs_data = tmp_entering_arcs.Data();
+  const int32_t *entering_arcs_data = entering_arcs.Data();
   const Arc *arcs_data = fsas.values.Data();
   int32_t num_fsas = fsas.Dim0();
   int32_t num_states = fsas.TotSize(1);

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -230,23 +230,18 @@ FsaVec LinearFsas(Ragged<int32_t> &symbols);
                  property kFsaPropertiesTopSortedAndAcyclic if you were
                  to compute properties.
 
-   @param [out,optional] entering_arcs   If non-NULL, it will be set to
-                a new Array1, indexed by state_idx01 into `fsas`,
-                saying which arc_idx012 is the best arc entering it,
-                or -1 if there is no such arc.
-
-   @param [out,optional]
-                    If non-NULL, it will contain array of total scores,
-                    of dimension fsas.Dim0(), which will contain the scores
-                    in the final-states of `forward_scores`, or -infinity for
-                    FSAs that had no states.
+   @param [in] entering_arcs  An array indexed by state-index (idx01 into
+                              fsas), i.e.
+                              `entering_arcs.Dim()==fsas.TotSize(1)`,
+                              containing forward scores. (these will be zero
+                              for the start-states). It is returned by
+                              GetForwardScores with log_semiring==false.
 
    @return returns a tensor with 2 axes indexed by [fsa_idx0][arc_idx012]
            containing the best arc indexes of each fsa.
  */
 Ragged<int32_t> ShortestPath(FsaVec &fsas,
-                             Array1<float> *total_scores = nullptr,
-                             Array1<int32_t> *entering_arcs = nullptr);
+                             const Array1<int32_t> &entering_arcs);
 
 }  // namespace k2
 

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -98,7 +98,6 @@ void TopSort(FsaVec &src, FsaVec *dest, Array1<int32_t> *arc_map = nullptr);
  */
 bool HostTopSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map = nullptr);
 
-
 /*
   Add epsilon self-loops to an Fsa or FsaVec (this is required when composing
   using a composition method that does not treat epsilons specially, if the
@@ -230,12 +229,9 @@ FsaVec LinearFsas(Ragged<int32_t> &symbols);
                  property kFsaPropertiesTopSortedAndAcyclic if you were
                  to compute properties.
 
-   @param [in] entering_arcs  An array indexed by state-index (idx01 into
-                              fsas), i.e.
-                              `entering_arcs.Dim()==fsas.TotSize(1)`,
-                              containing forward scores. (these will be zero
-                              for the start-states). It is returned by
-                              GetForwardScores with log_semiring==false.
+   @param [in] entering_arcs   An array indexed by state_idx01 into `fsas`,
+                saying which arc_idx012 is the best arc entering it,
+                or -1 if there is no such arc.
 
    @return returns a tensor with 2 axes indexed by [fsa_idx0][arc_idx012]
            containing the best arc indexes of each fsa.

--- a/k2/csrc/fsa_algo_test.cu
+++ b/k2/csrc/fsa_algo_test.cu
@@ -340,7 +340,19 @@ TEST(FsaAlgo, ShortestPath) {
     FsaVec fsa_vec = CreateFsaVec(3, &fsa_array[0]);
     fsa_vec = fsa_vec.To(context);
 
-    Ragged<int32_t> best_path_arc_indexes = ShortestPath(fsa_vec);
+    Ragged<int32_t> state_batches = GetStateBatches(fsa_vec, true);
+    Array1<int32_t> dest_states = GetDestStates(fsa_vec, true);
+    Ragged<int32_t> incoming_arcs = GetIncomingArcs(fsa_vec, dest_states);
+    Ragged<int32_t> entering_arc_batches =
+        GetEnteringArcIndexBatches(fsa_vec, incoming_arcs, state_batches);
+
+    bool log_semiring = false;
+    Array1<int32_t> entering_arcs;
+    GetForwardScores<float>(fsa_vec, state_batches, entering_arc_batches,
+                            log_semiring, &entering_arcs);
+
+    Ragged<int32_t> best_path_arc_indexes =
+        ShortestPath(fsa_vec, entering_arcs);
     CheckArrayData(best_path_arc_indexes.values,
                    std::vector<int32_t>{1, 3, 5, 10, 13, 16, 17, 19, 21, 23});
 

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1090,7 +1090,7 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
       entering_arc_start_index.To(GetCpuContext());
   const int32_t *cpu_entering_arc_start = cpu_entering_arc_start_index.Data();
   // copy the index of start state in each fsa to CPU
-  Array1<int32_t> arc_batches_row_splits1_array =
+  Array1<int32_t> &arc_batches_row_splits1_array =
       entering_arc_batches.RowSplits(1);
   Array1<int32_t> cpu_state_idx0xx =
       entering_arc_batches.RowSplits(2)[arc_batches_row_splits1_array].To(

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1092,11 +1092,12 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
   // copy the index of start state in each fsa to CPU
   Array1<int32_t> &arc_batches_row_splits1_array =
       entering_arc_batches.RowSplits(1);
-  Array1<int32_t> cpu_state_idx0xx =
+  Array1<int32_t> arc_batches_row_splits12_cpu =
       entering_arc_batches.RowSplits(2)[arc_batches_row_splits1_array].To(
           GetCpuContext());
-  K2_CHECK_EQ(cpu_state_idx0xx.Dim(), num_batches + 1);
-  const int32_t *cpu_state_idx0xx_data = cpu_state_idx0xx.Data();
+  K2_CHECK_EQ(arc_batches_row_splits12_cpu.Dim(), num_batches + 1);
+  const int32_t *arc_batches_row_splits12_cpu_data =
+      arc_batches_row_splits12_cpu.Data();
   Array1<int32_t> arc_row_splits_mem(c, num_states + 1);
   Array1<FloatType> score_cache(c, num_states + 1);
 
@@ -1110,8 +1111,8 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
   // process batch sequentially.
   for (int32_t i = 0; i < num_batches; ++i) {
     // get the range we would call Max/LogSum per sub list
-    int32_t this_state_idx0xx = cpu_state_idx0xx[i],
-            next_state_idx0xx = cpu_state_idx0xx_data[i + 1];
+    int32_t this_state_idx0xx = arc_batches_row_splits12_cpu_data[i],
+            next_state_idx0xx = arc_batches_row_splits12_cpu_data[i + 1];
     K2_CHECK_LT(this_state_idx0xx, num_states);
     K2_CHECK_LE(next_state_idx0xx, num_states);
     int32_t num_states_this_batch = next_state_idx0xx - this_state_idx0xx;
@@ -1326,19 +1327,21 @@ Array1<FloatType> GetBackwardScores(
   // copy the index of start state in each fsa to CPU
   Array1<int32_t> arc_batches_row_splits1_array =
       leaving_arc_batches.RowSplits(1);
-  Array1<int32_t> cpu_state_idx0xx =
+  Array1<int32_t> arc_batches_row_splits12_cpu =
       leaving_arc_batches.RowSplits(2)[arc_batches_row_splits1_array].To(
           GetCpuContext());
-  K2_CHECK_EQ(cpu_state_idx0xx.Dim(), num_batches + 1);
-  const int32_t *cpu_state_idx0xx_data = cpu_state_idx0xx.Data();
+  K2_CHECK_EQ(arc_batches_row_splits12_cpu.Dim(), num_batches + 1);
+  const int32_t *arc_batches_row_splits12_cpu_data =
+      arc_batches_row_splits12_cpu.Data();
   Array1<int32_t> arc_row_splits_mem(c, num_states + 1);
   Array1<FloatType> score_cache(c, num_states + 1);
   // process batch sequentially.
   for (int32_t i = num_batches - 1; i >= 0; --i) {
     // get the range we would call Max/LogSum per sub list
-    int32_t this_state_idx0xx = cpu_state_idx0xx[i];
+    int32_t this_state_idx0xx = arc_batches_row_splits12_cpu_data[i];
     int32_t next_state_idx0xx =
-        cpu_state_idx0xx_data[i + 1];  // the 1st state idx in the next batch
+        arc_batches_row_splits12_cpu_data[i + 1];  // the 1st state idx in the
+                                                   // next batch
     K2_CHECK_LT(this_state_idx0xx, num_states);
     K2_CHECK_LE(next_state_idx0xx, num_states);
     int32_t num_states_this_batch = next_state_idx0xx - this_state_idx0xx;

--- a/k2/csrc/fsa_utils.h
+++ b/k2/csrc/fsa_utils.h
@@ -258,7 +258,7 @@ Array1<FloatType> GetTotScores(FsaVec &fsas,
        @param [in] leaving_arc_batches  Arcs-indexes (idx012's in fsas) of arcs
                  leaving states in `state_batches`, indexed
                  [iter][fsa][state_list][arc_list], as returned by
-                 LeavingArcIndexBatches().
+                 GetLeavingArcIndexBatches().
        @param [in] tot_scores  If provided, we'll treat the backward
                   scores of final-states as the negative of these
                   tot_scores (which must have

--- a/k2/csrc/host_shim.cu
+++ b/k2/csrc/host_shim.cu
@@ -226,7 +226,6 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, bool log_semiring,
         b_cpu = b.To(GetCpuContext());
     return IsRandEquivalent(a, b, log_semiring, beam, treat_epsilons_specially,
                             delta, npath);
-
   }
   if (a.NumAxes() > 2) {
     for (int32_t i = 0; i < a.Dim0(); i++) {

--- a/k2/csrc/intersect_test.cu
+++ b/k2/csrc/intersect_test.cu
@@ -259,8 +259,8 @@ TEST(Intersect, RandomFsaVec) {
     FsaVec out_fsas;
     float beam = 10000.0;
     int32_t max_active = 10000, min_active = 0;
-    IntersectDensePruned(fsavec, dfsavec, beam, max_active, min_active, &out_fsas,
-                         &arc_map_a, &arc_map_b);
+    IntersectDensePruned(fsavec, dfsavec, beam, max_active, min_active,
+                         &out_fsas, &arc_map_a, &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_b = " << arc_map_b;
 
     FsaVec fsas_b = ConvertDenseToFsaVec(dfsavec);
@@ -270,7 +270,8 @@ TEST(Intersect, RandomFsaVec) {
     // IntersectDensePruned() treats epsilons as normal symbols, so we need to
     // as well.
 
-    ArcSort(&fsavec);  // CAUTION if you later test the arc_maps: we arc-sort here,
+    ArcSort(
+        &fsavec);  // CAUTION if you later test the arc_maps: we arc-sort here,
     // so the input `fsa` is not the same as before.
     bool treat_epsilons_specially = false;
     Intersect(fsavec, fsas_b, treat_epsilons_specially, &out_fsas2, &arc_map_a2,

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -38,7 +38,7 @@ void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst) {
   K2_CHECK(IsCompatible(src.shape, *dst));
 
   int32_t last_axis = src.NumAxes() - 1;
-  const Array1<int32_t> row_splits_array = src.shape.RowSplits(last_axis);
+  const Array1<int32_t> &row_splits_array = src.shape.RowSplits(last_axis);
   int32_t num_rows = row_splits_array.Dim() - 1;
   K2_CHECK_EQ(num_rows, dst->Dim());
 
@@ -226,8 +226,8 @@ Ragged<T> RandomRagged(T min_value, T max_value, int32_t min_num_axes,
   RaggedShape shape = RandomRaggedShape(true, min_num_axes, max_num_axes,
                                         min_num_elements, max_num_elements);
   ContextPtr c = GetCpuContext();
-  Array1<T> values = RandUniformArray1(c, shape.NumElements(),
-                                       min_value, max_value);
+  Array1<T> values =
+      RandUniformArray1(c, shape.NumElements(), min_value, max_value);
   return Ragged<T>(shape, values);
 }
 
@@ -314,7 +314,7 @@ template <typename T>
 std::istream &operator>>(std::istream &is, Ragged<T> &r) {
   // Note: the top element of 'row_splits' will end up being
   // discarded; the others will become the axes of `r`
-  std::vector<std::vector<int32_t> > row_splits;
+  std::vector<std::vector<int32_t>> row_splits;
   std::vector<T> elems;
   int32_t cur_level = 0;
   is >> std::ws;  // eat whitespace
@@ -338,17 +338,15 @@ std::istream &operator>>(std::istream &is, Ragged<T> &r) {
         return is;
       }
       row_splits[cur_level].push_back(
-          (cur_level + 1 >= row_splits.size()) ?
-          static_cast<int32_t>(elems.size()) :
-          (row_splits[cur_level+1].size() - 1));
+          (cur_level + 1 >= row_splits.size())
+              ? static_cast<int32_t>(elems.size())
+              : (row_splits[cur_level + 1].size() - 1));
       is.get();  // consume character 'c'
-      if (cur_level == 0)
-        break;
+      if (cur_level == 0) break;
     } else {
       InputFixer<T> t;
       is >> t;
-      if (!is.good() ||
-          cur_level != static_cast<int32_t>(row_splits.size()) ||
+      if (!is.good() || cur_level != static_cast<int32_t>(row_splits.size()) ||
           cur_level < 2) {
         is.setstate(std::ios::failbit);
         return is;
@@ -378,8 +376,6 @@ std::istream &operator>>(std::istream &is, Ragged<T> &r) {
   K2_CHECK(r.values.Dim() == r.shape.NumElements());
   return is;
 }
-
-
 
 }  // namespace k2
 

--- a/k2/python/csrc/torch/fsa.cu
+++ b/k2/python/csrc/torch/fsa.cu
@@ -23,23 +23,33 @@
 namespace k2 {
 
 static void PybindFsaBasicProperties(py::module &m) {
-  m.def("fsa_properties_as_str", &FsaPropertiesAsString);
+  m.def("fsa_properties_as_str", &FsaPropertiesAsString, py::arg("properties"));
 
-  m.def("get_fsa_basic_properties", &GetFsaBasicProperties);
+  m.def("get_fsa_basic_properties", &GetFsaBasicProperties, py::arg("fsa"));
 
-  m.def("is_arc_sorted", [](int32_t properties) -> bool {
-    return (properties & kFsaPropertiesArcSorted) == kFsaPropertiesArcSorted;
-  });
+  m.def(
+      "is_arc_sorted",
+      [](int32_t properties) -> bool {
+        return (properties & kFsaPropertiesArcSorted) ==
+               kFsaPropertiesArcSorted;
+      },
+      py::arg("properties"));
 
-  m.def("is_accessible", [](int32_t properties) -> bool {
-    return (properties & kFsaPropertiesMaybeAccessible) ==
-           kFsaPropertiesMaybeAccessible;
-  });
+  m.def(
+      "is_accessible",
+      [](int32_t properties) -> bool {
+        return (properties & kFsaPropertiesMaybeAccessible) ==
+               kFsaPropertiesMaybeAccessible;
+      },
+      py::arg("properties"));
 
-  m.def("is_coaccessible", [](int32_t properties) -> bool {
-    return (properties & kFsaPropertiesMaybeCoaccessible) ==
-           kFsaPropertiesMaybeCoaccessible;
-  });
+  m.def(
+      "is_coaccessible",
+      [](int32_t properties) -> bool {
+        return (properties & kFsaPropertiesMaybeCoaccessible) ==
+               kFsaPropertiesMaybeCoaccessible;
+      },
+      py::arg("properties"));
 }
 
 static void PybindFsaUtil(py::module &m) {
@@ -84,14 +94,15 @@ static void PybindFsaUtil(py::module &m) {
   m.def(
       "_fsa_to_str",
       [](Fsa &fsa, bool openfst = false,
-         torch::optional<torch::Tensor> aux_labels = {}) -> std::string {
+         torch::optional<torch::Tensor> aux_labels =
+             torch::nullopt) -> std::string {
         Array1<int32_t> array;
         if (aux_labels.has_value())
           array = FromTensor<int32_t>(aux_labels.value());
         return FsaToString(fsa, openfst, aux_labels ? &array : nullptr);
       },
       py::arg("fsa"), py::arg("openfst") = false,
-      py::arg("aux_labels") = py::none());
+      py::arg("aux_labels") = torch::nullopt);
 
   m.def(
       "_fsa_from_str",
@@ -111,11 +122,109 @@ static void PybindFsaUtil(py::module &m) {
 
   // the following methods are for debugging only
   m.def("_fsa_to_fsa_vec", &FsaToFsaVec, py::arg("fsa"));
+
   m.def("_get_fsa_vec_element", &GetFsaVecElement, py::arg("vec"),
         py::arg("i"));
-  m.def("_create_fsa_vec", [](std::vector<Fsa *> &fsas) -> FsaVec {
-    return CreateFsaVec(fsas.size(), fsas.data());
-  });
+
+  m.def(
+      "_create_fsa_vec",
+      [](std::vector<Fsa *> &fsas) -> FsaVec {
+        return CreateFsaVec(fsas.size(), fsas.data());
+      },
+      py::arg("fsas"));
+
+  // returns Ragged<int32_t>
+  m.def("_get_state_batches", &GetStateBatches, py::arg("fsas"),
+        py::arg("transpose") = true);
+
+  m.def(
+      "_get_dest_states",
+      [](FsaVec &fsas, bool as_idx01) -> torch::Tensor {
+        Array1<int32_t> ans = GetDestStates(fsas, as_idx01);
+        return ToTensor(ans);
+      },
+      py::arg("fsas"), py::arg("as_idx01"));
+
+  m.def(
+      "_get_incoming_arcs",
+      [](FsaVec &fsas, torch::Tensor dest_states) -> Ragged<int32_t> {
+        Array1<int32_t> dest_states_array = FromTensor<int32_t>(dest_states);
+        return GetIncomingArcs(fsas, dest_states_array);
+      },
+      py::arg("fsas"), py::arg("dest_states"));
+
+  // returns Ragged<int32_t>
+  m.def("_get_entering_arc_index_batches", &GetEnteringArcIndexBatches,
+        py::arg("fsas"), py::arg("incoming_arcs"), py::arg("state_batches"));
+
+  // returns Ragged<int32_t>
+  m.def("_get_leaving_arc_index_batches", &GetLeavingArcIndexBatches,
+        py::arg("fsas"), py::arg("state_batches"));
+}
+
+template <typename T>
+static void PybindGetForwardScores(py::module &m, const char *name) {
+  // Return a std::pair
+  //   - forward_scores, a torch::Tensor of dtype torch.float32 or torch.float64
+  //   (depending on T) containing the scores
+  //
+  //   - best_path_arc_indexes (optional)
+  //     - if log_semiring is true, it is None
+  //     - else it is a torch::Tensor of dtype torch.int32
+  m.def(
+      name,
+      [](FsaVec &fsas, Ragged<int32_t> &state_batches,
+         Ragged<int32_t> &entering_arc_batches, bool log_semiring)
+          -> std::pair<torch::Tensor, torch::optional<torch::Tensor>> {
+        Array1<int32_t> best_path_arc_indexes;
+        Array1<T> scores = GetForwardScores<T>(
+            fsas, state_batches, entering_arc_batches, log_semiring,
+            log_semiring ? nullptr : &best_path_arc_indexes);
+
+        torch::optional<torch::Tensor> best_path_arc_indexes_tensor;
+        if (!log_semiring)
+          best_path_arc_indexes_tensor = ToTensor(best_path_arc_indexes);
+
+        return std::make_pair(ToTensor(scores), best_path_arc_indexes_tensor);
+      },
+      py::arg("fsas"), py::arg("state_batches"),
+      py::arg("entering_arc_batches"), py::arg("log_semiring"));
+}
+
+template <typename T>
+static void PybindGetBackwardScores(py::module &m, const char *name) {
+  m.def(
+      name,
+      [](FsaVec &fsas, Ragged<int32_t> &state_batches,
+         Ragged<int32_t> &leaving_arc_batches,
+         torch::optional<torch::Tensor> tot_scores = torch::nullopt,
+         bool log_semiring = true) -> torch::Tensor {
+        if (tot_scores.has_value()) {
+          const Array1<T> tot_scores_array = FromTensor<T>(tot_scores.value());
+          Array1<T> ans =
+              GetBackwardScores<T>(fsas, state_batches, leaving_arc_batches,
+                                   &tot_scores_array, log_semiring);
+          return ToTensor(ans);
+        } else {
+          Array1<T> ans = GetBackwardScores<T>(
+              fsas, state_batches, leaving_arc_batches, nullptr, log_semiring);
+          return ToTensor(ans);
+        }
+      },
+      py::arg("fsas"), py::arg("state_batches"), py::arg("leaving_arc_batches"),
+      py::arg("tot_scores") = torch::nullopt, py::arg("log_semiring") = true);
+}
+
+template <typename T>
+static void PybindGetTotScores(py::module &m, const char *name) {
+  m.def(
+      name,
+      [](FsaVec &fsas, torch::Tensor forward_scores) -> torch::Tensor {
+        Array1<T> forward_scores_array = FromTensor<T>(forward_scores);
+        Array1<T> tot_scores = GetTotScores(fsas, forward_scores_array);
+        return ToTensor(tot_scores);
+      },
+      py::arg("fsas"), py::arg("forward_scores"));
 }
 
 static void PybindDenseFsaVec(py::module &m) {
@@ -124,21 +233,23 @@ static void PybindDenseFsaVec(py::module &m) {
   // We do not need to access its members in Python
 
   // TODO(fangjun): add docstring for this funciton
-  pyclass.def(py::init(
-      [](torch::Tensor scores, torch::Tensor row_splits) -> DenseFsaVec * {
-        // remove the contiguous check once the following comment
-        // https://github.com/k2-fsa/k2/commit/60b8e97b1838033b45b83cc88a58ec91912ce91e#r43174753
-        // is resolved.
-        K2_CHECK(scores.is_contiguous());
-        Array1<int32_t> _row_splits = FromTensor<int32_t>(row_splits);
-        DenseFsaVec *dense_fsa = new DenseFsaVec;  // will be freed by Python
-        dense_fsa->shape = RaggedShape2(&_row_splits, nullptr, -1);
-        dense_fsa->scores = FromTensor<float>(scores, Array2Tag{});
+  pyclass.def(py::init([](torch::Tensor scores,
+                          torch::Tensor row_splits) -> DenseFsaVec * {
+                // remove the contiguous check once the following comment
+                // https://github.com/k2-fsa/k2/commit/60b8e97b1838033b45b83cc88a58ec91912ce91e#r43174753
+                // is resolved.
+                K2_CHECK(scores.is_contiguous());
+                Array1<int32_t> _row_splits = FromTensor<int32_t>(row_splits);
+                DenseFsaVec *dense_fsa =
+                    new DenseFsaVec;  // will be freed by Python
+                dense_fsa->shape = RaggedShape2(&_row_splits, nullptr, -1);
+                dense_fsa->scores = FromTensor<float>(scores, Array2Tag{});
 
-        K2_CHECK(IsCompatible(dense_fsa->shape, dense_fsa->scores));
+                K2_CHECK(IsCompatible(dense_fsa->shape, dense_fsa->scores));
 
-        return dense_fsa;  // Python takes the ownership
-      }));
+                return dense_fsa;  // Python takes the ownership
+              }),
+              py::arg("scores"), py::arg("row_splits"));
 
   // the `to_str` method is for debugging only
   pyclass.def("to_str", [](PyClass &self) {
@@ -152,27 +263,19 @@ static void PybindDenseFsaVec(py::module &m) {
   });
 }
 
-// template <typename T>
-static void PybindGetArcScores(py::module &m) {
-  m.def("get_arc_scores", [](FsaVec &fsa_vec) -> torch::Tensor {
-    Ragged<int32_t> state_batches = GetStateBatches(fsa_vec, true);
-    Array1<int32_t> dest_states = GetDestStates(fsa_vec, true);
-    Ragged<int32_t> incoming_arcs = GetIncomingArcs(fsa_vec, dest_states);
-    Ragged<int32_t> entering_arc_batches =
-        GetEnteringArcIndexBatches(fsa_vec, incoming_arcs, state_batches);
-    Ragged<int32_t> leaving_arc_batches =
-        GetLeavingArcIndexBatches(fsa_vec, state_batches);
-
-    bool log_semiring = true;
-    Array1<float> forward_scores = GetForwardScores<float>(
-        fsa_vec, state_batches, entering_arc_batches, log_semiring);
-    Array1<float> tot_scores = GetTotScores(fsa_vec, forward_scores);
-    Array1<float> backward_scores = GetBackwardScores<float>(
-        fsa_vec, state_batches, leaving_arc_batches, &tot_scores, log_semiring);
-    Array1<float> arc_scores =
-        GetArcScores(fsa_vec, forward_scores, backward_scores);
-    return ToTensor(arc_scores);
-  });
+template <typename T>
+static void PybindGetArcScores(py::module &m, const char *name) {
+  m.def(
+      name,
+      [](FsaVec &fsas, torch::Tensor forward_scores,
+         torch::Tensor backward_scores) -> torch::Tensor {
+        Array1<T> forward_scores_array = FromTensor<T>(forward_scores);
+        Array1<T> backward_scores_array = FromTensor<T>(backward_scores);
+        Array1<T> arc_scores =
+            GetArcScores<T>(fsas, forward_scores_array, backward_scores_array);
+        return ToTensor(arc_scores);
+      },
+      py::arg("fsas"), py::arg("forward_scores"), py::arg("backward_scores"));
 }
 
 }  // namespace k2
@@ -181,5 +284,12 @@ void PybindFsa(py::module &m) {
   k2::PybindFsaUtil(m);
   k2::PybindDenseFsaVec(m);
   k2::PybindFsaBasicProperties(m);
-  k2::PybindGetArcScores(m);
+  k2::PybindGetForwardScores<float>(m, "_get_forward_scores_float");
+  k2::PybindGetForwardScores<double>(m, "_get_forward_scores_double");
+  k2::PybindGetBackwardScores<float>(m, "_get_backward_scores_float");
+  k2::PybindGetBackwardScores<double>(m, "_get_backward_scores_double");
+  k2::PybindGetTotScores<float>(m, "_get_tot_scores_float");
+  k2::PybindGetTotScores<double>(m, "_get_tot_scores_double");
+  k2::PybindGetArcScores<float>(m, "_get_arc_scores_float");
+  k2::PybindGetArcScores<double>(m, "_get_arc_scores_double");
 }

--- a/k2/python/csrc/torch/torch_util.cu
+++ b/k2/python/csrc/torch/torch_util.cu
@@ -43,6 +43,8 @@ Dtype ScalarTypeToDtype(torch::ScalarType scalar_type) {
   switch (scalar_type) {
     case torch::kFloat:
       return kFloatDtype;
+    case torch::kDouble:
+      return kDoubleDtype;
     case torch::kInt:
       return kInt32Dtype;
     default:
@@ -56,6 +58,8 @@ torch::ScalarType ScalarTypeFromDtype(Dtype dtype) {
   switch (dtype) {
     case kFloatDtype:
       return torch::kFloat;
+    case kDoubleDtype:
+      return torch::kDouble;
     case kInt32Dtype:
       return torch::kInt;
     default:

--- a/k2/python/csrc/torch/torch_util.h
+++ b/k2/python/csrc/torch/torch_util.h
@@ -47,6 +47,7 @@ struct ToScalarType;
 
 // TODO(fangjun): add other types if needed
 TO_SCALAR_TYPE(float, torch::kFloat);
+TO_SCALAR_TYPE(double, torch::kDouble);
 TO_SCALAR_TYPE(int32_t, torch::kInt);
 
 #undef TO_SCALAR_TYPE

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -1,4 +1,4 @@
-from .autograd import get_forward_log_like
+from .autograd import get_tot_scores
 from .dense_fsa import dense_fsa
 from .fsa import Fsa
 from .fsa_algo import arc_sort
@@ -26,8 +26,8 @@ __all__ = [
     'connect',
     'create_fsa_vec',
     'dense_fsa',
-    'get_forward_log_like',
     'get_properties',
+    'get_tot_scores',
     'intersect',
     'is_accessible',
     'is_arc_sorted',

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -1,3 +1,4 @@
+from .autograd import get_forward_log_like
 from .dense_fsa import dense_fsa
 from .fsa import Fsa
 from .fsa_algo import arc_sort
@@ -25,6 +26,7 @@ __all__ = [
     'connect',
     'create_fsa_vec',
     'dense_fsa',
+    'get_forward_log_like',
     'get_properties',
     'intersect',
     'is_accessible',

--- a/k2/python/k2/autograd.py
+++ b/k2/python/k2/autograd.py
@@ -10,12 +10,12 @@ import _k2
 from .fsa import Fsa
 
 
-class _ForwardLogLikeFunction(torch.autograd.Function):
+class _GetTotScoresFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, fsas: Fsa, log_semiring: bool, use_float_scores: bool,
                 unused_scores: torch.Tensor) -> torch.Tensor:
-        '''Compute the forward loglikes of an FsaVec.
+        '''Compute the total loglikes of an FsaVec.
 
         Args:
           fsas:
@@ -41,7 +41,7 @@ class _ForwardLogLikeFunction(torch.autograd.Function):
             tot_scores = fsas.update_tot_scores_log(use_float_scores)
 
         # NOTE: since `fsas`, `log_semiring` and `use_float_scores` are
-        # not tensors, they are saved as attributes as `ctx`
+        # not tensors, they are saved as attributes of `ctx`.
         ctx.fsas = fsas
         ctx.log_semiring = log_semiring
         ctx.use_float_scores = use_float_scores
@@ -81,9 +81,9 @@ class _ForwardLogLikeFunction(torch.autograd.Function):
             return None, None, None, arc_scores.exp()
 
 
-def get_forward_log_like(fsas: Fsa, log_semiring: bool,
-                         use_float_scores: bool) -> torch.Tensor:
-    '''Compute the forward loglikes of an FsaVec.
+def get_tot_scores(fsas: Fsa, log_semiring: bool,
+                   use_float_scores: bool) -> torch.Tensor:
+    '''Compute the total loglikes of an FsaVec.
     Args:
       fsas:
         The input FsaVec.
@@ -99,6 +99,6 @@ def get_forward_log_like(fsas: Fsa, log_semiring: bool,
       If `use_float_scores==True`, its dtype is `torch.float32`;
       it is `torch.float64` otherwise.
     '''
-    tot_scores = _ForwardLogLikeFunction.apply(fsas, log_semiring,
-                                               use_float_scores, fsas.scores)
+    tot_scores = _GetTotScoresFunction.apply(fsas, log_semiring,
+                                             use_float_scores, fsas.scores)
     return tot_scores

--- a/k2/python/k2/autograd.py
+++ b/k2/python/k2/autograd.py
@@ -1,0 +1,85 @@
+# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# See ../../../LICENSE for clarification regarding multiple authors
+
+import torch
+
+import _k2
+
+from .fsa import Fsa
+
+
+class _ForwardLogLikeFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, fsas: Fsa, log_semiring: bool, use_float_scores: bool,
+                unused_scores: torch.Tensor) -> torch.Tensor:
+        '''Compute the forward loglikes of an FsaVec.
+
+        Args:
+          fsas:
+            The input FsaVec.
+          log_semiring:
+            True to use log semiring.
+            False to use tropical semiring.
+          use_float_scores:
+            True to use float, i.e., single precision floating point,
+            to compute log likes. False to use double precision.
+          unused_scores:
+            It is used only for backward propagation purpose.
+            It equals to `fsas.scores`.
+
+        Returns:
+          The forward loglike contained in a 1-D tensor.
+          If `use_float_scores==True`, its dtype is `torch.float32`;
+          it is `torch.float64` otherwise.
+        '''
+        if log_semiring is False:
+            tot_scores = fsas.update_tot_scores_tropical(use_float_scores)
+        else:
+            tot_scores = fsas.update_tot_scores_log(use_float_scores)
+            #  forward_scores = fsas.update_forward_scores_log(use_float_scores)
+            #  backward_scores = fsas.update_backward_scores_log(use_float_scores)
+        ctx.fsas = fsas
+        ctx.log_semiring = log_semiring
+        ctx.use_float_scores = use_float_scores
+        ctx.save_for_backward(unused_scores)
+        return tot_scores
+
+    @staticmethod
+    def backward(ctx, unused):
+        fsas = ctx.fsas
+        log_semiring = ctx.log_semiring
+        use_float_scores = ctx.use_float_scores
+        scores, = ctx.saved_tensors
+        if log_semiring is False:
+            entering_arcs = fsas.update_entering_arcs(use_float_scores)
+            _, ragged_int = _k2.shortest_path(fsas.arcs, entering_arcs)
+            best_path_arc_indexes = ragged_int.values().to(torch.int64)
+            out_grad = torch.zeros_like(scores, requires_grad=False)
+            out_grad[best_path_arc_indexes] = 1
+            # We return four values since the `forward` method accepts four
+            # arguments (excluding ctx).
+            #      fsas, log_semiring, use_float_scores
+            return None, None, None, out_grad
+
+
+def get_forward_log_like(fsas: Fsa, log_semiring: bool,
+                         use_float_scores: bool) -> torch.Tensor:
+    '''Compute the forward loglikes of an FsaVec.
+    Args:
+      fsas:
+        The input FsaVec.
+      log_semiring:
+        True to use log semiring.
+        False to use tropical semiring.
+      use_float_scores:
+        True to use float, i.e., single precision floating point,
+        to compute log likes. False to use double precision.
+    Returns:
+      The forward loglike contained in a 1-D tensor.
+      If `use_float_scores==True`, its dtype is `torch.float32`;
+      it is `torch.float64` otherwise.
+    '''
+    tot_scores = _ForwardLogLikeFunction.apply(fsas, log_semiring,
+                                               use_float_scores, fsas.scores)
+    return tot_scores

--- a/k2/python/k2/autograd.py
+++ b/k2/python/k2/autograd.py
@@ -1,6 +1,8 @@
 # Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 # See ../../../LICENSE for clarification regarding multiple authors
 
+from typing import Tuple
+
 import torch
 
 import _k2
@@ -37,20 +39,25 @@ class _ForwardLogLikeFunction(torch.autograd.Function):
             tot_scores = fsas.update_tot_scores_tropical(use_float_scores)
         else:
             tot_scores = fsas.update_tot_scores_log(use_float_scores)
-            #  forward_scores = fsas.update_forward_scores_log(use_float_scores)
-            #  backward_scores = fsas.update_backward_scores_log(use_float_scores)
+
+        # NOTE: since `fsas`, `log_semiring` and `use_float_scores` are
+        # not tensors, they are saved as attributes as `ctx`
         ctx.fsas = fsas
         ctx.log_semiring = log_semiring
         ctx.use_float_scores = use_float_scores
+
         ctx.save_for_backward(unused_scores)
+
         return tot_scores
 
     @staticmethod
-    def backward(ctx, unused):
+    def backward(ctx, unused: torch.Tensor
+                ) -> Tuple[None, None, None, torch.Tensor]:  # noqa
         fsas = ctx.fsas
         log_semiring = ctx.log_semiring
         use_float_scores = ctx.use_float_scores
         scores, = ctx.saved_tensors
+
         if log_semiring is False:
             entering_arcs = fsas.update_entering_arcs(use_float_scores)
             _, ragged_int = _k2.shortest_path(fsas.arcs, entering_arcs)
@@ -59,8 +66,19 @@ class _ForwardLogLikeFunction(torch.autograd.Function):
             out_grad[best_path_arc_indexes] = 1
             # We return four values since the `forward` method accepts four
             # arguments (excluding ctx).
-            #      fsas, log_semiring, use_float_scores
+            #      fsas, log_semiring, use_float_scores, unused_scores
             return None, None, None, out_grad
+        else:
+            forward_scores = fsas.update_forward_scores_log(use_float_scores)
+            backward_scores = fsas.update_backward_scores_log(use_float_scores)
+            if use_float_scores:
+                func = _k2._get_arc_scores_float
+            else:
+                func = _k2._get_arc_scores_double
+            arc_scores = func(fsas=fsas.arcs,
+                              forward_scores=forward_scores,
+                              backward_scores=backward_scores)
+            return None, None, None, arc_scores.exp()
 
 
 def get_forward_log_like(fsas: Fsa, log_semiring: bool,
@@ -75,6 +93,7 @@ def get_forward_log_like(fsas: Fsa, log_semiring: bool,
       use_float_scores:
         True to use float, i.e., single precision floating point,
         to compute log likes. False to use double precision.
+
     Returns:
       The forward loglike contained in a 1-D tensor.
       If `use_float_scores==True`, its dtype is `torch.float32`;

--- a/k2/python/k2/dense_fsa.py
+++ b/k2/python/k2/dense_fsa.py
@@ -1,4 +1,5 @@
 # Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# See ../../../LICENSE for clarification regarding multiple authors
 
 import _k2
 import numpy as np

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -109,8 +109,49 @@ class Fsa(object):
             self.aux_labels = aux_labels.to(torch.int32)
 
     def _init_internal(self) -> None:
+        # There are three kinds of attribute dictionaries:
+        #
+        # - `_tensor_attr`
+        #     It saves attribute values of type torch.Tensor. `shape[0]` of
+        #     attribute values have to be equal to the number of arcs
+        #     in the FSA.
+        #
+        # - `_non_tensor_attr`
+        #     It saves non-tensor attributes, e.g., :class:`SymbolTable`.
+        #
+        # - `_cache`
+        #     It contains tensors for autograd. Users should NOT manipulate it.
+        #     The dict is filled in automagically.
         self._tensor_attr = OrderedDict()
         self._non_tensor_attr = OrderedDict()
+
+        self._cache = OrderedDict()
+        # The `_cache` dict contains the following attributes:
+        #
+        #  - `state_batches`:
+        #           returned by :func:`_k2._get_state_batches`
+        #  - `dest_states`:
+        #           returned by :func:`_k2._get_dest_states`
+        #  - `incoming_arcs`:
+        #           returned by :func:`_k2._get_incoming_arcs`
+        #  - `entering_arc_batches`:
+        #           returned by :func:`_k2._get_entering_arc_index_batches`
+        #  - `leaving_arc_batches`:
+        #           returned by :func:`_k2._get_leaving_arc_index_batches`
+        #  - `forward_scores_tropical_semiring`:
+        #           returned by :func:`_k2._get_forward_scores_float` or
+        #           :func:`_get_forward_scores_double` with `log_semiring=False`
+        #  - `forward_scores_log_semiring`:
+        #           returned by :func:`_k2._get_forward_scores_float` or
+        #           :func:`_get_forward_scores_double` with `log_semiring=True`
+        #  - `backward_scores_tropical_semiring`:
+        #           returned by :func:`_k2._get_backward_scores_float` or
+        #           :func:`_k2._get_backward_scores_double` with
+        #           `log_semiring=False`
+        #  - `backward_scores_log_semiring`:
+        #           returned by :func:`_k2._get_backward_scores_float` or
+        #           :func:`_k2._get_backward_scores_double` with
+        #           `log_semiring=True`
 
     def __setattr__(self, name: str, value: Any) -> None:
         '''

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -147,10 +147,12 @@ class Fsa(object):
         #           :func:`_get_forward_scores_double` with `log_semiring=True`
         #  - `tot_scores_tropical`:
         #           returned by :func:`_k2._get_tot_scores_float` or
-        #           :func:`_k2._get_tot_scores_double` with `forward_scores_tropical`.
+        #           :func:`_k2._get_tot_scores_double` with
+        #           `forward_scores_tropical`.
         #  - `tot_scores_log`:
         #           returned by :func:`_k2._get_tot_scores_float` or
-        #           :func:`_k2._get_tot_scores_double` with `forward_scores_log`.
+        #           :func:`_k2._get_tot_scores_double` with
+        #           `forward_scores_log`.
         #  - `backward_scores_tropical`:
         #           returned by :func:`_k2._get_backward_scores_float` or
         #           :func:`_k2._get_backward_scores_double` with
@@ -216,26 +218,26 @@ class Fsa(object):
         self._grad_cache[name] = value
 
     def update_state_batches(self) -> _k2.RaggedInt:
-        if hasattr(self, 'state_batches') == False:
+        if hasattr(self, 'state_batches') is False:
             state_batches = _k2._get_state_batches(self.arcs, transpose=True)
             self._update_cache('state_batches', state_batches)
         return self.state_batches
 
     def update_dest_states(self) -> torch.Tensor:
-        if hasattr(self, 'dest_states') == False:
+        if hasattr(self, 'dest_states') is False:
             dest_states = _k2._get_dest_states(self.arcs, as_idx01=True)
             self._update_cache('dest_states', dest_states)
         return self.dest_states
 
     def update_incoming_arcs(self) -> _k2.RaggedInt:
-        if hasattr(self, 'incoming_arcs') == False:
+        if hasattr(self, 'incoming_arcs') is False:
             dest_states = self.update_dest_states()
             incoming_arcs = _k2._get_incoming_arcs(self.arcs, dest_states)
             self._update_cache('incoming_arcs', incoming_arcs)
         return self.incoming_arcs
 
     def update_entering_arc_batches(self) -> _k2.RaggedInt:
-        if hasattr(self, 'entering_arc_batches') == False:
+        if hasattr(self, 'entering_arc_batches') is False:
             incoming_arcs = self.update_incoming_arcs()
             state_batches = self.update_state_batches()
             entering_arc_batches = _k2._get_entering_arc_index_batches(
@@ -246,7 +248,7 @@ class Fsa(object):
         return self.entering_arc_batches
 
     def update_leaving_arc_batches(self) -> _k2.RaggedInt:
-        if hasattr(self, 'leaving_arc_batches') == False:
+        if hasattr(self, 'leaving_arc_batches') is False:
             state_batches = self.update_state_batches()
             leaving_arc_batches = _k2._get_leaving_arc_index_batches(
                 self.arcs, state_batches)
@@ -254,9 +256,9 @@ class Fsa(object):
         return self.leaving_arc_batches
 
     def update_forward_scores_tropical(self, use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'forward_scores_tropical') == False \
-                or (use_float_scores == True and self.forward_scores_tropical.dtype == torch.float64) \
-                or (use_float_scores == False and self.forward_scores_tropical.dtype == torch.float32):
+        if hasattr(self, 'forward_scores_tropical') is False \
+                or (use_float_scores is True and self.forward_scores_tropical.dtype == torch.float64) \
+                or (use_float_scores is False and self.forward_scores_tropical.dtype == torch.float32): # noqa
             if use_float_scores:
                 func = _k2._get_forward_scores_float
             else:
@@ -276,9 +278,9 @@ class Fsa(object):
         return self.forward_scores_tropical
 
     def update_forward_scores_log(self, use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'forward_scores_log') == False \
-                or (use_float_scores == True and self.forward_scores_log.dtype == torch.float64) \
-                or (use_float_scores == False and self.forward_scores_log.dtype == torch.float32):
+        if hasattr(self, 'forward_scores_log') is False \
+                or (use_float_scores is True and self.forward_scores_log.dtype == torch.float64) \
+                or (use_float_scores is False and self.forward_scores_log.dtype == torch.float32): # noqa
             if use_float_scores:
                 func = _k2._get_forward_scores_float
             else:
@@ -292,14 +294,14 @@ class Fsa(object):
                 state_batches=state_batches,
                 entering_arc_batches=entering_arc_batches,
                 log_semiring=True)
-            self._update_cache('forward_scores_log', forward_scores_tropical)
+            self._update_cache('forward_scores_log', forward_scores_log)
         return self.forward_scores_log
 
     def update_tot_scores_tropical(self, use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'tot_scores_tropical') == False \
-                or (use_float_scores == True and self.tot_scores_tropical.dtype == torch.float64) \
-                or (use_float_scores == False and self.tot_scores_tropical.dtype == torch.float32):
-            if use_float_scores == True:
+        if hasattr(self, 'tot_scores_tropical') is False \
+                or (use_float_scores is True and self.tot_scores_tropical.dtype == torch.float64) \
+                or (use_float_scores is False and self.tot_scores_tropical.dtype == torch.float32): # noqa
+            if use_float_scores is True:
                 func = _k2._get_tot_scores_float
             else:
                 func = _k2._get_tot_scores_double
@@ -310,10 +312,10 @@ class Fsa(object):
         return self.tot_scores_tropical
 
     def update_tot_scores_log(self, use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'tot_scores_log') == False \
-                or (use_float_scores == True and self.tot_scores_log.dtype == torch.float64) \
-                or (use_float_scores == False and self.tot_scores_log.dtype == torch.float32):
-            if use_float_scores == True:
+        if hasattr(self, 'tot_scores_log') is False \
+                or (use_float_scores is True and self.tot_scores_log.dtype == torch.float64) \
+                or (use_float_scores is False and self.tot_scores_log.dtype == torch.float32): # noqa
+            if use_float_scores is True:
                 func = _k2._get_tot_scores_float
             else:
                 func = _k2._get_tot_scores_double
@@ -325,9 +327,9 @@ class Fsa(object):
 
     def update_backward_scores_tropical(self,
                                         use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'backward_scores_tropical') == False \
-                or (use_float_scores == True and self.backward_scores_tropical.dtype == torch.float64) \
-                or (use_float_scores == False and self.backward_scores_tropical.dtype == torch.float32):
+        if hasattr(self, 'backward_scores_tropical') is False \
+                or (use_float_scores is True and self.backward_scores_tropical.dtype == torch.float64) \
+                or (use_float_scores is False and self.backward_scores_tropical.dtype == torch.float32): # noqa
             if use_float_scores:
                 func = _k2._get_backward_scores_float
             else:
@@ -348,9 +350,9 @@ class Fsa(object):
         return self.backward_scores_tropical
 
     def update_backward_scores_log(self, use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'backward_scores_log') == False \
-                or (use_float_scores == True and self.backward_scores_log.dtype == torch.float64) \
-                or (use_float_scores == False and self.backward_scores_log.dtype == torch.float32):
+        if hasattr(self, 'backward_scores_log') is False \
+                or (use_float_scores is True and self.backward_scores_log.dtype == torch.float64) \
+                or (use_float_scores is False and self.backward_scores_log.dtype == torch.float32): # noqa
             if use_float_scores:
                 func = _k2._get_backward_scores_float
             else:
@@ -368,7 +370,7 @@ class Fsa(object):
         return self.backward_scores_log
 
     def update_entering_arcs(self, use_float_scores) -> torch.Tensor:
-        if hasattr(self, 'entering_arcs') == False:
+        if hasattr(self, 'entering_arcs') is False:
             if hasattr(self, 'forward_scores_tropical'):
                 del self.forward_scores_tropical
             self.update_forward_scores_tropical(use_float_scores)

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -376,6 +376,26 @@ class Fsa(object):
             self.update_forward_scores_tropical(use_float_scores)
         return self.entering_arcs
 
+    def requires_grad_(self, requires_grad: bool) -> 'Fsa':
+        '''Change if autograd should record operations on this FSA:
+
+        Sets the `scores`'s requires_grad attribute in-place.
+        Returns this FSA.
+
+        Caution:
+          This is an **in-place** operation as you can see that the function
+          name ends with `_`.
+
+        Args:
+          requires_grad:
+            If autograd should record operations on this FSA or not.
+
+        Returns:
+          This FSA itself.
+        '''
+        self.scores.requires_grad_(requires_grad)
+        return self
+
     def invert_(self) -> 'Fsa':
         '''Swap the ``labels`` and ``aux_labels``.
 

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 # please sort the files in alphabetic order
 set(py_test_files
   arc_sort_test.py
+  autograd_test.py
   connect_test.py
   dense_fsa_test.py
   fsa_test.py

--- a/k2/python/tests/arc_sort_test.py
+++ b/k2/python/tests/arc_sort_test.py
@@ -24,8 +24,7 @@ class TestArcSort(unittest.TestCase):
             2
         '''
         fsa = k2.Fsa.from_str(s)
-        print(k2.to_str(fsa))
-        fsa.scores.requires_grad_(True)
+        fsa.requires_grad_(True)
         sorted_fsa = k2.arc_sort(fsa)
 
         actual_str = k2.to_str(sorted_fsa)

--- a/k2/python/tests/autograd_test.py
+++ b/k2/python/tests/autograd_test.py
@@ -6,7 +6,7 @@
 
 # To run this single test, use
 #
-#  ctest --verbose -R shortest_path_test_py
+#  ctest --verbose -R autograd_test_py
 
 import unittest
 
@@ -15,24 +15,10 @@ import k2
 import torch
 
 
-class TestShortestPath(unittest.TestCase):
+class TestGetForwardLogLike(unittest.TestCase):
 
-    def _test(self):
-        s = '''
-            0 1 1 0.1
-            0 2 2 0.2
-            1 2 3 0.3
-            1 3 4 0.4
-            2 3 5 0.5
-            3 4 -1 0
-            4
-        '''
-        fsa = k2.Fsa.from_str(s)
-        fsa_vec = k2.create_fsa_vec([fsa])
-        a = _k2.get_arc_scores(fsa_vec.arcs)
-        print(a.exp())
-
-    def test_single_fsa(self):
+    def test_tropical_single_fsa(self):
+        # best path arc indexes are: 1, 3, 5, 10
         s = '''
             0 4 1 1
             0 1 1 1
@@ -51,21 +37,33 @@ class TestShortestPath(unittest.TestCase):
         fsa = k2.Fsa.from_str(s)
         fsa = k2.create_fsa_vec([fsa])
         fsa.scores.requires_grad_(True)
-        best_path = k2.shortest_path(fsa, use_float_scores=True)
+        log_like = k2.get_forward_log_like(fsa,
+                                           log_semiring=False,
+                                           use_float_scores=True)
 
-        # we recompute the total_scores for backprop
-        total_scores = best_path.scores.sum()
+        assert log_like == 14
+        assert log_like.dtype == torch.float32
 
-        assert total_scores == 14
-        expected = torch.zeros(12)
+        log_like.sum().backward()
+        expected = torch.zeros(len(fsa.scores))
         expected[torch.tensor([1, 3, 5, 10])] = 1
-        total_scores.backward()
         assert torch.allclose(fsa.scores.grad, expected)
 
-    def test_fsa_vec(self):
+        # now for double
+        fsa.scores.grad = None
+        log_like = k2.get_forward_log_like(fsa,
+                                           log_semiring=False,
+                                           use_float_scores=False)
+        assert log_like == 14
+        assert log_like.dtype == torch.float64
+        log_like.sum().backward()
+        assert torch.allclose(fsa.scores.grad, expected)
+
+    def test_tropical_multiple_fsas(self):
         # best path:
         #  states: 0 -> 1 -> 3 -> 7 -> 9
         #  arcs:     1 -> 3 -> 5 -> 10
+        #  scores: 1 + 3 + 5 + 5 = 14
         s1 = '''
             0 4 1 1
             0 1 1 1
@@ -85,6 +83,7 @@ class TestShortestPath(unittest.TestCase):
         #  best path:
         #   states: 0 -> 2 -> 3 -> 4 -> 5
         #   arcs:     1 -> 4 -> 5 -> 7
+        #   scores: 6 + 4 + 3 + 0 = 13
         s2 = '''
             0 1 1 1
             0 2 2 6
@@ -100,6 +99,7 @@ class TestShortestPath(unittest.TestCase):
         #  best path:
         #   states: 0 -> 2 -> 3
         #   arcs:     1 -> 3
+        #   scores: 100 + 5.5 = 105.5
         s3 = '''
             0 1 1 10
             0 2 2 100
@@ -117,13 +117,14 @@ class TestShortestPath(unittest.TestCase):
         fsa3.scores.requires_grad_(True)
 
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2, fsa3])
-        assert fsa_vec.shape == (3, None, None)
 
-        best_path = k2.shortest_path(fsa_vec, use_float_scores=True)
+        log_like = k2.get_forward_log_like(fsa_vec,
+                                           log_semiring=False,
+                                           use_float_scores=True)
+        expected_log_like = torch.tensor([14, 13, 105.5])
+        assert torch.allclose(log_like, expected_log_like)
 
-        # we recompute the total_scores for backprop
-        total_scores = best_path.scores.sum()
-        total_scores.backward()
+        log_like.sum().backward()
 
         fsa1_best_arc_indexes = torch.tensor([1, 3, 5, 10])
         assert torch.allclose(fsa1.scores.grad[fsa1_best_arc_indexes],
@@ -136,6 +137,31 @@ class TestShortestPath(unittest.TestCase):
         assert fsa2.scores.grad.sum() == 4
 
         fsa3_best_arc_indexes = torch.tensor([1, 3])
+        assert torch.allclose(fsa3.scores.grad[fsa3_best_arc_indexes],
+                              torch.ones(2, dtype=torch.float32))
+        assert fsa3.scores.grad.sum() == 2
+
+        # now for double
+        fsa1.scores.grad = None
+        fsa2.scores.grad = None
+        fsa3.scores.grad = None
+        log_like = k2.get_forward_log_like(fsa_vec,
+                                           log_semiring=False,
+                                           use_float_scores=False)
+
+        expected_log_like = expected_log_like.to(torch.float64)
+        assert torch.allclose(log_like, expected_log_like)
+
+        log_like.sum().backward()
+
+        assert torch.allclose(fsa1.scores.grad[fsa1_best_arc_indexes],
+                              torch.ones(4, dtype=torch.float32))
+        assert fsa1.scores.grad.sum() == 4
+
+        assert torch.allclose(fsa2.scores.grad[fsa2_best_arc_indexes],
+                              torch.ones(4, dtype=torch.float32))
+        assert fsa2.scores.grad.sum() == 4
+
         assert torch.allclose(fsa3.scores.grad[fsa3_best_arc_indexes],
                               torch.ones(2, dtype=torch.float32))
         assert fsa3.scores.grad.sum() == 2

--- a/k2/python/tests/autograd_test.py
+++ b/k2/python/tests/autograd_test.py
@@ -10,7 +10,6 @@
 
 import unittest
 
-import _k2
 import k2
 import torch
 
@@ -121,6 +120,7 @@ class TestGetForwardLogLike(unittest.TestCase):
         log_like = k2.get_forward_log_like(fsa_vec,
                                            log_semiring=False,
                                            use_float_scores=True)
+        assert log_like.dtype == torch.float32
         expected_log_like = torch.tensor([14, 13, 105.5])
         assert torch.allclose(log_like, expected_log_like)
 
@@ -149,6 +149,7 @@ class TestGetForwardLogLike(unittest.TestCase):
                                            log_semiring=False,
                                            use_float_scores=False)
 
+        assert log_like.dtype == torch.float64
         expected_log_like = expected_log_like.to(torch.float64)
         assert torch.allclose(log_like, expected_log_like)
 
@@ -165,6 +166,128 @@ class TestGetForwardLogLike(unittest.TestCase):
         assert torch.allclose(fsa3.scores.grad[fsa3_best_arc_indexes],
                               torch.ones(2, dtype=torch.float32))
         assert fsa3.scores.grad.sum() == 2
+
+    def test_log_single_fsa(self):
+        s = '''
+            0 1 1 0.1
+            0 2 2 0.2
+            1 2 3 0.3
+            1 3 4 0.4
+            2 3 5 0.5
+            3 4 -1 0
+            4
+        '''
+        fsa = k2.Fsa.from_str(s)
+        fsa.scores.requires_grad_(True)
+        fsa_vec = k2.create_fsa_vec([fsa])
+        log_like = k2.get_forward_log_like(fsa_vec,
+                                           log_semiring=True,
+                                           use_float_scores=True)
+        assert log_like.dtype == torch.float32
+        # The expected_log_like is computed using gtn.
+        # See https://bit.ly/3oUiRx9
+        expected_log_like = torch.tensor([1.8119014501571655])
+        assert torch.allclose(log_like, expected_log_like)
+
+        # The expected_grad is computed using gtn.
+        # See https://bit.ly/3oUiRx9
+        expected_grad = torch.tensor([
+            0.6710670590400696, 0.32893291115760803, 0.4017595648765564,
+            0.2693074941635132, 0.7306925058364868, 1.0
+        ])
+
+        log_like.sum().backward()
+        assert torch.allclose(fsa.scores.grad, expected_grad)
+
+        # now for double
+        fsa.scores.grad = None
+
+        log_like = k2.get_forward_log_like(fsa_vec,
+                                           log_semiring=True,
+                                           use_float_scores=False)
+        assert log_like.dtype == torch.float64
+        expected_log_like = expected_log_like.to(torch.float64)
+        assert torch.allclose(log_like, expected_log_like)
+
+        log_like.sum().backward()
+        assert torch.allclose(fsa.scores.grad, expected_grad)
+
+    def test_log_multiple_fsas(self):
+        s1 = '''
+            0 1 1 0.1
+            0 2 2 0.2
+            1 2 3 0.3
+            1 3 4 0.4
+            2 3 5 0.5
+            3 4 -1 0
+            4
+        '''
+
+        s2 = '''
+            0 3 3 0.1
+            0 1 1 0.2
+            0 2 2 0.3
+            1 2 2 0.4
+            1 3 3 0.5
+            2 3 3 0.6
+            2 4 4 0.7
+            3 4 4 0.8
+            3 5 -1 0.9
+            4 5 -1 1.0
+            5
+        '''
+
+        fsa1 = k2.Fsa.from_str(s1)
+        fsa2 = k2.Fsa.from_str(s2)
+
+        fsa1.scores.requires_grad_(True)
+        fsa2.scores.requires_grad_(True)
+
+        fsa_vec = k2.create_fsa_vec([fsa1, fsa2])
+        log_like = k2.get_forward_log_like(fsa_vec,
+                                           log_semiring=True,
+                                           use_float_scores=True)
+        assert log_like.dtype == torch.float32
+        # The expected_log_likes are computed using gtn.
+        # See https://bit.ly/3oUiRx9
+        expected_log_like = torch.tensor(
+            [1.8119014501571655, 4.533502578735352])
+        assert torch.allclose(log_like, expected_log_like)
+
+        log_like.sum().backward()
+
+        # The expected_grads are computed using gtn.
+        # See https://bit.ly/3oUiRx9
+        expected_grad_fsa1 = torch.tensor([
+            0.6710670590400696, 0.32893291115760803, 0.4017595648765564,
+            0.2693074941635132, 0.7306925058364868, 1.0
+        ])
+
+        expected_grad_fsa2 = torch.tensor([
+            0.10102888941764832, 0.5947467088699341, 0.3042244613170624,
+            0.410660058259964, 0.1840866357088089, 0.5283515453338623,
+            0.18653297424316406, 0.5783339142799377, 0.2351330667734146,
+            0.764866828918457
+        ])
+
+        assert torch.allclose(fsa1.scores.grad, expected_grad_fsa1)
+        assert torch.allclose(fsa2.scores.grad, expected_grad_fsa2)
+
+        # now for double
+        fsa1.scores.grad = None
+        fsa2.scores.grad = None
+
+        log_like = k2.get_forward_log_like(fsa_vec,
+                                           log_semiring=True,
+                                           use_float_scores=False)
+        assert log_like.dtype == torch.float64
+        expected_log_like = expected_log_like.to(torch.float64)
+        assert torch.allclose(log_like, expected_log_like)
+
+        log_like.sum().backward()
+
+        assert torch.allclose(fsa1.scores.grad, expected_grad_fsa1)
+        assert torch.allclose(fsa2.scores.grad, expected_grad_fsa2)
 
 
 if __name__ == '__main__':

--- a/k2/python/tests/autograd_test.py
+++ b/k2/python/tests/autograd_test.py
@@ -35,7 +35,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         fsa = k2.Fsa.from_str(s)
         fsa = k2.create_fsa_vec([fsa])
-        fsa.scores.requires_grad_(True)
+        fsa.requires_grad_(True)
         log_like = k2.get_tot_scores(fsa,
                                      log_semiring=False,
                                      use_float_scores=True)
@@ -111,9 +111,9 @@ class TestGetTotScores(unittest.TestCase):
         fsa2 = k2.Fsa.from_str(s2)
         fsa3 = k2.Fsa.from_str(s3)
 
-        fsa1.scores.requires_grad_(True)
-        fsa2.scores.requires_grad_(True)
-        fsa3.scores.requires_grad_(True)
+        fsa1.requires_grad_(True)
+        fsa2.requires_grad_(True)
+        fsa3.requires_grad_(True)
 
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2, fsa3])
 
@@ -178,7 +178,7 @@ class TestGetTotScores(unittest.TestCase):
             4
         '''
         fsa = k2.Fsa.from_str(s)
-        fsa.scores.requires_grad_(True)
+        fsa.requires_grad_(True)
         fsa_vec = k2.create_fsa_vec([fsa])
         log_like = k2.get_tot_scores(fsa_vec,
                                      log_semiring=True,
@@ -240,8 +240,8 @@ class TestGetTotScores(unittest.TestCase):
         fsa1 = k2.Fsa.from_str(s1)
         fsa2 = k2.Fsa.from_str(s2)
 
-        fsa1.scores.requires_grad_(True)
-        fsa2.scores.requires_grad_(True)
+        fsa1.requires_grad_(True)
+        fsa2.requires_grad_(True)
 
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2])
         log_like = k2.get_tot_scores(fsa_vec,

--- a/k2/python/tests/autograd_test.py
+++ b/k2/python/tests/autograd_test.py
@@ -14,7 +14,7 @@ import k2
 import torch
 
 
-class TestGetForwardLogLike(unittest.TestCase):
+class TestGetTotScores(unittest.TestCase):
 
     def test_tropical_single_fsa(self):
         # best path arc indexes are: 1, 3, 5, 10
@@ -36,9 +36,9 @@ class TestGetForwardLogLike(unittest.TestCase):
         fsa = k2.Fsa.from_str(s)
         fsa = k2.create_fsa_vec([fsa])
         fsa.scores.requires_grad_(True)
-        log_like = k2.get_forward_log_like(fsa,
-                                           log_semiring=False,
-                                           use_float_scores=True)
+        log_like = k2.get_tot_scores(fsa,
+                                     log_semiring=False,
+                                     use_float_scores=True)
 
         assert log_like == 14
         assert log_like.dtype == torch.float32
@@ -50,9 +50,9 @@ class TestGetForwardLogLike(unittest.TestCase):
 
         # now for double
         fsa.scores.grad = None
-        log_like = k2.get_forward_log_like(fsa,
-                                           log_semiring=False,
-                                           use_float_scores=False)
+        log_like = k2.get_tot_scores(fsa,
+                                     log_semiring=False,
+                                     use_float_scores=False)
         assert log_like == 14
         assert log_like.dtype == torch.float64
         log_like.sum().backward()
@@ -117,9 +117,9 @@ class TestGetForwardLogLike(unittest.TestCase):
 
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2, fsa3])
 
-        log_like = k2.get_forward_log_like(fsa_vec,
-                                           log_semiring=False,
-                                           use_float_scores=True)
+        log_like = k2.get_tot_scores(fsa_vec,
+                                     log_semiring=False,
+                                     use_float_scores=True)
         assert log_like.dtype == torch.float32
         expected_log_like = torch.tensor([14, 13, 105.5])
         assert torch.allclose(log_like, expected_log_like)
@@ -145,9 +145,9 @@ class TestGetForwardLogLike(unittest.TestCase):
         fsa1.scores.grad = None
         fsa2.scores.grad = None
         fsa3.scores.grad = None
-        log_like = k2.get_forward_log_like(fsa_vec,
-                                           log_semiring=False,
-                                           use_float_scores=False)
+        log_like = k2.get_tot_scores(fsa_vec,
+                                     log_semiring=False,
+                                     use_float_scores=False)
 
         assert log_like.dtype == torch.float64
         expected_log_like = expected_log_like.to(torch.float64)
@@ -180,9 +180,9 @@ class TestGetForwardLogLike(unittest.TestCase):
         fsa = k2.Fsa.from_str(s)
         fsa.scores.requires_grad_(True)
         fsa_vec = k2.create_fsa_vec([fsa])
-        log_like = k2.get_forward_log_like(fsa_vec,
-                                           log_semiring=True,
-                                           use_float_scores=True)
+        log_like = k2.get_tot_scores(fsa_vec,
+                                     log_semiring=True,
+                                     use_float_scores=True)
         assert log_like.dtype == torch.float32
         # The expected_log_like is computed using gtn.
         # See https://bit.ly/3oUiRx9
@@ -202,9 +202,9 @@ class TestGetForwardLogLike(unittest.TestCase):
         # now for double
         fsa.scores.grad = None
 
-        log_like = k2.get_forward_log_like(fsa_vec,
-                                           log_semiring=True,
-                                           use_float_scores=False)
+        log_like = k2.get_tot_scores(fsa_vec,
+                                     log_semiring=True,
+                                     use_float_scores=False)
         assert log_like.dtype == torch.float64
         expected_log_like = expected_log_like.to(torch.float64)
         assert torch.allclose(log_like, expected_log_like)
@@ -244,9 +244,9 @@ class TestGetForwardLogLike(unittest.TestCase):
         fsa2.scores.requires_grad_(True)
 
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2])
-        log_like = k2.get_forward_log_like(fsa_vec,
-                                           log_semiring=True,
-                                           use_float_scores=True)
+        log_like = k2.get_tot_scores(fsa_vec,
+                                     log_semiring=True,
+                                     use_float_scores=True)
         assert log_like.dtype == torch.float32
         # The expected_log_likes are computed using gtn.
         # See https://bit.ly/3oUiRx9
@@ -277,9 +277,9 @@ class TestGetForwardLogLike(unittest.TestCase):
         fsa1.scores.grad = None
         fsa2.scores.grad = None
 
-        log_like = k2.get_forward_log_like(fsa_vec,
-                                           log_semiring=True,
-                                           use_float_scores=False)
+        log_like = k2.get_tot_scores(fsa_vec,
+                                     log_semiring=True,
+                                     use_float_scores=False)
         assert log_like.dtype == torch.float64
         expected_log_like = expected_log_like.to(torch.float64)
         assert torch.allclose(log_like, expected_log_like)

--- a/k2/python/tests/connect_test.py
+++ b/k2/python/tests/connect_test.py
@@ -23,7 +23,7 @@ class TestConnect(unittest.TestCase):
         4
     '''
     fsa = k2.Fsa.from_str(s)
-    fsa.scores.requires_grad_(True)
+    fsa.requires_grad_(True)
     expected_str = '\n'.join(['0 1 1 0.1', '1 2 -1 0.3', '2'])
     connected_fsa = k2.connect(fsa)
     actual_str = k2.to_str(connected_fsa)

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -11,10 +11,9 @@
 
 import unittest
 
+import _k2  # for test only, users should not import it.
 import k2
 import torch
-
-import _k2  # for test only, users should not import it.
 
 
 def _remove_leading_spaces(s: str) -> str:

--- a/k2/python/tests/intersect_test.py
+++ b/k2/python/tests/intersect_test.py
@@ -34,7 +34,7 @@ class TestIntersect(unittest.TestCase):
             5
         '''
         a_fsa = k2.Fsa.from_str(s)
-        a_fsa.scores.requires_grad_(True)
+        a_fsa.requires_grad_(True)
 
         # an FSA that recognizes ab
         s = '''
@@ -44,7 +44,7 @@ class TestIntersect(unittest.TestCase):
             3
         '''
         b_fsa = k2.Fsa.from_str(s)
-        b_fsa.scores.requires_grad_(True)
+        b_fsa.requires_grad_(True)
 
         fsa = k2.intersect(a_fsa, b_fsa)
         actual_str = k2.to_str(fsa)

--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -34,7 +34,7 @@ class TestShortestPath(unittest.TestCase):
         '''
         fsa = k2.Fsa.from_str(s)
         fsa = k2.create_fsa_vec([fsa])
-        fsa.scores.requires_grad_(True)
+        fsa.requires_grad_(True)
         best_path = k2.shortest_path(fsa, use_float_scores=True)
 
         # we recompute the total_scores for backprop
@@ -96,9 +96,9 @@ class TestShortestPath(unittest.TestCase):
         fsa2 = k2.Fsa.from_str(s2)
         fsa3 = k2.Fsa.from_str(s3)
 
-        fsa1.scores.requires_grad_(True)
-        fsa2.scores.requires_grad_(True)
-        fsa3.scores.requires_grad_(True)
+        fsa1.requires_grad_(True)
+        fsa2.requires_grad_(True)
+        fsa3.requires_grad_(True)
 
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2, fsa3])
         assert fsa_vec.shape == (3, None, None)

--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -10,27 +10,11 @@
 
 import unittest
 
-import _k2
 import k2
 import torch
 
 
 class TestShortestPath(unittest.TestCase):
-
-    def _test(self):
-        s = '''
-            0 1 1 0.1
-            0 2 2 0.2
-            1 2 3 0.3
-            1 3 4 0.4
-            2 3 5 0.5
-            3 4 -1 0
-            4
-        '''
-        fsa = k2.Fsa.from_str(s)
-        fsa_vec = k2.create_fsa_vec([fsa])
-        a = _k2.get_arc_scores(fsa_vec.arcs)
-        print(a.exp())
 
     def test_single_fsa(self):
         s = '''

--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -11,12 +11,28 @@
 import unittest
 
 import k2
+import _k2
 import torch
 
 
 class TestShortestPath(unittest.TestCase):
 
-    def test_single_fsa(self):
+    def test(self):
+        s = '''
+            0 1 1 0.1
+            0 2 2 0.2
+            1 2 3 0.3
+            1 3 4 0.4
+            2 3 5 0.5
+            3 4 -1 0
+            4
+        '''
+        fsa = k2.Fsa.from_str(s)
+        fsa_vec = k2.create_fsa_vec([fsa])
+        a = _k2.get_arc_scores(fsa_vec.arcs)
+        print(a.exp())
+
+    def _test_single_fsa(self):
         s = '''
             0 4 1 1
             0 1 1 1
@@ -45,7 +61,7 @@ class TestShortestPath(unittest.TestCase):
         total_scores.backward()
         assert torch.allclose(fsa.scores.grad, expected)
 
-    def test_fsa_vec(self):
+    def _test_fsa_vec(self):
         # best path:
         #  states: 0 -> 1 -> 3 -> 7 -> 9
         #  arcs:     1 -> 3 -> 5 -> 10

--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -17,7 +17,7 @@ import torch
 
 class TestShortestPath(unittest.TestCase):
 
-    def test(self):
+    def _test(self):
         s = '''
             0 1 1 0.1
             0 2 2 0.2
@@ -32,7 +32,7 @@ class TestShortestPath(unittest.TestCase):
         a = _k2.get_arc_scores(fsa_vec.arcs)
         print(a.exp())
 
-    def _test_single_fsa(self):
+    def test_single_fsa(self):
         s = '''
             0 4 1 1
             0 1 1 1
@@ -49,8 +49,9 @@ class TestShortestPath(unittest.TestCase):
             9
         '''
         fsa = k2.Fsa.from_str(s)
+        fsa = k2.create_fsa_vec([fsa])
         fsa.scores.requires_grad_(True)
-        best_path, _ = k2.shortest_path(fsa)
+        best_path = k2.shortest_path(fsa, use_float_scores=True)
 
         # we recompute the total_scores for backprop
         total_scores = best_path.scores.sum()
@@ -61,7 +62,7 @@ class TestShortestPath(unittest.TestCase):
         total_scores.backward()
         assert torch.allclose(fsa.scores.grad, expected)
 
-    def _test_fsa_vec(self):
+    def test_fsa_vec(self):
         # best path:
         #  states: 0 -> 1 -> 3 -> 7 -> 9
         #  arcs:     1 -> 3 -> 5 -> 10
@@ -118,7 +119,7 @@ class TestShortestPath(unittest.TestCase):
         fsa_vec = k2.create_fsa_vec([fsa1, fsa2, fsa3])
         assert fsa_vec.shape == (3, None, None)
 
-        best_path, _ = k2.shortest_path(fsa_vec)
+        best_path = k2.shortest_path(fsa_vec, use_float_scores=True)
 
         # we recompute the total_scores for backprop
         total_scores = best_path.scores.sum()

--- a/k2/python/tests/top_sort_test.py
+++ b/k2/python/tests/top_sort_test.py
@@ -31,7 +31,7 @@ class TestTopSort(unittest.TestCase):
             1
         '''
         fsa = k2.Fsa.from_str(s)
-        fsa.scores.requires_grad_(True)
+        fsa.requires_grad_(True)
         sorted_fsa = k2.top_sort(fsa)
 
         # the shortest path in the sorted fsa is (arc 0) -> (arc 3)

--- a/scripts/build_pip.sh
+++ b/scripts/build_pip.sh
@@ -59,9 +59,9 @@ if [ ! -d $build_dir/lib ]; then
 fi
 
 for lib in $build_dir/lib/*.so; do
+  # remove RPATH information
+  strip $lib
   chrpath -r '$ORIGIN' $lib
 done
 
-tag=$(python3 -c "import sys; print(sys.version[:3].replace('.', ''))")
-
-python3 setup.py bdist_wheel --python-tag py$tag
+python3 setup.py bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,34 @@
+# Welcome to the k2 setup.py.
+#
+# Please follow instructions in scripts/build_pip.sh to use this file.
+#
+import datetime
 import setuptools
+import sys
+
+if sys.version_info < (3,):
+    print('Python 2 has reached end-of-life and is no longer supported by k2.')
+    sys.exit(-1)
+
+if sys.version_info < (3, 6):
+    print('Python 3.5 has reached end-of-life on September 13th, 2020 '
+          'and is no longer supported by k2.')
+    sys.exit(-1)
+
+# Refer to https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it
+# for why to introduce `bdist_wheel`.
+#
+# With `bdist_wheel`, the final wheel name looks like `k2-0.0.1.dev20201104-cp37-cp37m-linux_x86_64.whl`
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    class bdist_wheel(_bdist_wheel):
+
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+except ImportError:
+    bdist_wheel = None
 
 
 def get_long_description():
@@ -7,17 +37,46 @@ def get_long_description():
         return long_description
 
 
-version = '0.0.1'
-description = 'FSA/FST algorithms, intended to (eventually) be interoperable with PyTorch and similar'
+def get_cuda_version():
+    from torch.utils import collect_env
+    cuda_version = collect_env.get_running_cuda_version(
+        collect_env.run).split('.')
+    major, minor = int(cuda_version[0]), int(cuda_version[1])
+    cuda_version = major * 10 + minor
+    return f'{cuda_version}'
+
+
+def get_package_version():
+    # Set a default CUDA version here so that `pip install k2`
+    # uses the default CUDA version.
+    #
+    # `pip install k2==x.x.x+cu100` to install k2 with CUDA 10.0
+    #
+    default_cuda_version = '101'  # CUDA 10.1
+    cuda_version = get_cuda_version()
+    if default_cuda_version != cuda_version:
+        cuda_version = f'+cu{cuda_version}'
+    else:
+        cuda_version = ''
+
+    latest_version = '0.0.1'
+    dt = datetime.datetime.utcnow()
+    package_version = f'{latest_version}{cuda_version}.dev{dt.year}{dt.month:02d}{dt.day:02d}{dt.hour:02d}{dt.minute:02d}{dt.second:02d}'
+    return package_version
+
+
+def get_short_description():
+    return 'FSA/FST algorithms, intended to (eventually) be interoperable with PyTorch and similar'
+
 
 setuptools.setup(
     python_requires='>=3.6',
     name='k2',
-    version=version,
+    version=get_package_version(),
     author='Daniel Povey',
     author_email='dpovey@gmail.com',
-    description=description,
     keywords='k2, FSA, FST',
+    description=get_short_description(),
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
     url='https://github.com/k2-fsa/k2',
@@ -25,6 +84,7 @@ setuptools.setup(
     packages=['k2'],
     install_requires=['torch', 'graphviz'],
     data_files=[('', ['LICENSE'])],
+    cmdclass={'bdist_wheel': bdist_wheel},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
TODO lists:

- [x] Update `ShortestPath` to reuse entries `Fsa._cache`.
- [x] Implement a `Function` class supporting

```python
def get_tot_scores(fsa: Fsa, is_log_semiring: bool)
```

which will update/reuse `fsa._cache` if needed.