### PR TITLE
use random fsas to test Union.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(BUILD_SHARED_LIBS "Whether to build shared or static lib" ON)
 option(USE_PYTORCH "Whether to build with PyTorch" ON)
 
-
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
@@ -45,52 +44,34 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 endif()
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-  set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ version to be used.")
-  set(CUDAToolkit_LIBRARY_DIR "" CACHE STRING "The cudatoolkit library directory.")
-  set(CUDAToolkit_INCLUDE_DIRS "" CACHE STRING "The cudatoolkit include directory.")
+# ========= Settings for CUB begin =========
+# the following settings are modified from cub/CMakeLists.txt
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ version to be used.")
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-  find_package(CUDAToolkit REQUIRED)
-  if(CUDAToolkit_FOUND)
-    message(STATUS "found CUDAToolkit " ${CUDAToolkit_LIBRARY_DIR})
-    message(STATUS "CUDAToolkit_INCLUDE_DIRS " ${CUDAToolkit_INCLUDE_DIRS})
-    message(STATUS "CUDAToolkit_LIBRARY_DIR " ${CUDAToolkit_LIBRARY_DIR})
+message(STATUS "C++ Standard version: ${CMAKE_CXX_STANDARD}")
 
-    enable_language(CUDA)
-
-    # With many architectures set here, the nvcc build time would be much longer.
-    # Thus, "61" is put here for speed and compatibility.
-    # @ToDo Need to cover more architectures, before release these code.
-    set(CMAKE_CUDA_ARCHITECTURES 61)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
-  endif()
-else()
-  # the following settings are modified from cub/CMakeLists.txt
-  set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ version to be used.")
-  set(CMAKE_CXX_EXTENSIONS OFF)
-
-  message(STATUS "C++ Standard version: ${CMAKE_CXX_STANDARD}")
-
-  # Force CUDA C++ standard to be the same as the C++ standard used.
-  #
-  # Now, CMake is unaligned with reality on standard versions: https://gitlab.kitware.com/cmake/cmake/issues/18597
-  # which means that using standard CMake methods, it's impossible to actually sync the CXX and CUDA versions for pre-11
-  # versions of C++; CUDA accepts 98 but translates that to 03, while CXX doesn't accept 03 (and doesn't translate that to 03).
-  # In case this gives You, dear user, any trouble, please escalate the above CMake bug, so we can support reality properly.
-  if(DEFINED CMAKE_CUDA_STANDARD)
-    message(WARNING "You've set CMAKE_CUDA_STANDARD; please note that this variable is ignored, and CMAKE_CXX_STANDARD"
-      " is used as the C++ standard version for both C++ and CUDA.")
-  endif()
-  unset(CMAKE_CUDA_STANDARD CACHE)
-  set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
-
-  # set(K2_COMPUTE_ARCHS 30 32 35 50 52 53 60 61 62 70 72)
-  message(WARNING "arch 62/72 are not supported for now")
-  set(K2_COMPUTE_ARCHS 35 50 60 61 70 75)
-  foreach(COMPUTE_ARCH IN LISTS K2_COMPUTE_ARCHS)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -gencode arch=compute_${COMPUTE_ARCH},code=sm_${COMPUTE_ARCH}")
-  endforeach()
+# Force CUDA C++ standard to be the same as the C++ standard used.
+#
+# Now, CMake is unaligned with reality on standard versions: https://gitlab.kitware.com/cmake/cmake/issues/18597
+# which means that using standard CMake methods, it's impossible to actually sync the CXX and CUDA versions for pre-11
+# versions of C++; CUDA accepts 98 but translates that to 03, while CXX doesn't accept 03 (and doesn't translate that to 03).
+# In case this gives You, dear user, any trouble, please escalate the above CMake bug, so we can support reality properly.
+if(DEFINED CMAKE_CUDA_STANDARD)
+  message(WARNING "You've set CMAKE_CUDA_STANDARD; please note that this variable is ignored, and CMAKE_CXX_STANDARD"
+    " is used as the C++ standard version for both C++ and CUDA.")
 endif()
+unset(CMAKE_CUDA_STANDARD CACHE)
+set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
+
+# set(K2_COMPUTE_ARCHS 30 32 35 50 52 53 60 61 62 70 72)
+message(WARNING "arch 62/72 are not supported for now")
+set(K2_COMPUTE_ARCHS 35 50 60 61 70 75)
+foreach(COMPUTE_ARCH IN LISTS K2_COMPUTE_ARCHS)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -gencode arch=compute_${COMPUTE_ARCH},code=sm_${COMPUTE_ARCH}")
+  set(CMAKE_CUDA_ARCHITECTURES "${COMPUTE_ARCH}-real;${COMPUTE_ARCH}-virtual;${CMAKE_CUDA_ARCHITECTURES}")
+endforeach()
+# ========= Settings for CUB end=========
 
 enable_testing()
 

--- a/k2/csrc/host/CMakeLists.txt
+++ b/k2/csrc/host/CMakeLists.txt
@@ -22,16 +22,6 @@ add_library(fsa SHARED
     )
 set_target_properties(fsa PROPERTIES OUTPUT_NAME "k2fsa")
 
-# set cpp standard 11
-# ToDo: is it necessary?
-if (CMAKE_VERSION VERSION_LESS 3.8)
-  set(CMAKE_CXX_STANDARD 11)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-else ()
-  target_compile_features(fsa PUBLIC cxx_std_11)
-endif ()
-
 #---------------------------- Test K2 host sources ----------------------------
 
 # please sort the source files alphabetically

--- a/k2/python/k2/fsa_properties.py
+++ b/k2/python/k2/fsa_properties.py
@@ -2,7 +2,7 @@
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
-import torch
+import torch  # noqa
 import _k2
 
 from .fsa import Fsa

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -7,7 +7,6 @@ import torch
 import _k2
 
 
-
 def index(src: _k2.RaggedArc,
           indexes: torch.Tensor,
           need_value_indexes: bool = True

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -5,12 +5,13 @@
 from typing import List
 from typing import Optional
 
+import torch
+
 from .fsa import Fsa
 from _k2 import _create_fsa_vec
 from _k2 import _fsa_to_str
 from _k2 import _fsa_to_tensor
-
-import torch
+from graphviz import Digraph
 
 
 def to_str(fsa: Fsa, openfst: bool = False) -> str:
@@ -54,7 +55,7 @@ def to_tensor(fsa: Fsa) -> torch.Tensor:
     return _fsa_to_tensor(fsa.arcs)
 
 
-def to_dot(fsa: Fsa, title: Optional[str] = None):
+def to_dot(fsa: Fsa, title: Optional[str] = None) -> Digraph:
     '''Visualize an Fsa via graphviz.
 
     Note:
@@ -70,7 +71,6 @@ def to_dot(fsa: Fsa, title: Optional[str] = None):
     Returns:
       a Diagraph from grahpviz.
     '''
-    from graphviz import Digraph
     assert len(fsa.shape) == 2, 'FsaVec is not supported'
     if hasattr(fsa, 'aux_labels'):
         aux_labels = fsa.aux_labels

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -16,7 +16,6 @@ import _k2  # for test only, users should not import it.
 import k2
 
 
-
 def _remove_leading_spaces(s: str) -> str:
     lines = [line.strip() for line in s.split('\n') if line.strip()]
     return '\n'.join(lines)
@@ -363,8 +362,16 @@ class TestFsa(unittest.TestCase):
         fsa.symbols = symbols
         fsa.aux_symbols = aux_symbols
         dot = k2.to_dot(fsa)
-        dot.render('/tmp/fsa', format='pdf')
-        # the fsa is saved to /tmp/fsa.pdf
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dot.render(filename='fsa',
+                       directory=tmp_dir,
+                       format='pdf',
+                       cleanup=True)
+            # the fsa is saved to tmp_dir/fsa.pdf
+            import os
+            os.system('ls -l {}/fsa.pdf'.format(tmp_dir))
 
     def test_to(self):
         s = '''


### PR DESCRIPTION
And remove special handling of CMake 3.18

I find that it is error-prone to set row splits inside the lambda when the input FsaVec contains
special cases, e.g., some states have no leaving arcs. I decide to use `RowIdsToRowSplits`
to compute the result.