### PR TITLE
fix a bug in Fsa.invert_.

### DIFF
--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -413,7 +413,7 @@ class Fsa(object):
         '''
         if hasattr(self, 'aux_labels'):
             aux_labels = self.aux_labels
-            self.aux_labels = self.labels
+            self.aux_labels = self.labels.clone()
             self.labels = aux_labels
 
         symbols = getattr(self, 'symbols', None)


### PR DESCRIPTION
By default, `fsa.labels` returns a reference.
We need to get a copy.