### PR TITLE
Handle the case when torch.device has no `index` attr.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        cuda: ["10.2"] # only for building
+        cuda: ["10.1", "10.2"]
         gcc: ["5"]
-        torch: ["1.6.0"]
+        torch: ["1.6.0", "1.7.0"]
         python-version: [3.6]
         build_type: ["Release", "Debug"]
 

--- a/k2/python/csrc/torch/ragged.cu
+++ b/k2/python/csrc/torch/ragged.cu
@@ -37,7 +37,11 @@ static void PybindRaggedTpl(py::module &m, const char *name) {
           return self.To(GetCpuContext());
         }
 
-        int32_t device_index = static_cast<py::int_>(device.attr("index"));
+        auto index_attr = static_cast<py::object>(device.attr("index"));
+        int32_t device_index = 0;
+        if (!index_attr.is_none())
+          device_index = static_cast<py::int_>(index_attr);
+
         if (context->GetDeviceType() == kCuda &&
             context->GetDeviceId() == device_index)
           return self;
@@ -50,9 +54,8 @@ static void PybindRaggedTpl(py::module &m, const char *name) {
     return self.To(GetCpuContext());
   });
 
-  pyclass.def("clone", [](const PyClass &self) -> PyClass {
-    return self.Clone();
-  });
+  pyclass.def("clone",
+              [](const PyClass &self) -> PyClass { return self.Clone(); });
 
   pyclass.def("is_cpu", [](const PyClass &self) -> bool {
     return self.Context()->GetDeviceType() == kCpu;

--- a/k2/python/tests/get_tot_scores_test.py
+++ b/k2/python/tests/get_tot_scores_test.py
@@ -35,7 +35,7 @@ class TestGetTotScores(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda', 0))
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa = k2.Fsa.from_str(s).to(device)
@@ -118,7 +118,7 @@ class TestGetTotScores(unittest.TestCase):
 
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda', 0))
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa1 = k2.Fsa.from_str(s1).to(device)

--- a/k2/python/tests/union_test.py
+++ b/k2/python/tests/union_test.py
@@ -39,7 +39,7 @@ class TestUnion(unittest.TestCase):
         '''
         devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            devices.append(torch.device('cuda', 0))
+            devices.append(torch.device('cuda'))
 
         for device in devices:
             fsa0 = k2.Fsa.from_str(s0)


### PR DESCRIPTION
Fix #387.