### PR TITLE
Support virtualenv by upgrading pybind11 from v2.5 to v2.6

### DIFF
--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -8,8 +8,8 @@ function(download_pybind11)
 
   include(FetchContent)
 
-  set(pybind11_URL  "https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz")
-  set(pybind11_HASH "SHA256=97504db65640570f32d3fdf701c25a340c8643037c3b69aec469c10c93dc8504")
+  set(pybind11_URL  "https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz")
+  set(pybind11_HASH "SHA256=90b705137b69ee3b5fc655eaca66d0dc9862ea1759226f7ccd3098425ae69571")
 
   set(double_quotes "\"")
   set(dollar "\$")

--- a/cmake/torch.cmake
+++ b/cmake/torch.cmake
@@ -1,5 +1,6 @@
 
 # PYTHON_EXECUTABLE is set by pybind11.cmake
+message(STATUS "Python executable: ${PYTHON_EXECUTABLE}")
 execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c "import os; import torch; print(os.path.dirname(torch.__file__))"
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
`PYTHON_EXECUTABLE` is set as `/usr/bin/python` by pybind11 under version 2.5, which should be `<venv-path>/bin/python` for the virtual environment.
The version 2.6 pybind11 works well with virtualenv.

I have tested the pybind11 v2.6, and all the unit tests passed. So I think it is safe to upgrade pybind11 from v2.5 to v2.6.