### PR TITLE
Fix some ctest fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ GSYMS
 GPATH
 tags
 TAGS
+.tags
 
 # python build files
 **/__pycache__

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -176,7 +176,7 @@ class TestFsa(unittest.TestCase):
     def test_transducer_from_tensor(self):
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa_tensor = torch.tensor(

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -176,7 +176,7 @@ class TestFsa(unittest.TestCase):
     def test_transducer_from_tensor(self):
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa_tensor = torch.tensor(

--- a/k2/python/tests/get_tot_scores_test.py
+++ b/k2/python/tests/get_tot_scores_test.py
@@ -35,7 +35,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa = k2.Fsa.from_str(s).to(device)
@@ -118,7 +118,7 @@ class TestGetTotScores(unittest.TestCase):
 
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa1 = k2.Fsa.from_str(s1).to(device)
@@ -201,7 +201,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa = k2.Fsa.from_str(s).to(device)
@@ -266,7 +266,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa1 = k2.Fsa.from_str(s1).to(device)

--- a/k2/python/tests/get_tot_scores_test.py
+++ b/k2/python/tests/get_tot_scores_test.py
@@ -35,7 +35,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa = k2.Fsa.from_str(s).to(device)
@@ -118,7 +118,7 @@ class TestGetTotScores(unittest.TestCase):
 
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa1 = k2.Fsa.from_str(s1).to(device)
@@ -201,7 +201,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa = k2.Fsa.from_str(s).to(device)
@@ -266,7 +266,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa1 = k2.Fsa.from_str(s1).to(device)

--- a/k2/python/tests/index_add_test.py
+++ b/k2/python/tests/index_add_test.py
@@ -19,7 +19,7 @@ class TestIndexAdd(unittest.TestCase):
     def test_contiguous(self):
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             num_elements = torch.randint(10, 1000, (1,)).item()
@@ -43,7 +43,7 @@ class TestIndexAdd(unittest.TestCase):
     def test_non_contiguous(self):
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             num_elements = torch.randint(100, 10000, (1,)).item()

--- a/k2/python/tests/index_add_test.py
+++ b/k2/python/tests/index_add_test.py
@@ -19,7 +19,7 @@ class TestIndexAdd(unittest.TestCase):
     def test_contiguous(self):
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             num_elements = torch.randint(10, 1000, (1,)).item()
@@ -43,7 +43,7 @@ class TestIndexAdd(unittest.TestCase):
     def test_non_contiguous(self):
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             num_elements = torch.randint(100, 10000, (1,)).item()

--- a/k2/python/tests/union_test.py
+++ b/k2/python/tests/union_test.py
@@ -39,7 +39,7 @@ class TestUnion(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa0 = k2.Fsa.from_str(s0)
@@ -101,7 +101,7 @@ class TestUnion(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append('cuda', 0)
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa0 = k2.Fsa.from_str(s0).to(device).requires_grad_(True)

--- a/k2/python/tests/union_test.py
+++ b/k2/python/tests/union_test.py
@@ -39,7 +39,7 @@ class TestUnion(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa0 = k2.Fsa.from_str(s0)
@@ -101,7 +101,7 @@ class TestUnion(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda'))
+            devices.append(torch.device('cuda', 0))
 
         for device in devices:
             fsa0 = k2.Fsa.from_str(s0).to(device).requires_grad_(True)


### PR DESCRIPTION
The following unit tests failed on my environment (where the torch version is `1.7.0+cu101`):
```
         32 - get_tot_scores_test_py (Failed)
         36 - fsa_test_py (Failed)
         38 - index_add_test_py (Failed)
         46 - union_test_py (Failed)
```

This PR fixed the test `fsa_test_py` and `index_add_test_py`. But the `get_tot_scores_test_py` and `union_test_py` still fails with the error:

```
Traceback (most recent call last):
  File "/home/tj-storage07/zhangjunbo/src/k2/k2/python/tests/union_test.py", line 107, in test_autograd
    fsa0 = k2.Fsa.from_str(s0).to(device).requires_grad_(True)
  File "/home/tj-storage07/zhangjunbo/src/k2/k2/python/k2/fsa.py", line 677, in to
    self.arcs = self.arcs.to(device)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

I haven't found the solution. Could @csukuangfj have a look?