### PR TITLE
remove template on device type for tests

### DIFF
--- a/k2/csrc/algorithms_test.cu
+++ b/k2/csrc/algorithms_test.cu
@@ -23,83 +23,71 @@
 #include "k2/csrc/array.h"
 
 namespace k2 {
-template <DeviceType d>
-void TestRenumbering() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // empty case
-    int32_t num_old_elems = 0;
-    Renumbering numbering(context, num_old_elems);
-    EXPECT_EQ(numbering.NumOldElems(), num_old_elems);
-    Array1<char> &keep = numbering.Keep();
-    EXPECT_EQ(keep.Dim(), num_old_elems);
-    Array1<int32_t> old2new = numbering.Old2New();
-    EXPECT_EQ(old2new.Dim(), num_old_elems);
-    Array1<int32_t> new2old = numbering.New2Old();
-    EXPECT_EQ(new2old.Dim(), 0);
-    EXPECT_EQ(numbering.NumNewElems(), 0);
-  }
-
-  {
-    // num_old_elems != 0 but num_new_elems = 0
-    int32_t num_old_elems = 5;
-    Renumbering numbering(context, num_old_elems);
-    EXPECT_EQ(numbering.NumOldElems(), num_old_elems);
-    Array1<char> &keep = numbering.Keep();
-    EXPECT_EQ(keep.Dim(), num_old_elems);
-    std::vector<char> keep_data(num_old_elems, 0);
-    Array1<char> keep_array(context, keep_data);
-    keep.CopyFrom(keep_array);
-    Array1<int32_t> old2new = numbering.Old2New();
-    old2new = old2new.To(cpu);
-    EXPECT_EQ(old2new.Dim(), num_old_elems);
-
-    std::vector<int32_t> cpu_old2new(old2new.Data(),
-                                     old2new.Data() + old2new.Dim());
-    EXPECT_THAT(cpu_old2new, ::testing::ElementsAre(0, 0, 0, 0, 0));
-    Array1<int32_t> new2old = numbering.New2Old();
-    EXPECT_EQ(new2old.Dim(), 0);
-    EXPECT_EQ(numbering.NumNewElems(), 0);
-  }
-
-  {
-    // normal case
-    int32_t num_old_elems = 7;
-    Renumbering numbering(context, num_old_elems);
-    EXPECT_EQ(numbering.NumOldElems(), num_old_elems);
-    Array1<char> &keep = numbering.Keep();
-    EXPECT_EQ(keep.Dim(), num_old_elems);
-    std::vector<char> keep_data = {1, 0, 1, 1, 0, 0, 1};
-    ASSERT_EQ(keep_data.size(), num_old_elems);
-    Array1<char> keep_array(context, keep_data);
-    keep.CopyFrom(keep_array);
-    Array1<int32_t> old2new = numbering.Old2New();
-    old2new = old2new.To(cpu);
-    EXPECT_EQ(old2new.Dim(), num_old_elems);
-    std::vector<int32_t> cpu_old2new(old2new.Data(),
-                                     old2new.Data() + old2new.Dim());
-    EXPECT_THAT(cpu_old2new, ::testing::ElementsAre(0, 1, 1, 2, 3, 3, 3));
-    Array1<int32_t> new2old = numbering.New2Old();
-    EXPECT_EQ(new2old.Dim(), 4);
-    EXPECT_EQ(numbering.NumNewElems(), 4);
-    new2old = new2old.To(cpu);
-    std::vector<int32_t> cpu_new2old(new2old.Data(),
-                                     new2old.Data() + new2old.Dim());
-    EXPECT_THAT(cpu_new2old, ::testing::ElementsAre(0, 2, 3, 6));
-  }
-}
-
 TEST(AlgorithmsTest, TestRenumbering) {
-  TestRenumbering<kCpu>();
-  TestRenumbering<kCuda>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // empty case
+      int32_t num_old_elems = 0;
+      Renumbering numbering(context, num_old_elems);
+      EXPECT_EQ(numbering.NumOldElems(), num_old_elems);
+      Array1<char> &keep = numbering.Keep();
+      EXPECT_EQ(keep.Dim(), num_old_elems);
+      Array1<int32_t> old2new = numbering.Old2New();
+      EXPECT_EQ(old2new.Dim(), num_old_elems);
+      Array1<int32_t> new2old = numbering.New2Old();
+      EXPECT_EQ(new2old.Dim(), 0);
+      EXPECT_EQ(numbering.NumNewElems(), 0);
+    }
+
+    {
+      // num_old_elems != 0 but num_new_elems = 0
+      int32_t num_old_elems = 5;
+      Renumbering numbering(context, num_old_elems);
+      EXPECT_EQ(numbering.NumOldElems(), num_old_elems);
+      Array1<char> &keep = numbering.Keep();
+      EXPECT_EQ(keep.Dim(), num_old_elems);
+      std::vector<char> keep_data(num_old_elems, 0);
+      Array1<char> keep_array(context, keep_data);
+      keep.CopyFrom(keep_array);
+      Array1<int32_t> old2new = numbering.Old2New();
+      old2new = old2new.To(cpu);
+      EXPECT_EQ(old2new.Dim(), num_old_elems);
+
+      std::vector<int32_t> cpu_old2new(old2new.Data(),
+                                       old2new.Data() + old2new.Dim());
+      EXPECT_THAT(cpu_old2new, ::testing::ElementsAre(0, 0, 0, 0, 0));
+      Array1<int32_t> new2old = numbering.New2Old();
+      EXPECT_EQ(new2old.Dim(), 0);
+      EXPECT_EQ(numbering.NumNewElems(), 0);
+    }
+
+    {
+      // normal case
+      int32_t num_old_elems = 7;
+      Renumbering numbering(context, num_old_elems);
+      EXPECT_EQ(numbering.NumOldElems(), num_old_elems);
+      Array1<char> &keep = numbering.Keep();
+      EXPECT_EQ(keep.Dim(), num_old_elems);
+      std::vector<char> keep_data = {1, 0, 1, 1, 0, 0, 1};
+      ASSERT_EQ(keep_data.size(), num_old_elems);
+      Array1<char> keep_array(context, keep_data);
+      keep.CopyFrom(keep_array);
+      Array1<int32_t> old2new = numbering.Old2New();
+      old2new = old2new.To(cpu);
+      EXPECT_EQ(old2new.Dim(), num_old_elems);
+      std::vector<int32_t> cpu_old2new(old2new.Data(),
+                                       old2new.Data() + old2new.Dim());
+      EXPECT_THAT(cpu_old2new, ::testing::ElementsAre(0, 1, 1, 2, 3, 3, 3));
+      Array1<int32_t> new2old = numbering.New2Old();
+      EXPECT_EQ(new2old.Dim(), 4);
+      EXPECT_EQ(numbering.NumNewElems(), 4);
+      new2old = new2old.To(cpu);
+      std::vector<int32_t> cpu_new2old(new2old.Data(),
+                                       new2old.Data() + new2old.Dim());
+      EXPECT_THAT(cpu_new2old, ::testing::ElementsAre(0, 2, 3, 6));
+    }
+  }
 }
 
 }  // namespace k2

--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -269,7 +269,7 @@ Array2<T> RandUniformArray2(ContextPtr c, int32_t dim0, int32_t dim1,
    so ans[i] = first_value + i * inc.
 */
 template <typename T>
-Array1<T> Range(ContextPtr &c, int32_t dim, T first_value, T inc = 1);
+Array1<T> Range(ContextPtr c, int32_t dim, T first_value, T inc = 1);
 
 /*
   This is a convenience wrapper for the function of the same name in utils.h.

--- a/k2/csrc/array_ops_inl.h
+++ b/k2/csrc/array_ops_inl.h
@@ -467,7 +467,7 @@ Array2<T> RandUniformArray2(ContextPtr c, int32_t dim0, int32_t dim1,
 }
 
 template <typename T>
-Array1<T> Range(ContextPtr &c, int32_t dim, T first_value, T inc /*=1*/) {
+Array1<T> Range(ContextPtr c, int32_t dim, T first_value, T inc /*=1*/) {
   NVTX_RANGE("Range");
   K2_CHECK_GE(dim, 0);
   Array1<T> ans = Array1<T>(c, dim);

--- a/k2/csrc/array_ops_test.cu
+++ b/k2/csrc/array_ops_test.cu
@@ -158,122 +158,114 @@ void CheckExclusiveSumArray1Result(const std::vector<S> &src_data,
   }
 }
 
-template <typename S, typename T, DeviceType d>
+template <typename S, typename T>
 void TestExclusiveSumArray1(int32_t num_elem) {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // Test ExclusiveSum(Array1<T> &src)
+      std::vector<S> data(num_elem);
+      int32_t start = RandInt(0, 2);
+      std::iota(data.begin(), data.end(), static_cast<S>(start));
+      Array1<S> src(context, data);
+      Array1<S> dest = ExclusiveSum(src);
+      CheckExclusiveSumArray1Result(data, dest);
+    }
 
-  {
-    // Test ExclusiveSum(Array1<T> &src)
-    std::vector<S> data(num_elem);
-    int32_t start = RandInt(0, 2);
-    std::iota(data.begin(), data.end(), static_cast<S>(start));
-    Array1<S> src(context, data);
-    Array1<S> dest = ExclusiveSum(src);
-    CheckExclusiveSumArray1Result(data, dest);
-  }
+    {
+      // Test ExclusiveSum(Array1<S> &src, Array1<T> *dest) with
+      // dest.Dim() == src.Dim()
+      std::vector<S> data(num_elem);
+      int32_t start = RandInt(0, 2);
+      std::iota(data.begin(), data.end(), static_cast<S>(start));
+      Array1<S> src(context, data);
+      Array1<T> dest(context, num_elem);
+      ExclusiveSum(src, &dest);
+      CheckExclusiveSumArray1Result(data, dest);
+    }
 
-  {
-    // Test ExclusiveSum(Array1<S> &src, Array1<T> *dest) with
-    // dest.Dim() == src.Dim()
-    std::vector<S> data(num_elem);
-    int32_t start = RandInt(0, 2);
-    std::iota(data.begin(), data.end(), static_cast<S>(start));
-    Array1<S> src(context, data);
-    Array1<T> dest(context, num_elem);
-    ExclusiveSum(src, &dest);
-    CheckExclusiveSumArray1Result(data, dest);
-  }
+    {
+      // Test ExclusiveSum(Array1<T> &src, Array1<T> *dest) where
+      // &dest = &src
+      std::vector<S> data(num_elem);
+      int32_t start = RandInt(0, 2);
+      std::iota(data.begin(), data.end(), static_cast<S>(start));
+      Array1<S> src(context, data);
+      ExclusiveSum(src, &src);
+      CheckExclusiveSumArray1Result(data, src);
+    }
 
-  {
-    // Test ExclusiveSum(Array1<T> &src, Array1<T> *dest) where
-    // &dest = &src
-    std::vector<S> data(num_elem);
-    int32_t start = RandInt(0, 2);
-    std::iota(data.begin(), data.end(), static_cast<S>(start));
-    Array1<S> src(context, data);
-    ExclusiveSum(src, &src);
-    CheckExclusiveSumArray1Result(data, src);
-  }
+    {
+      // Test ExclusiveSum(Array1<T> &src, Array1<T> *dest) with
+      // dest.Dim() == src.Dim() + 1
+      int32_t src_dim = num_elem - 1;
+      std::vector<S> data(src_dim);
+      int32_t start = RandInt(0, 2);
+      std::iota(data.begin(), data.end(), static_cast<S>(start));
+      // note we allocate one extra element in region for `src`,
+      // but its value will not be set.
+      int32_t num_bytes = num_elem * sizeof(T);
+      RegionPtr region = NewRegion(context, num_bytes);
+      S *region_data = region->GetData<S>();
+      auto kind = GetMemoryCopyKind(*cpu, *region->context);
+      MemoryCopy(static_cast<void *>(region_data),
+                 static_cast<const void *>(data.data()), src_dim * sizeof(T),
+                 kind, region->context.get());
+      Array1<S> src(src_dim, region, 0);
+      Array1<T> dest(context, num_elem);
+      ASSERT_EQ(dest.Dim(), src.Dim() + 1);
+      ExclusiveSum(src, &dest);
+      CheckExclusiveSumArray1Result(data, dest);
+    }
 
-  {
-    // Test ExclusiveSum(Array1<T> &src, Array1<T> *dest) with
-    // dest.Dim() == src.Dim() + 1
-    int32_t src_dim = num_elem - 1;
-    std::vector<S> data(src_dim);
-    int32_t start = RandInt(0, 2);
-    std::iota(data.begin(), data.end(), static_cast<S>(start));
-    // note we allocate one extra element in region for `src`,
-    // but its value will not be set.
-    int32_t num_bytes = num_elem * sizeof(T);
-    RegionPtr region = NewRegion(context, num_bytes);
-    S *region_data = region->GetData<S>();
-    auto kind = GetMemoryCopyKind(*cpu, *region->context);
-    MemoryCopy(static_cast<void *>(region_data),
-               static_cast<const void *>(data.data()), src_dim * sizeof(T),
-               kind, region->context.get());
-    Array1<S> src(src_dim, region, 0);
-    Array1<T> dest(context, num_elem);
-    ASSERT_EQ(dest.Dim(), src.Dim() + 1);
-    ExclusiveSum(src, &dest);
-    CheckExclusiveSumArray1Result(data, dest);
-  }
+    {
+      // Test ExclusiveSumDeref(Array1<S*> &src, Array1<S> *dest) with
+      // dest.Dim() == src.Dim()
+      std::vector<S> data(num_elem);
+      int32_t start = RandInt(0, 2);
+      std::iota(data.begin(), data.end(), static_cast<S>(start));
+      Array1<S> src(context, data);
+      S *src_data = src.Data();
+      auto lambda_set_values = [=] __host__ __device__(int32_t i) -> const S * {
+        return &src_data[i];
+      };
+      Array1<const S *> src_ptr(context, num_elem, lambda_set_values);
+      Array1<S> dest(context, num_elem);
+      ExclusiveSumDeref(src_ptr, &dest);
+      CheckExclusiveSumArray1Result(data, dest);
+    }
 
-  {
-    // Test ExclusiveSumDeref(Array1<S*> &src, Array1<S> *dest) with
-    // dest.Dim() == src.Dim()
-    std::vector<S> data(num_elem);
-    int32_t start = RandInt(0, 2);
-    std::iota(data.begin(), data.end(), static_cast<S>(start));
-    Array1<S> src(context, data);
-    S *src_data = src.Data();
-    auto lambda_set_values = [=] __host__ __device__(int32_t i) -> const S * {
-      return &src_data[i];
-    };
-    Array1<const S *> src_ptr(context, num_elem, lambda_set_values);
-    Array1<S> dest(context, num_elem);
-    ExclusiveSumDeref(src_ptr, &dest);
-    CheckExclusiveSumArray1Result(data, dest);
-  }
-
-  {
-    // Test ExclusiveSumDeref(Array1<S*> &src, Array1<S> *dest) with
-    // dest.Dim() == src.Dim() + 1
-    int32_t src_dim = num_elem - 1;
-    std::vector<S> data(num_elem);
-    int32_t start = RandInt(0, 2);
-    std::iota(data.begin(), data.end(), static_cast<S>(start));
-    // note we allocate one extra element in region for `src`,
-    // but its value will not be set.
-    Array1<S> src(context, data);
-    S *src_data = src.Data();
-    int32_t num_bytes = num_elem * sizeof(S *);
-    RegionPtr region = NewRegion(context, num_bytes);
-    S **region_data = region->GetData<S *>();
-    auto lambda_set_values = [=] __host__ __device__(int32_t i) -> void {
-      region_data[i] = &src_data[i];
-    };
-    Eval(context, num_elem, lambda_set_values);
-    // not src_ptr.Dim() == src_dim == num_elem - 1
-    Array1<const S *> src_ptr(src_dim, region, 0);
-    Array1<S> dest(context, num_elem);
-    ASSERT_EQ(dest.Dim(), src_ptr.Dim() + 1);
-    ExclusiveSumDeref(src_ptr, &dest);
-    CheckExclusiveSumArray1Result(data, dest);
+    {
+      // Test ExclusiveSumDeref(Array1<S*> &src, Array1<S> *dest) with
+      // dest.Dim() == src.Dim() + 1
+      int32_t src_dim = num_elem - 1;
+      std::vector<S> data(num_elem);
+      int32_t start = RandInt(0, 2);
+      std::iota(data.begin(), data.end(), static_cast<S>(start));
+      // note we allocate one extra element in region for `src`,
+      // but its value will not be set.
+      Array1<S> src(context, data);
+      S *src_data = src.Data();
+      int32_t num_bytes = num_elem * sizeof(S *);
+      RegionPtr region = NewRegion(context, num_bytes);
+      S **region_data = region->GetData<S *>();
+      auto lambda_set_values = [=] __host__ __device__(int32_t i) -> void {
+        region_data[i] = &src_data[i];
+      };
+      Eval(context, num_elem, lambda_set_values);
+      // not src_ptr.Dim() == src_dim == num_elem - 1
+      Array1<const S *> src_ptr(src_dim, region, 0);
+      Array1<S> dest(context, num_elem);
+      ASSERT_EQ(dest.Dim(), src_ptr.Dim() + 1);
+      ExclusiveSumDeref(src_ptr, &dest);
+      CheckExclusiveSumArray1Result(data, dest);
+    }
   }
 }
 
 TEST(OpsTest, ExclusiveSumArray1Test) {
-  TestExclusiveSumArray1<int32_t, int32_t, kCpu>(1000);
-  TestExclusiveSumArray1<int32_t, int32_t, kCuda>(1000);
-  TestExclusiveSumArray1<float, double, kCpu>(1000);
-  TestExclusiveSumArray1<float, double, kCuda>(1000);
+  TestExclusiveSumArray1<int32_t, int32_t>(1000);
+  TestExclusiveSumArray1<float, double>(1000);
 }
 
 template <typename T>
@@ -338,206 +330,200 @@ void CheckExclusiveSumArray2Result(const std::vector<T> &src_data,
   EXPECT_EQ(dest_data, expected_data);
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // axis == 0 && &dest == &src, ElementStride0 == cols
-    int32_t axis = 0;
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> src_array1(context, data);
-    Array2<T> src(src_array1, rows, cols);
-    ExclusiveSum(src, &src, axis);
-    CheckExclusiveSumArray2Result(data, src, axis);
-  }
-
-  {
-    // axis == 0 && &dest == &src, ElementStride0 > cols
-    int32_t axis = 0;
-    int32_t stride0 = RandInt(cols + 1, cols + 10);
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> data_array(context, data);
-    const T *src_data = data_array.Data();
-    // allocate extra memory as there stride0 > 0
-    int32_t num_bytes = rows * stride0 * sizeof(T);
-    RegionPtr region = NewRegion(context, num_bytes);
-    T *region_data = region->GetData<T>();
-    auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                    int32_t j) -> void {
-      region_data[i * stride0 + j] = src_data[i * cols + j];
-    };
-    Eval2(context, rows, cols, lambda_set_elems);
-    Array2<T> src(rows, cols, stride0, 0, region);
-    ExclusiveSum(src, &src, axis);
-    CheckExclusiveSumArray2Result(data, src, axis);
-  }
-
-  {
-    // axis == 0 && dest.Dim0() == src.Dim0(), ElementStride0 == cols
-    int32_t axis = 0;
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> src_array1(context, data);
-    Array2<T> src(src_array1, rows, cols);
-    Array2<T> dest(context, rows, cols);
-    ExclusiveSum(src, &dest, axis);
-    CheckExclusiveSumArray2Result(data, dest, axis);
-  }
-
-  {
-    // axis == 0 && dest.Dim0() == src.Dim0(), ElementStride0 > cols
-    int32_t axis = 0;
-    int32_t stride0 = RandInt(cols + 1, cols + 10);
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> data_array(context, data);
-    const T *src_data = data_array.Data();
-    // allocate extra memory as there stride0 > 0
-    int32_t num_bytes = rows * stride0 * sizeof(T);
-    RegionPtr region = NewRegion(context, num_bytes);
-    T *region_data = region->GetData<T>();
-    auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                    int32_t j) -> void {
-      region_data[i * stride0 + j] = src_data[i * cols + j];
-    };
-    Eval2(context, rows, cols, lambda_set_elems);
-    Array2<T> src(rows, cols, stride0, 0, region);
-    Array2<T> dest(context, rows, cols);
-    ExclusiveSum(src, &dest, axis);
-    CheckExclusiveSumArray2Result(data, dest, axis);
-  }
-
-  {
-    // axis == 0 && dest.Dim0() == src.Dim0() + 1, we need to allocate one extra
-    // element for src
-    int32_t axis = 0;
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> data_array(context, data);
-    const T *src_data = data_array.Data();
-    int32_t num_bytes = (rows * cols + 1) * sizeof(T);
-    RegionPtr region = NewRegion(context, num_bytes);
-    T *region_data = region->GetData<T>();
-    auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                    int32_t j) -> void {
-      region_data[i * cols + j] = src_data[i * cols + j];
-    };
-    Eval2(context, rows, cols, lambda_set_elems);
-    Array2<T> src(rows, cols, cols, 0, region);
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     {
-      // dest.stride0 == dest.cols
-      Array2<T> dest(context, rows + 1, cols);
+      // axis == 0 && &dest == &src, ElementStride0 == cols
+      int32_t axis = 0;
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> src_array1(context, data);
+      Array2<T> src(src_array1, rows, cols);
+      ExclusiveSum(src, &src, axis);
+      CheckExclusiveSumArray2Result(data, src, axis);
+    }
+
+    {
+      // axis == 0 && &dest == &src, ElementStride0 > cols
+      int32_t axis = 0;
+      int32_t stride0 = RandInt(cols + 1, cols + 10);
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> data_array(context, data);
+      const T *src_data = data_array.Data();
+      // allocate extra memory as there stride0 > 0
+      int32_t num_bytes = rows * stride0 * sizeof(T);
+      RegionPtr region = NewRegion(context, num_bytes);
+      T *region_data = region->GetData<T>();
+      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
+                                                      int32_t j) -> void {
+        region_data[i * stride0 + j] = src_data[i * cols + j];
+      };
+      Eval2(context, rows, cols, lambda_set_elems);
+      Array2<T> src(rows, cols, stride0, 0, region);
+      ExclusiveSum(src, &src, axis);
+      CheckExclusiveSumArray2Result(data, src, axis);
+    }
+
+    {
+      // axis == 0 && dest.Dim0() == src.Dim0(), ElementStride0 == cols
+      int32_t axis = 0;
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> src_array1(context, data);
+      Array2<T> src(src_array1, rows, cols);
+      Array2<T> dest(context, rows, cols);
       ExclusiveSum(src, &dest, axis);
       CheckExclusiveSumArray2Result(data, dest, axis);
     }
+
     {
-      // dest.stride0 > dest.cols
-      int32_t dest_stride0 = cols + 5;
-      int32_t dest_rows = rows + 1;
-      RegionPtr dest_region =
-          NewRegion(context, dest_rows * dest_stride0 * sizeof(T));
-      Array2<T> dest(dest_rows, cols, dest_stride0, 0, dest_region);
+      // axis == 0 && dest.Dim0() == src.Dim0(), ElementStride0 > cols
+      int32_t axis = 0;
+      int32_t stride0 = RandInt(cols + 1, cols + 10);
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> data_array(context, data);
+      const T *src_data = data_array.Data();
+      // allocate extra memory as there stride0 > 0
+      int32_t num_bytes = rows * stride0 * sizeof(T);
+      RegionPtr region = NewRegion(context, num_bytes);
+      T *region_data = region->GetData<T>();
+      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
+                                                      int32_t j) -> void {
+        region_data[i * stride0 + j] = src_data[i * cols + j];
+      };
+      Eval2(context, rows, cols, lambda_set_elems);
+      Array2<T> src(rows, cols, stride0, 0, region);
+      Array2<T> dest(context, rows, cols);
       ExclusiveSum(src, &dest, axis);
       CheckExclusiveSumArray2Result(data, dest, axis);
     }
-  }
 
-  {
-    // axis == 1 && &dest == &src, ElementStride0 == cols
-    int32_t axis = 1;
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> src_array1(context, data);
-    Array2<T> src(src_array1, rows, cols);
-    ExclusiveSum(src, &src, axis);
-    CheckExclusiveSumArray2Result(data, src, axis);
-  }
-
-  {
-    // axis == 1 && &dest == &src, ElementStride0 > cols
-    int32_t axis = 1;
-    int32_t stride0 = RandInt(cols + 1, cols + 10);
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> data_array(context, data);
-    const T *src_data = data_array.Data();
-    // allocate extra memory as there stride0 > 0
-    int32_t num_bytes = rows * stride0 * sizeof(T);
-    RegionPtr region = NewRegion(context, num_bytes);
-    T *region_data = region->GetData<T>();
-    auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                    int32_t j) -> void {
-      region_data[i * stride0 + j] = src_data[i * cols + j];
-    };
-    Eval2(context, rows, cols, lambda_set_elems);
-    Array2<T> src(rows, cols, stride0, 0, region);
-    ExclusiveSum(src, &src, axis);
-    CheckExclusiveSumArray2Result(data, src, axis);
-  }
-
-  {
-    // axis == 1 && dest.Dim1() == src.Dim1(), ElementStride0 == cols
-    int32_t axis = 1;
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> src_array1(context, data);
-    Array2<T> src(src_array1, rows, cols);
-    Array2<T> dest(context, rows, cols);
-    ExclusiveSum(src, &dest, axis);
-    CheckExclusiveSumArray2Result(data, dest, axis);
-  }
-
-  {
-    // axis == 1 && dest.Dim1() == src.Dim1() + 1, we need to allocate one extra
-    // element for src
-    int32_t axis = 1;
-    int32_t num_elems = rows * cols;
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> data_array(context, data);
-    const T *src_data = data_array.Data();
-    int32_t num_bytes = (rows * cols + 1) * sizeof(T);
-    RegionPtr region = NewRegion(context, num_bytes);
-    T *region_data = region->GetData<T>();
-    auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                    int32_t j) -> void {
-      region_data[i * cols + j] = src_data[i * cols + j];
-    };
-    Eval2(context, rows, cols, lambda_set_elems);
-    Array2<T> src(rows, cols, cols, 0, region);
     {
-      // dest.stride0 == dest.cols
-      Array2<T> dest(context, rows, cols + 1);
+      // axis == 0 && dest.Dim0() == src.Dim0() + 1, we need to allocate one
+      // extra element for src
+      int32_t axis = 0;
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> data_array(context, data);
+      const T *src_data = data_array.Data();
+      int32_t num_bytes = (rows * cols + 1) * sizeof(T);
+      RegionPtr region = NewRegion(context, num_bytes);
+      T *region_data = region->GetData<T>();
+      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
+                                                      int32_t j) -> void {
+        region_data[i * cols + j] = src_data[i * cols + j];
+      };
+      Eval2(context, rows, cols, lambda_set_elems);
+      Array2<T> src(rows, cols, cols, 0, region);
+      {
+        // dest.stride0 == dest.cols
+        Array2<T> dest(context, rows + 1, cols);
+        ExclusiveSum(src, &dest, axis);
+        CheckExclusiveSumArray2Result(data, dest, axis);
+      }
+      {
+        // dest.stride0 > dest.cols
+        int32_t dest_stride0 = cols + 5;
+        int32_t dest_rows = rows + 1;
+        RegionPtr dest_region =
+            NewRegion(context, dest_rows * dest_stride0 * sizeof(T));
+        Array2<T> dest(dest_rows, cols, dest_stride0, 0, dest_region);
+        ExclusiveSum(src, &dest, axis);
+        CheckExclusiveSumArray2Result(data, dest, axis);
+      }
+    }
+
+    {
+      // axis == 1 && &dest == &src, ElementStride0 == cols
+      int32_t axis = 1;
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> src_array1(context, data);
+      Array2<T> src(src_array1, rows, cols);
+      ExclusiveSum(src, &src, axis);
+      CheckExclusiveSumArray2Result(data, src, axis);
+    }
+
+    {
+      // axis == 1 && &dest == &src, ElementStride0 > cols
+      int32_t axis = 1;
+      int32_t stride0 = RandInt(cols + 1, cols + 10);
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> data_array(context, data);
+      const T *src_data = data_array.Data();
+      // allocate extra memory as there stride0 > 0
+      int32_t num_bytes = rows * stride0 * sizeof(T);
+      RegionPtr region = NewRegion(context, num_bytes);
+      T *region_data = region->GetData<T>();
+      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
+                                                      int32_t j) -> void {
+        region_data[i * stride0 + j] = src_data[i * cols + j];
+      };
+      Eval2(context, rows, cols, lambda_set_elems);
+      Array2<T> src(rows, cols, stride0, 0, region);
+      ExclusiveSum(src, &src, axis);
+      CheckExclusiveSumArray2Result(data, src, axis);
+    }
+
+    {
+      // axis == 1 && dest.Dim1() == src.Dim1(), ElementStride0 == cols
+      int32_t axis = 1;
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> src_array1(context, data);
+      Array2<T> src(src_array1, rows, cols);
+      Array2<T> dest(context, rows, cols);
       ExclusiveSum(src, &dest, axis);
       CheckExclusiveSumArray2Result(data, dest, axis);
     }
+
     {
-      // dest.stride0 > dest.cols
-      int32_t dest_stride0 = cols + 5;
-      int32_t dest_cols = cols + 1;
-      RegionPtr dest_region =
-          NewRegion(context, rows * dest_stride0 * sizeof(T));
-      Array2<T> dest(rows, dest_cols, dest_stride0, 0, dest_region);
-      ExclusiveSum(src, &dest, axis);
-      CheckExclusiveSumArray2Result(data, dest, axis);
+      // axis == 1 && dest.Dim1() == src.Dim1() + 1, we need to allocate one
+      // extra element for src
+      int32_t axis = 1;
+      int32_t num_elems = rows * cols;
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> data_array(context, data);
+      const T *src_data = data_array.Data();
+      int32_t num_bytes = (rows * cols + 1) * sizeof(T);
+      RegionPtr region = NewRegion(context, num_bytes);
+      T *region_data = region->GetData<T>();
+      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
+                                                      int32_t j) -> void {
+        region_data[i * cols + j] = src_data[i * cols + j];
+      };
+      Eval2(context, rows, cols, lambda_set_elems);
+      Array2<T> src(rows, cols, cols, 0, region);
+      {
+        // dest.stride0 == dest.cols
+        Array2<T> dest(context, rows, cols + 1);
+        ExclusiveSum(src, &dest, axis);
+        CheckExclusiveSumArray2Result(data, dest, axis);
+      }
+      {
+        // dest.stride0 > dest.cols
+        int32_t dest_stride0 = cols + 5;
+        int32_t dest_cols = cols + 1;
+        RegionPtr dest_region =
+            NewRegion(context, rows * dest_stride0 * sizeof(T));
+        Array2<T> dest(rows, dest_cols, dest_stride0, 0, dest_region);
+        ExclusiveSum(src, &dest, axis);
+        CheckExclusiveSumArray2Result(data, dest, axis);
+      }
     }
   }
 }
@@ -545,761 +531,697 @@ void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
 TEST(OpsTest, ExclusiveSumArray2Test) {
   int32_t rows = RandInt(500, 1000);
   int32_t cols = RandInt(500, 1000);
-  TestExclusiveSumArray2<int32_t, kCpu>(rows, cols);
-  TestExclusiveSumArray2<int32_t, kCuda>(rows, cols);
+  TestExclusiveSumArray2<int32_t>(rows, cols);
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestArrayMaxAndOr() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // Max
+      const std::vector<T> values = {1, 3, 2, 8, 0, -1};
+      Array1<T> src(context, values);
+      Array1<T> dst(context, 1);
+      T default_value = 0;
+      Max(src, default_value, &dst);
+      EXPECT_EQ(dst[0], 8);
+    }
 
-  {
-    // Max
-    const std::vector<T> values = {1, 3, 2, 8, 0, -1};
-    Array1<T> src(context, values);
-    Array1<T> dst(context, 1);
-    T default_value = 0;
-    Max(src, default_value, &dst);
-    EXPECT_EQ(dst[0], 8);
-  }
+    {
+      // Max, dst is one of element of src
+      const std::vector<T> values = {1, 3, 2, 8, 0, -1};
+      Array1<T> src(context, values);
+      Array1<T> dst = src.Range(2, 1);
+      T default_value = 0;
+      Max(src, default_value, &dst);
+      EXPECT_EQ(dst[0], 8);
+      // src has been changed as well
+      EXPECT_EQ(src[2], 8);
+      // other values are not changed
+      src = src.To(cpu);
+      std::vector<T> cpu_data(src.Data(), src.Data() + src.Dim());
+      const std::vector<T> expected_data = {1, 3, 8, 8, 0, -1};
+      EXPECT_EQ(cpu_data, expected_data);
+    }
 
-  {
-    // Max, dst is one of element of src
-    const std::vector<T> values = {1, 3, 2, 8, 0, -1};
-    Array1<T> src(context, values);
-    Array1<T> dst = src.Range(2, 1);
-    T default_value = 0;
-    Max(src, default_value, &dst);
-    EXPECT_EQ(dst[0], 8);
-    // src has been changed as well
-    EXPECT_EQ(src[2], 8);
-    // other values are not changed
-    src = src.To(cpu);
-    std::vector<T> cpu_data(src.Data(), src.Data() + src.Dim());
-    const std::vector<T> expected_data = {1, 3, 8, 8, 0, -1};
-    EXPECT_EQ(cpu_data, expected_data);
-  }
+    {
+      // Max, with random large size
+      int32_t num_elems = RandInt(1000, 10000);
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), num_elems);
+      // random set a value to  `max_value`
+      int32_t pos = RandInt(0, num_elems - 1);
+      T max_value = static_cast<T>(num_elems * 2);
+      data[pos] = max_value;
+      Array1<T> src(context, data);
+      Array1<T> dst(context, 1);
+      T default_value = 0;
+      Max(src, default_value, &dst);
+      EXPECT_EQ(dst[0], max_value);
+    }
 
-  {
-    // Max, with random large size
-    int32_t num_elems = RandInt(1000, 10000);
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), num_elems);
-    // random set a value to  `max_value`
-    int32_t pos = RandInt(0, num_elems - 1);
-    T max_value = static_cast<T>(num_elems * 2);
-    data[pos] = max_value;
-    Array1<T> src(context, data);
-    Array1<T> dst(context, 1);
-    T default_value = 0;
-    Max(src, default_value, &dst);
-    EXPECT_EQ(dst[0], max_value);
-  }
+    {
+      // And
+      const std::vector<T> values = {3, 6, 11};
+      Array1<T> src(context, values);
+      Array1<T> dst(context, 1);
+      T default_value = -1;
+      And(src, default_value, &dst);
+      EXPECT_EQ(dst[0], 2);
+    }
 
-  {
-    // And
-    const std::vector<T> values = {3, 6, 11};
-    Array1<T> src(context, values);
-    Array1<T> dst(context, 1);
-    T default_value = -1;
-    And(src, default_value, &dst);
-    EXPECT_EQ(dst[0], 2);
-  }
-
-  {
-    // Or
-    const std::vector<T> values = {3, 6, 4};
-    Array1<T> src(context, values);
-    Array1<T> dst(context, 1);
-    T default_value = 0;
-    Or(src, default_value, &dst);
-    EXPECT_EQ(dst[0], 7);
+    {
+      // Or
+      const std::vector<T> values = {3, 6, 4};
+      Array1<T> src(context, values);
+      Array1<T> dst(context, 1);
+      T default_value = 0;
+      Or(src, default_value, &dst);
+      EXPECT_EQ(dst[0], 7);
+    }
   }
 }
 
-TEST(OpsTest, ArrayMaxAndOrTest) {
-  TestArrayMaxAndOr<int32_t, kCpu>();
-  TestArrayMaxAndOr<int32_t, kCuda>();
-}
+TEST(OpsTest, ArrayMaxAndOrTest) { TestArrayMaxAndOr<int32_t>(); }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestAppend() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // a case with small size
-    std::vector<T> data1 = {3, 1, 2};
-    std::vector<T> data2 = {5, 6, 7, 8};
-    std::vector<T> data3 = {};  // empty
-    std::vector<T> data4 = {9};
-    std::vector<T> expected_data = {3, 1, 2, 5, 6, 7, 8, 9};
-
-    Array1<T> array1(context, data1);
-    Array1<T> array2(context, data2);
-    Array1<T> array3(context, data3);
-    Array1<T> array4(context, data4);
-
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     {
-      // test Append(int32_t, Array1<T>**)
-      std::vector<const Array1<T> *> arrays = {&array1, &array2, &array3,
-                                               &array4};
-      const Array1<T> **src = arrays.data();
-      Array1<T> dst = Append(4, src);
-      EXPECT_EQ(dst.Dim(), 8);
-      // copy memory from GPU/CPU to CPU
-      std::vector<T> cpu_data(dst.Dim());
-      auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(dst.Data()),
-                 dst.Dim() * dst.ElementSize(), kind, nullptr);
-      EXPECT_EQ(cpu_data, expected_data);
-    }
+      // a case with small size
+      std::vector<T> data1 = {3, 1, 2};
+      std::vector<T> data2 = {5, 6, 7, 8};
+      std::vector<T> data3 = {};  // empty
+      std::vector<T> data4 = {9};
+      std::vector<T> expected_data = {3, 1, 2, 5, 6, 7, 8, 9};
 
-    {
-      // test Append(int32_t, Array1<T>*)
-      std::vector<Array1<T>> arrays = {array1, array2, array3, array4};
-      const Array1<T> *src = arrays.data();
-      Array1<T> dst = Append(4, src);
-      EXPECT_EQ(dst.Dim(), 8);
+      Array1<T> array1(context, data1);
+      Array1<T> array2(context, data2);
+      Array1<T> array3(context, data3);
+      Array1<T> array4(context, data4);
 
-      // copy memory from GPU/CPU to CPU
-      std::vector<T> cpu_data(dst.Dim());
-      auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(dst.Data()),
-                 dst.Dim() * dst.ElementSize(), kind, nullptr);
-      EXPECT_EQ(cpu_data, expected_data);
-    }
-  }
-
-  {
-    // test with random large size, the arrays' sizes are fairly balanced.
-    for (int32_t i = 0; i != 2; ++i) {
-      int32_t num_array = RandInt(10, 1000);
-      std::vector<Array1<T>> arrays_vec(num_array);
-      std::vector<const Array1<T> *> arrays(num_array);
-      int32_t total_size = 0;
-      for (int32_t j = 0; j != num_array; ++j) {
-        int32_t curr_array_size = RandInt(0, 10000);
-        std::vector<T> data(curr_array_size);
-        std::iota(data.begin(), data.end(), total_size);
-        total_size += curr_array_size;
-        arrays_vec[j] = Array1<T>(context, data);
-        arrays[j] = &arrays_vec[j];
-      }
-      const Array1<T> **src = arrays.data();
-      Array1<T> dst = Append(num_array, src);
-      EXPECT_EQ(dst.Dim(), total_size);
-      // copy memory from GPU/CPU to CPU
-      std::vector<T> cpu_data(dst.Dim());
-      auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(dst.Data()),
-                 dst.Dim() * dst.ElementSize(), kind, nullptr);
-      std::vector<T> expected_data(dst.Dim());
-      std::iota(expected_data.begin(), expected_data.end(), 0);
-      EXPECT_EQ(cpu_data, expected_data);
-    }
-  }
-
-  {
-    // test with random large size: the arrays' sizes are not balanced.
-    for (int32_t i = 0; i != 2; ++i) {
-      int32_t num_array = RandInt(10, 1000);
-      std::vector<Array1<T>> arrays_vec(num_array);
-      std::vector<const Array1<T> *> arrays(num_array);
-      int32_t total_size = 0, max_size = 0;
-      // notice `j != num_array - 1`, we would push a very long array
-      // after the loop
-      for (int32_t j = 0; j != num_array - 1; ++j) {
-        int32_t curr_array_size = RandInt(0, 10000);
-        std::vector<T> data(curr_array_size);
-        std::iota(data.begin(), data.end(), total_size);
-        total_size += curr_array_size;
-        arrays_vec[j] = Array1<T>(context, data);
-        arrays[j] = &arrays_vec[j];
-        if (curr_array_size > max_size) max_size = curr_array_size;
-      }
-      // generate an array with very large size
       {
-        int32_t average_size = total_size / num_array;
-        int32_t long_size = average_size * 10;
-        std::vector<T> data(long_size);
-        std::iota(data.begin(), data.end(), total_size);
-        total_size += long_size;
-        arrays_vec[num_array - 1] = Array1<T>(context, data);
-        arrays[num_array - 1] = &arrays_vec[num_array - 1];
+        // test Append(int32_t, Array1<T>**)
+        std::vector<const Array1<T> *> arrays = {&array1, &array2, &array3,
+                                                 &array4};
+        const Array1<T> **src = arrays.data();
+        Array1<T> dst = Append(4, src);
+        EXPECT_EQ(dst.Dim(), 8);
+        // copy memory from GPU/CPU to CPU
+        std::vector<T> cpu_data(dst.Dim());
+        auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(dst.Data()),
+                   dst.Dim() * dst.ElementSize(), kind, nullptr);
+        EXPECT_EQ(cpu_data, expected_data);
       }
-      const Array1<T> **src = arrays.data();
-      Array1<T> dst = Append(num_array, src);
-      EXPECT_EQ(dst.Dim(), total_size);
-      // copy memory from GPU/CPU to CPU
-      std::vector<T> cpu_data(dst.Dim());
-      auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(dst.Data()),
-                 dst.Dim() * dst.ElementSize(), kind, nullptr);
-      std::vector<T> expected_data(dst.Dim());
-      std::iota(expected_data.begin(), expected_data.end(), 0);
-      EXPECT_EQ(cpu_data, expected_data);
+
+      {
+        // test Append(int32_t, Array1<T>*)
+        std::vector<Array1<T>> arrays = {array1, array2, array3, array4};
+        const Array1<T> *src = arrays.data();
+        Array1<T> dst = Append(4, src);
+        EXPECT_EQ(dst.Dim(), 8);
+
+        // copy memory from GPU/CPU to CPU
+        std::vector<T> cpu_data(dst.Dim());
+        auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(dst.Data()),
+                   dst.Dim() * dst.ElementSize(), kind, nullptr);
+        EXPECT_EQ(cpu_data, expected_data);
+      }
+    }
+
+    {
+      // test with random large size, the arrays' sizes are fairly balanced.
+      for (int32_t i = 0; i != 2; ++i) {
+        int32_t num_array = RandInt(10, 1000);
+        std::vector<Array1<T>> arrays_vec(num_array);
+        std::vector<const Array1<T> *> arrays(num_array);
+        int32_t total_size = 0;
+        for (int32_t j = 0; j != num_array; ++j) {
+          int32_t curr_array_size = RandInt(0, 10000);
+          std::vector<T> data(curr_array_size);
+          std::iota(data.begin(), data.end(), total_size);
+          total_size += curr_array_size;
+          arrays_vec[j] = Array1<T>(context, data);
+          arrays[j] = &arrays_vec[j];
+        }
+        const Array1<T> **src = arrays.data();
+        Array1<T> dst = Append(num_array, src);
+        EXPECT_EQ(dst.Dim(), total_size);
+        // copy memory from GPU/CPU to CPU
+        std::vector<T> cpu_data(dst.Dim());
+        auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(dst.Data()),
+                   dst.Dim() * dst.ElementSize(), kind, nullptr);
+        std::vector<T> expected_data(dst.Dim());
+        std::iota(expected_data.begin(), expected_data.end(), 0);
+        EXPECT_EQ(cpu_data, expected_data);
+      }
+    }
+
+    {
+      // test with random large size: the arrays' sizes are not balanced.
+      for (int32_t i = 0; i != 2; ++i) {
+        int32_t num_array = RandInt(10, 1000);
+        std::vector<Array1<T>> arrays_vec(num_array);
+        std::vector<const Array1<T> *> arrays(num_array);
+        int32_t total_size = 0, max_size = 0;
+        // notice `j != num_array - 1`, we would push a very long array
+        // after the loop
+        for (int32_t j = 0; j != num_array - 1; ++j) {
+          int32_t curr_array_size = RandInt(0, 10000);
+          std::vector<T> data(curr_array_size);
+          std::iota(data.begin(), data.end(), total_size);
+          total_size += curr_array_size;
+          arrays_vec[j] = Array1<T>(context, data);
+          arrays[j] = &arrays_vec[j];
+          if (curr_array_size > max_size) max_size = curr_array_size;
+        }
+        // generate an array with very large size
+        {
+          int32_t average_size = total_size / num_array;
+          int32_t long_size = average_size * 10;
+          std::vector<T> data(long_size);
+          std::iota(data.begin(), data.end(), total_size);
+          total_size += long_size;
+          arrays_vec[num_array - 1] = Array1<T>(context, data);
+          arrays[num_array - 1] = &arrays_vec[num_array - 1];
+        }
+        const Array1<T> **src = arrays.data();
+        Array1<T> dst = Append(num_array, src);
+        EXPECT_EQ(dst.Dim(), total_size);
+        // copy memory from GPU/CPU to CPU
+        std::vector<T> cpu_data(dst.Dim());
+        auto kind = GetMemoryCopyKind(*dst.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(dst.Data()),
+                   dst.Dim() * dst.ElementSize(), kind, nullptr);
+        std::vector<T> expected_data(dst.Dim());
+        std::iota(expected_data.begin(), expected_data.end(), 0);
+        EXPECT_EQ(cpu_data, expected_data);
+      }
     }
   }
 }
 
 TEST(OpsTest, AppendTest) {
-  TestAppend<int32_t, kCpu>();
-  TestAppend<int32_t, kCuda>();
-  TestAppend<float, kCpu>();
-  TestAppend<float, kCuda>();
-}
-
-template <DeviceType d>
-void TestSpliceRowSplits() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // a case with small size
-    std::vector<int32_t> data1 = {0, 2, 5};
-    std::vector<int32_t> data2 = {0, 2, 2, 3};
-    std::vector<int32_t> data3 = {0};
-    std::vector<int32_t> data4 = {0, 3};
-    std::vector<int32_t> expected_data = {0, 2, 5, 7, 7, 8, 11};
-
-    Array1<int32_t> array1(context, data1);
-    Array1<int32_t> array2(context, data2);
-    Array1<int32_t> array3(context, data3);
-    Array1<int32_t> array4(context, data4);
-
-    std::vector<const Array1<int32_t> *> arrays = {&array1, &array2, &array3,
-                                                   &array4};
-    const Array1<int32_t> **src = arrays.data();
-    Array1<int32_t> dst = SpliceRowSplits(4, src);
-    EXPECT_EQ(dst.Dim(), expected_data.size());
-    // copy memory from GPU/CPU to CPU
-    dst = dst.To(cpu);
-    std::vector<int32_t> cpu_data(dst.Data(), dst.Data() + dst.Dim());
-    EXPECT_EQ(cpu_data, expected_data);
-  }
-
-  {
-    // test with random large size, the arrays' sizes are fairly balanced.
-    for (int32_t i = 0; i != 2; ++i) {
-      int32_t num_array = RandInt(10, 1000);
-      std::vector<Array1<int32_t>> arrays_vec(num_array);
-      std::vector<const Array1<int32_t> *> arrays(num_array);
-      std::vector<int32_t> expected_data;
-      int32_t data_offset = 0;
-      for (int32_t j = 0; j != num_array; ++j) {
-        int32_t curr_array_size = RandInt(0, 10000);
-        RaggedShape shape =
-            RandomRaggedShape(false, 2, 2, curr_array_size, curr_array_size);
-        ASSERT_EQ(shape.NumAxes(), 2);
-        Array1<int32_t> cpu_row_splits = shape.RowSplits(1).To(cpu);
-        int32_t num_splits = cpu_row_splits.Dim();
-        ASSERT_GE(num_splits, 1);
-        const int32_t *splits_data = cpu_row_splits.Data();
-        for (int32_t n = 0; n < num_splits; ++n) {
-          expected_data.push_back(splits_data[n] + data_offset);
-        }
-        if (j + 1 < num_array) expected_data.pop_back();
-        data_offset += splits_data[num_splits - 1];
-        Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
-        ASSERT_GE(row_splits.Dim(), 1);
-        arrays_vec[j] = row_splits;
-        arrays[j] = &arrays_vec[j];
-      }
-      const Array1<int32_t> **src = arrays.data();
-      Array1<int32_t> dst = SpliceRowSplits(num_array, src);
-      EXPECT_EQ(dst.Dim(), expected_data.size());
-      // copy memory from GPU/CPU to CPU
-      dst = dst.To(cpu);
-      std::vector<int32_t> cpu_data(dst.Data(), dst.Data() + dst.Dim());
-      EXPECT_EQ(cpu_data, expected_data);
-    }
-  }
-
-  {
-    // test with random large size: the arrays' sizes are not balanced.
-    for (int32_t i = 0; i != 2; ++i) {
-      int32_t num_array = RandInt(10, 1000);
-      std::vector<Array1<int32_t>> arrays_vec(num_array);
-      std::vector<const Array1<int32_t> *> arrays(num_array);
-      std::vector<int32_t> expected_data;
-      int32_t data_offset = 0;
-      int32_t max_size = 0;
-      for (int32_t j = 0; j != num_array - 1; ++j) {
-        int32_t curr_array_size = RandInt(0, 10000);
-        RaggedShape shape =
-            RandomRaggedShape(false, 2, 2, curr_array_size, curr_array_size);
-        ASSERT_EQ(shape.NumAxes(), 2);
-        Array1<int32_t> cpu_row_splits = shape.RowSplits(1).To(cpu);
-        int32_t num_splits = cpu_row_splits.Dim();
-        ASSERT_GE(num_splits, 1);
-        const int32_t *splits_data = cpu_row_splits.Data();
-        for (int32_t n = 0; n < num_splits; ++n) {
-          expected_data.push_back(splits_data[n] + data_offset);
-        }
-        expected_data.pop_back();
-        data_offset += splits_data[num_splits - 1];
-        Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
-        ASSERT_GE(row_splits.Dim(), 1);
-        arrays_vec[j] = row_splits;
-        arrays[j] = &arrays_vec[j];
-        if (num_splits > max_size) max_size = num_splits;
-      }
-      // generate an array with very large size
-      {
-        int32_t total_size = static_cast<int32_t>(expected_data.size());
-        int32_t average_size = total_size / num_array;
-        int32_t long_size = average_size * 10;
-
-        RaggedShape shape =
-            RandomRaggedShape(false, 2, 2, long_size, long_size);
-        ASSERT_EQ(shape.NumAxes(), 2);
-        Array1<int32_t> cpu_row_splits = shape.RowSplits(1).To(cpu);
-        int32_t num_splits = cpu_row_splits.Dim();
-        ASSERT_GE(num_splits, 1);
-        const int32_t *splits_data = cpu_row_splits.Data();
-        for (int32_t n = 0; n < num_splits; ++n) {
-          expected_data.push_back(splits_data[n] + data_offset);
-        }
-        Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
-        ASSERT_GE(row_splits.Dim(), 1);
-        arrays_vec[num_array - 1] = row_splits;
-        arrays[num_array - 1] = &arrays_vec[num_array - 1];
-      }
-      const Array1<int32_t> **src = arrays.data();
-      Array1<int32_t> dst = SpliceRowSplits(num_array, src);
-      EXPECT_EQ(dst.Dim(), expected_data.size());
-      // copy memory from GPU/CPU to CPU
-      dst = dst.To(cpu);
-      std::vector<int32_t> cpu_data(dst.Data(), dst.Data() + dst.Dim());
-      EXPECT_EQ(cpu_data, expected_data);
-    }
-  }
+  TestAppend<int32_t>();
+  TestAppend<float>();
 }
 
 TEST(OpsTest, SpliceRowSplitsTest) {
-  TestSpliceRowSplits<kCpu>();
-  TestSpliceRowSplits<kCuda>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // a case with small size
+      std::vector<int32_t> data1 = {0, 2, 5};
+      std::vector<int32_t> data2 = {0, 2, 2, 3};
+      std::vector<int32_t> data3 = {0};
+      std::vector<int32_t> data4 = {0, 3};
+      std::vector<int32_t> expected_data = {0, 2, 5, 7, 7, 8, 11};
+
+      Array1<int32_t> array1(context, data1);
+      Array1<int32_t> array2(context, data2);
+      Array1<int32_t> array3(context, data3);
+      Array1<int32_t> array4(context, data4);
+
+      std::vector<const Array1<int32_t> *> arrays = {&array1, &array2, &array3,
+                                                     &array4};
+      const Array1<int32_t> **src = arrays.data();
+      Array1<int32_t> dst = SpliceRowSplits(4, src);
+      EXPECT_EQ(dst.Dim(), expected_data.size());
+      // copy memory from GPU/CPU to CPU
+      dst = dst.To(cpu);
+      std::vector<int32_t> cpu_data(dst.Data(), dst.Data() + dst.Dim());
+      EXPECT_EQ(cpu_data, expected_data);
+    }
+
+    {
+      // test with random large size, the arrays' sizes are fairly balanced.
+      for (int32_t i = 0; i != 2; ++i) {
+        int32_t num_array = RandInt(10, 1000);
+        std::vector<Array1<int32_t>> arrays_vec(num_array);
+        std::vector<const Array1<int32_t> *> arrays(num_array);
+        std::vector<int32_t> expected_data;
+        int32_t data_offset = 0;
+        for (int32_t j = 0; j != num_array; ++j) {
+          int32_t curr_array_size = RandInt(0, 10000);
+          RaggedShape shape =
+              RandomRaggedShape(false, 2, 2, curr_array_size, curr_array_size);
+          ASSERT_EQ(shape.NumAxes(), 2);
+          Array1<int32_t> cpu_row_splits = shape.RowSplits(1).To(cpu);
+          int32_t num_splits = cpu_row_splits.Dim();
+          ASSERT_GE(num_splits, 1);
+          const int32_t *splits_data = cpu_row_splits.Data();
+          for (int32_t n = 0; n < num_splits; ++n) {
+            expected_data.push_back(splits_data[n] + data_offset);
+          }
+          if (j + 1 < num_array) expected_data.pop_back();
+          data_offset += splits_data[num_splits - 1];
+          Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
+          ASSERT_GE(row_splits.Dim(), 1);
+          arrays_vec[j] = row_splits;
+          arrays[j] = &arrays_vec[j];
+        }
+        const Array1<int32_t> **src = arrays.data();
+        Array1<int32_t> dst = SpliceRowSplits(num_array, src);
+        EXPECT_EQ(dst.Dim(), expected_data.size());
+        // copy memory from GPU/CPU to CPU
+        dst = dst.To(cpu);
+        std::vector<int32_t> cpu_data(dst.Data(), dst.Data() + dst.Dim());
+        EXPECT_EQ(cpu_data, expected_data);
+      }
+    }
+
+    {
+      // test with random large size: the arrays' sizes are not balanced.
+      for (int32_t i = 0; i != 2; ++i) {
+        int32_t num_array = RandInt(10, 1000);
+        std::vector<Array1<int32_t>> arrays_vec(num_array);
+        std::vector<const Array1<int32_t> *> arrays(num_array);
+        std::vector<int32_t> expected_data;
+        int32_t data_offset = 0;
+        int32_t max_size = 0;
+        for (int32_t j = 0; j != num_array - 1; ++j) {
+          int32_t curr_array_size = RandInt(0, 10000);
+          RaggedShape shape =
+              RandomRaggedShape(false, 2, 2, curr_array_size, curr_array_size);
+          ASSERT_EQ(shape.NumAxes(), 2);
+          Array1<int32_t> cpu_row_splits = shape.RowSplits(1).To(cpu);
+          int32_t num_splits = cpu_row_splits.Dim();
+          ASSERT_GE(num_splits, 1);
+          const int32_t *splits_data = cpu_row_splits.Data();
+          for (int32_t n = 0; n < num_splits; ++n) {
+            expected_data.push_back(splits_data[n] + data_offset);
+          }
+          expected_data.pop_back();
+          data_offset += splits_data[num_splits - 1];
+          Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
+          ASSERT_GE(row_splits.Dim(), 1);
+          arrays_vec[j] = row_splits;
+          arrays[j] = &arrays_vec[j];
+          if (num_splits > max_size) max_size = num_splits;
+        }
+        // generate an array with very large size
+        {
+          int32_t total_size = static_cast<int32_t>(expected_data.size());
+          int32_t average_size = total_size / num_array;
+          int32_t long_size = average_size * 10;
+
+          RaggedShape shape =
+              RandomRaggedShape(false, 2, 2, long_size, long_size);
+          ASSERT_EQ(shape.NumAxes(), 2);
+          Array1<int32_t> cpu_row_splits = shape.RowSplits(1).To(cpu);
+          int32_t num_splits = cpu_row_splits.Dim();
+          ASSERT_GE(num_splits, 1);
+          const int32_t *splits_data = cpu_row_splits.Data();
+          for (int32_t n = 0; n < num_splits; ++n) {
+            expected_data.push_back(splits_data[n] + data_offset);
+          }
+          Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
+          ASSERT_GE(row_splits.Dim(), 1);
+          arrays_vec[num_array - 1] = row_splits;
+          arrays[num_array - 1] = &arrays_vec[num_array - 1];
+        }
+        const Array1<int32_t> **src = arrays.data();
+        Array1<int32_t> dst = SpliceRowSplits(num_array, src);
+        EXPECT_EQ(dst.Dim(), expected_data.size());
+        // copy memory from GPU/CPU to CPU
+        dst = dst.To(cpu);
+        std::vector<int32_t> cpu_data(dst.Data(), dst.Data() + dst.Dim());
+        EXPECT_EQ(cpu_data, expected_data);
+      }
+    }
+  }
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestRangeAndRandomArray1() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // test Range with small size
+      Array1<T> result = Range<T>(context, 6, 3, 2);
+      const std::vector<T> values = {3, 5, 7, 9, 11, 13};
+      result = result.To(cpu);
+      std::vector<T> cpu_data(result.Data(), result.Data() + result.Dim());
+      EXPECT_EQ(cpu_data, values);
+    }
 
-  {
-    // test Range with small size
-    Array1<T> result = Range<T>(context, 6, 3, 2);
-    const std::vector<T> values = {3, 5, 7, 9, 11, 13};
-    result = result.To(cpu);
-    std::vector<T> cpu_data(result.Data(), result.Data() + result.Dim());
-    EXPECT_EQ(cpu_data, values);
-  }
+    {
+      // test Range with random large size
+      int32_t num_elems = RandInt(1000, 10000);
+      std::vector<T> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> result = Range<T>(context, num_elems, 0);
+      result = result.To(cpu);
+      std::vector<T> cpu_data(result.Data(), result.Data() + result.Dim());
+      EXPECT_EQ(cpu_data, data);
+    }
 
-  {
-    // test Range with random large size
-    int32_t num_elems = RandInt(1000, 10000);
-    std::vector<T> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> result = Range<T>(context, num_elems, 0);
-    result = result.To(cpu);
-    std::vector<T> cpu_data(result.Data(), result.Data() + result.Dim());
-    EXPECT_EQ(cpu_data, data);
-  }
-
-  {
-    // test RandUniformArray1
-    Array1<T> result = RandUniformArray1<T>(context, 1000, 0, 10000);
-    result = result.To(cpu);
+    {
+      // test RandUniformArray1
+      Array1<T> result = RandUniformArray1<T>(context, 1000, 0, 10000);
+      result = result.To(cpu);
+    }
   }
 }
 
 TEST(OpsTest, RangeTest) {
-  TestRangeAndRandomArray1<int32_t, kCpu>();
-  TestRangeAndRandomArray1<int32_t, kCuda>();
-  TestRangeAndRandomArray1<float, kCpu>();
-  TestRangeAndRandomArray1<float, kCuda>();
-  TestRangeAndRandomArray1<double, kCpu>();
-  TestRangeAndRandomArray1<double, kCuda>();
+  TestRangeAndRandomArray1<int32_t>();
+  TestRangeAndRandomArray1<float>();
+  TestRangeAndRandomArray1<double>();
 }
 
-template <DeviceType d>
-void TestValidateRowSplitsAndIds() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // test RowSplitsToRowIds and RowIdsToRowSplits
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
+TEST(OpsTest, ValidateRowSplitsAndIdsTest) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     {
-      Array1<int32_t> row_splits(context, row_splits_vec);
-      Array1<int32_t> row_ids(context, row_ids_vec.size());
-      RowSplitsToRowIds(row_splits, &row_ids);
-      row_ids = row_ids.To(cpu);
-      std::vector<int32_t> cpu_data(row_ids.Data(),
-                                    row_ids.Data() + row_ids.Dim());
-      EXPECT_EQ(cpu_data, row_ids_vec);
+      // test RowSplitsToRowIds and RowIdsToRowSplits
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      {
+        Array1<int32_t> row_splits(context, row_splits_vec);
+        Array1<int32_t> row_ids(context, row_ids_vec.size());
+        RowSplitsToRowIds(row_splits, &row_ids);
+        row_ids = row_ids.To(cpu);
+        std::vector<int32_t> cpu_data(row_ids.Data(),
+                                      row_ids.Data() + row_ids.Dim());
+        EXPECT_EQ(cpu_data, row_ids_vec);
+      }
+      {
+        Array1<int32_t> row_ids(context, row_ids_vec);
+        Array1<int32_t> row_splits(context, row_splits_vec.size());
+        RowIdsToRowSplits(row_ids, &row_splits);
+        row_splits = row_splits.To(cpu);
+        std::vector<int32_t> cpu_data(row_splits.Data(),
+                                      row_splits.Data() + row_splits.Dim());
+        EXPECT_EQ(cpu_data, row_splits_vec);
+      }
     }
+
     {
+      // empty case for row splits and row ids
+      const std::vector<int32_t> row_splits_vec;
+      const std::vector<int32_t> row_ids_vec;
       Array1<int32_t> row_ids(context, row_ids_vec);
-      Array1<int32_t> row_splits(context, row_splits_vec.size());
-      RowIdsToRowSplits(row_ids, &row_splits);
-      row_splits = row_splits.To(cpu);
-      std::vector<int32_t> cpu_data(row_splits.Data(),
-                                    row_splits.Data() + row_splits.Dim());
-      EXPECT_EQ(cpu_data, row_splits_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_FALSE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
     }
-  }
 
-  {
-    // empty case for row splits and row ids
-    const std::vector<int32_t> row_splits_vec;
-    const std::vector<int32_t> row_ids_vec;
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_FALSE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // valid case for row splits and row ids
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_TRUE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_TRUE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // valid case for row splits and row ids with random size
-    for (int32_t i = 0; i != 5; ++i) {
-      RaggedShape shape = RandomRaggedShape(true, 2, 2, 2000, 10000);
-      ASSERT_EQ(shape.NumAxes(), 2);
-      // note shape is on CPU
-      Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
-      Array1<int32_t> row_ids = shape.RowIds(1).To(context);
-
+    {
+      // valid case for row splits and row ids
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
       EXPECT_TRUE(ValidateRowSplits(row_splits));
       EXPECT_TRUE(ValidateRowIds(row_ids));
       EXPECT_TRUE(ValidateRowSplitsAndIds(row_splits, row_ids));
     }
-  }
-
-  {
-    // provided tmp storage
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
 
     {
-      Array1<int32_t> tmp(context, 3, 2);
-      EXPECT_TRUE(ValidateRowSplits(row_splits, &tmp));
-      // check elments
-      tmp = tmp.To(cpu);
-      std::vector<int32_t> cpu_data(tmp.Data(), tmp.Data() + tmp.Dim());
-      EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 2, 2));
-    }
+      // valid case for row splits and row ids with random size
+      for (int32_t i = 0; i != 5; ++i) {
+        RaggedShape shape = RandomRaggedShape(true, 2, 2, 2000, 10000);
+        ASSERT_EQ(shape.NumAxes(), 2);
+        // note shape is on CPU
+        Array1<int32_t> row_splits = shape.RowSplits(1).To(context);
+        Array1<int32_t> row_ids = shape.RowIds(1).To(context);
 
-    {
-      Array1<int32_t> tmp(context, 3, 2);
-      EXPECT_TRUE(ValidateRowIds(row_ids, &tmp));
-      // check elments
-      tmp = tmp.To(cpu);
-      std::vector<int32_t> cpu_data(tmp.Data(), tmp.Data() + tmp.Dim());
-      EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 2, 2));
-    }
-
-    {
-      Array1<int32_t> tmp(context, 3, 2);
-      EXPECT_TRUE(ValidateRowSplitsAndIds(row_splits, row_ids, &tmp));
-      // check elments
-      tmp = tmp.To(cpu);
-      std::vector<int32_t> cpu_data(tmp.Data(), tmp.Data() + tmp.Dim());
-      EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 2, 2));
-    }
-  }
-
-  {
-    // bad case for row splits, not starts with 0
-    const std::vector<int32_t> row_splits_vec = {1,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_FALSE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // bad case for row splits, contains negative value
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  -5, 8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_FALSE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // bad case for row splits, not non-decreasing
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  1,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_FALSE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // bad case row ids, contains negative value
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, -2, 3, 3, 3,
-                                              4, 5, 5, 5, 6,  7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_TRUE(ValidateRowSplits(row_splits));
-    EXPECT_FALSE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // bad case row ids, not non-decreasing
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 6, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_TRUE(ValidateRowSplits(row_splits));
-    EXPECT_FALSE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // bad case row ids and row splits don't agree with each other
-    // i < row_splits[row_ids[i]]
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 8, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_TRUE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // another bad case that row ids and row splits don't agree with each other
-    // i > = row_splits[row_ids[i]]
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 5, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_TRUE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-
-  {
-    // bad case for row ids, num_elems != row_splits[-1]
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    EXPECT_TRUE(ValidateRowSplits(row_splits));
-    EXPECT_TRUE(ValidateRowIds(row_ids));
-    EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
-  }
-}
-
-TEST(OpsTest, ValidateRowSplitsAndIdsTest) {
-  TestValidateRowSplitsAndIds<kCpu>();
-  TestValidateRowSplitsAndIds<kCuda>();
-}
-
-template <DeviceType d>
-void TestGetCounts() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // empty case
-    int32_t n = 0;
-    std::vector<int32_t> values;
-    Array1<int32_t> src(context, values);
-    Array1<int32_t> ans = GetCounts(src, n);
-    EXPECT_EQ(ans.Dim(), 0);
-  }
-
-  {
-    // simple case
-    int32_t n = 8;
-    std::vector<int32_t> values = {0, 1, 2, 1, 5, 5, 7, 6, 3, 2};
-    std::vector<int32_t> expected_data = {1, 2, 2, 1, 0, 2, 1, 1};
-    Array1<int32_t> src(context, values);
-    Array1<int32_t> ans = GetCounts(src, n);
-    ans = ans.To(cpu);
-    std::vector<int32_t> data(ans.Data(), ans.Data() + ans.Dim());
-    EXPECT_EQ(data, expected_data);
-  }
-
-  {
-    // random large case
-    for (int32_t i = 0; i != 2; ++i) {
-      int32_t n = RandInt(1, 10000);
-      int32_t src_dim = RandInt(0, 10000);
-      Array1<int32_t> src = RandUniformArray1(context, src_dim, 0, n - 1);
-      Array1<int32_t> ans = GetCounts(src, n);
-      ans = ans.To(cpu);
-      std::vector<int32_t> data(ans.Data(), ans.Data() + ans.Dim());
-      src = src.To(cpu);
-      int32_t *src_data = src.Data();
-      std::vector<int32_t> expected_data(n, 0);
-      for (int32_t j = 0; j < src.Dim(); ++j) {
-        ++expected_data[src_data[j]];
+        EXPECT_TRUE(ValidateRowSplits(row_splits));
+        EXPECT_TRUE(ValidateRowIds(row_ids));
+        EXPECT_TRUE(ValidateRowSplitsAndIds(row_splits, row_ids));
       }
-      EXPECT_EQ(data, expected_data);
+    }
+
+    {
+      // provided tmp storage
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+
+      {
+        Array1<int32_t> tmp(context, 3, 2);
+        EXPECT_TRUE(ValidateRowSplits(row_splits, &tmp));
+        // check elments
+        tmp = tmp.To(cpu);
+        std::vector<int32_t> cpu_data(tmp.Data(), tmp.Data() + tmp.Dim());
+        EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 2, 2));
+      }
+
+      {
+        Array1<int32_t> tmp(context, 3, 2);
+        EXPECT_TRUE(ValidateRowIds(row_ids, &tmp));
+        // check elments
+        tmp = tmp.To(cpu);
+        std::vector<int32_t> cpu_data(tmp.Data(), tmp.Data() + tmp.Dim());
+        EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 2, 2));
+      }
+
+      {
+        Array1<int32_t> tmp(context, 3, 2);
+        EXPECT_TRUE(ValidateRowSplitsAndIds(row_splits, row_ids, &tmp));
+        // check elments
+        tmp = tmp.To(cpu);
+        std::vector<int32_t> cpu_data(tmp.Data(), tmp.Data() + tmp.Dim());
+        EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 2, 2));
+      }
+    }
+
+    {
+      // bad case for row splits, not starts with 0
+      const std::vector<int32_t> row_splits_vec = {1,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_FALSE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // bad case for row splits, contains negative value
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  -5, 8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_FALSE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // bad case for row splits, not non-decreasing
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  1,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_FALSE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // bad case row ids, contains negative value
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, -2, 3, 3, 3,
+                                                4, 5, 5, 5, 6,  7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_TRUE(ValidateRowSplits(row_splits));
+      EXPECT_FALSE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // bad case row ids, not non-decreasing
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 6, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_TRUE(ValidateRowSplits(row_splits));
+      EXPECT_FALSE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // bad case row ids and row splits don't agree with each other
+      // i < row_splits[row_ids[i]]
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 8, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_TRUE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // another bad case that row ids and row splits don't agree with each
+      // other i > = row_splits[row_ids[i]]
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 5, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_TRUE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
+    }
+
+    {
+      // bad case for row ids, num_elems != row_splits[-1]
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      EXPECT_TRUE(ValidateRowSplits(row_splits));
+      EXPECT_TRUE(ValidateRowIds(row_ids));
+      EXPECT_FALSE(ValidateRowSplitsAndIds(row_splits, row_ids));
     }
   }
 }
 
 TEST(OpsTest, GetCountsTest) {
-  TestGetCounts<kCpu>();
-  TestGetCounts<kCuda>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // empty case
+      int32_t n = 0;
+      std::vector<int32_t> values;
+      Array1<int32_t> src(context, values);
+      Array1<int32_t> ans = GetCounts(src, n);
+      EXPECT_EQ(ans.Dim(), 0);
+    }
+
+    {
+      // simple case
+      int32_t n = 8;
+      std::vector<int32_t> values = {0, 1, 2, 1, 5, 5, 7, 6, 3, 2};
+      std::vector<int32_t> expected_data = {1, 2, 2, 1, 0, 2, 1, 1};
+      Array1<int32_t> src(context, values);
+      Array1<int32_t> ans = GetCounts(src, n);
+      ans = ans.To(cpu);
+      std::vector<int32_t> data(ans.Data(), ans.Data() + ans.Dim());
+      EXPECT_EQ(data, expected_data);
+    }
+
+    {
+      // random large case
+      for (int32_t i = 0; i != 2; ++i) {
+        int32_t n = RandInt(1, 10000);
+        int32_t src_dim = RandInt(0, 10000);
+        Array1<int32_t> src = RandUniformArray1(context, src_dim, 0, n - 1);
+        Array1<int32_t> ans = GetCounts(src, n);
+        ans = ans.To(cpu);
+        std::vector<int32_t> data(ans.Data(), ans.Data() + ans.Dim());
+        src = src.To(cpu);
+        int32_t *src_data = src.Data();
+        std::vector<int32_t> expected_data(n, 0);
+        for (int32_t j = 0; j < src.Dim(); ++j) {
+          ++expected_data[src_data[j]];
+        }
+        EXPECT_EQ(data, expected_data);
+      }
+    }
+  }
 }
 
-template <DeviceType d, typename S, typename T>
+template <typename S, typename T>
 void TestMonotonicLowerBound() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // empty case
+      std::vector<S> values;
+      Array1<S> src(context, values);
+      Array1<T> dest(context, 0);
+      MonotonicLowerBound(src, &dest);
+      EXPECT_EQ(dest.Dim(), 0);
+    }
 
-  {
-    // empty case
-    std::vector<S> values;
-    Array1<S> src(context, values);
-    Array1<T> dest(context, 0);
-    MonotonicLowerBound(src, &dest);
-    EXPECT_EQ(dest.Dim(), 0);
-  }
-
-  {
-    // simple case
-    std::vector<S> values = {2, 1, 3, 7, 5, 8, 20, 15};
-    std::vector<T> expected_data = {1, 1, 3, 5, 5, 8, 15, 15};
-    ASSERT_EQ(values.size(), expected_data.size());
-    Array1<S> src(context, values);
-    Array1<T> dest(context, static_cast<int32_t>(values.size()));
-    MonotonicLowerBound(src, &dest);
-    dest = dest.To(cpu);
-    std::vector<T> data(dest.Data(), dest.Data() + dest.Dim());
-    EXPECT_EQ(data, expected_data);
-  }
-
-  {
-    // simple case with dest = &src
-    std::vector<S> values = {2, 1, 3, 7, 5, 8, 20, 15};
-    std::vector<T> expected_data = {1, 1, 3, 5, 5, 8, 15, 15};
-    ASSERT_EQ(values.size(), expected_data.size());
-    Array1<S> src(context, values);
-    MonotonicLowerBound(src, &src);
-    src = src.To(cpu);
-    std::vector<T> data(src.Data(), src.Data() + src.Dim());
-    EXPECT_EQ(data, expected_data);
-  }
-
-  {
-    // random large case
-    for (int32_t i = 0; i != 2; ++i) {
-      int32_t n = RandInt(1, 10000);
-      int32_t src_dim = RandInt(0, 10000);
-      Array1<S> src = RandUniformArray1(context, src_dim, 0, n - 1);
-      Array1<T> dest(context, src_dim);
+    {
+      // simple case
+      std::vector<S> values = {2, 1, 3, 7, 5, 8, 20, 15};
+      std::vector<T> expected_data = {1, 1, 3, 5, 5, 8, 15, 15};
+      ASSERT_EQ(values.size(), expected_data.size());
+      Array1<S> src(context, values);
+      Array1<T> dest(context, static_cast<int32_t>(values.size()));
       MonotonicLowerBound(src, &dest);
       dest = dest.To(cpu);
       std::vector<T> data(dest.Data(), dest.Data() + dest.Dim());
-      src = src.To(cpu);
-      int32_t *src_data = src.Data();
-      S min_value = std::numeric_limits<S>::max();
-      std::vector<T> expected_data(src_dim);
-      for (int32_t i = src_dim - 1; i >= 0; --i) {
-        min_value = std::min(src_data[i], min_value);
-        expected_data[i] = min_value;
-      }
       EXPECT_EQ(data, expected_data);
     }
+
+    {
+      // simple case with dest = &src
+      std::vector<S> values = {2, 1, 3, 7, 5, 8, 20, 15};
+      std::vector<T> expected_data = {1, 1, 3, 5, 5, 8, 15, 15};
+      ASSERT_EQ(values.size(), expected_data.size());
+      Array1<S> src(context, values);
+      MonotonicLowerBound(src, &src);
+      src = src.To(cpu);
+      std::vector<T> data(src.Data(), src.Data() + src.Dim());
+      EXPECT_EQ(data, expected_data);
+    }
+
+    {
+      // random large case
+      for (int32_t i = 0; i != 2; ++i) {
+        int32_t n = RandInt(1, 10000);
+        int32_t src_dim = RandInt(0, 10000);
+        Array1<S> src = RandUniformArray1(context, src_dim, 0, n - 1);
+        Array1<T> dest(context, src_dim);
+        MonotonicLowerBound(src, &dest);
+        dest = dest.To(cpu);
+        std::vector<T> data(dest.Data(), dest.Data() + dest.Dim());
+        src = src.To(cpu);
+        int32_t *src_data = src.Data();
+        S min_value = std::numeric_limits<S>::max();
+        std::vector<T> expected_data(src_dim);
+        for (int32_t i = src_dim - 1; i >= 0; --i) {
+          min_value = std::min(src_data[i], min_value);
+          expected_data[i] = min_value;
+        }
+        EXPECT_EQ(data, expected_data);
+      }
+    }
   }
+}
+
+TEST(OpsTest, MonotonicLowerBoundTest) {
+  TestMonotonicLowerBound<int32_t, int32_t>();
+  TestMonotonicLowerBound<int32_t, double>();
 }
 
 TEST(OpsTest, Array1IndexTest) {
@@ -1371,13 +1293,6 @@ TEST(OpsTest, Array2IndexTest) {
       }
     }
   }
-}
-
-TEST(OpsTest, MonotonicLowerBoundTest) {
-  TestMonotonicLowerBound<kCpu, int32_t, int32_t>();
-  TestMonotonicLowerBound<kCuda, int32_t, int32_t>();
-  TestMonotonicLowerBound<kCpu, int32_t, double>();
-  TestMonotonicLowerBound<kCuda, int32_t, double>();
 }
 
 }  // namespace k2

--- a/k2/csrc/array_test.cu
+++ b/k2/csrc/array_test.cu
@@ -39,643 +39,634 @@ void CheckArrayEqual(const Array1<T> &a, const Array1<T> &b) {
   Eval(a.Context(), n, compare);
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestArray1() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // created with Array1(ContextPtr ctx, int32_t size), test Array1.Data()
-    Array1<T> array(context, 5);
-    ASSERT_EQ(array.Dim(), 5);
-    std::vector<T> data(array.Dim());
-    std::iota(data.begin(), data.end(), 0);
-    T *array_data = array.Data();
-    // copy data from CPU to CPU/GPU
-    auto kind = GetMemoryCopyKind(*cpu, *array.Context());
-    MemoryCopy(static_cast<void *>(array_data),
-               static_cast<void *>(data.data()),
-               array.Dim() * array.ElementSize(), kind, nullptr);
-    for (int32_t i = 0; i < array.Dim(); ++i) {
-      EXPECT_EQ(array[i], i);
-    }
-  }
-
-  {
-    // test operator=(T t) and "operator[](int32_t i) const"
-    Array1<T> array(context, 5);
-    ASSERT_EQ(array.Dim(), 5);
-    // operator=(T t)
-    array = 2;
-    for (int32_t i = 0; i < array.Dim(); ++i) {
-      EXPECT_EQ(array[i], 2);
-    }
-  }
-
-  {
-    // test Back()"
-    std::vector<T> data(5);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> array(context, data);
-    EXPECT_EQ(array.Back(), 4);
-  }
-
-  {
-    // created with Array1(ContextPtr, int32_t size, T elem)
-    Array1<T> array(context, 5, T(2));
-    ASSERT_EQ(array.Dim(), 5);
-    // copy data from CPU/GPU to CPU
-    for (int32_t i = 0; i < array.Dim(); ++i) {
-      EXPECT_EQ(array[i], 2);
-    }
-  }
-
-  {
-    // created with Array1(ContextPtr, int32_t size, Callable &&callable)
-    auto lambda_set_values = [] __host__ __device__(int32_t i) -> T {
-      return i * i;
-    };
-    Array1<T> array(context, 5, lambda_set_values);
-    ASSERT_EQ(array.Dim(), 5);
-    for (int32_t i = 0; i < array.Dim(); ++i) {
-      EXPECT_EQ(array[i], i * i);
-    }
-  }
-
-  {
-    // created with Array(ContextPtr, const std:vector<T>&)
-    std::vector<T> data(5);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> array(context, data);
-    ASSERT_EQ(array.Dim(), 5);
-    for (int32_t i = 0; i < array.Dim(); ++i) {
-      EXPECT_EQ(array[i], data[i]);
-    }
-  }
-
-  {
-    // test Range(start, size)
-    std::vector<T> data(10);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> array(context, data);
-    int32_t start = 2;
-    int32_t size = 6;
-    Array1<T> sub_array = array.Range(start, size);
-    ASSERT_EQ(sub_array.Dim(), size);
-    for (int32_t i = 0; i < sub_array.Dim(); ++i) {
-      EXPECT_EQ(sub_array[i], data[i + start]);
-    }
-  }
-
-  {
-    // test Range(start, size, inc)
-    std::vector<T> data(20);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> array(context, data);
-    int32_t start = 3;
-    int32_t size = 8;
-    int32_t inc = 2;
-    Tensor sub_tensor = array.Range(start, size, inc);
-    Dtype type = DtypeOf<T>::dtype;
-    EXPECT_EQ(sub_tensor.GetDtype(), type);
-    Shape shape = sub_tensor.GetShape();
-    EXPECT_EQ(shape.NumAxes(), 1);
-    EXPECT_EQ(shape.Nelement(), size);
-    EXPECT_EQ(shape.StorageSize(), (size - 1) * inc + 1);
-    EXPECT_EQ(shape.Dim(0), size);
-    EXPECT_EQ(shape.Stride(0), inc);
-    // copy data from CPU/GPU to CPU
-    const T *sub_tensor_data = sub_tensor.Data<T>();
-    auto kind = GetMemoryCopyKind(*(sub_tensor.GetRegion()->context), *cpu);
-    std::vector<T> cpu_data(shape.StorageSize());
-    MemoryCopy(static_cast<void *>(cpu_data.data()),
-               static_cast<const void *>(sub_tensor_data),
-               shape.StorageSize() * TraitsOf(sub_tensor.GetDtype()).NumBytes(),
-               kind, nullptr);
-    int32_t dim0 = shape.Dim(0);
-    int32_t stride0 = shape.Stride(0);
-    for (int32_t i = 0, j = start; i < dim0; ++i, j += inc) {
-      EXPECT_EQ(cpu_data[i * stride0], data[j]);
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // created with Array1(ContextPtr ctx, int32_t size), test Array1.Data()
+      Array1<T> array(context, 5);
+      ASSERT_EQ(array.Dim(), 5);
+      std::vector<T> data(array.Dim());
+      std::iota(data.begin(), data.end(), 0);
+      T *array_data = array.Data();
+      // copy data from CPU to CPU/GPU
+      auto kind = GetMemoryCopyKind(*cpu, *array.Context());
+      MemoryCopy(static_cast<void *>(array_data),
+                 static_cast<void *>(data.data()),
+                 array.Dim() * array.ElementSize(), kind, nullptr);
+      for (int32_t i = 0; i < array.Dim(); ++i) {
+        EXPECT_EQ(array[i], i);
+      }
     }
 
-    Array1<T> arr(sub_tensor);
-    ASSERT_EQ(arr.Dim(), dim0);
-    for (int32_t i = 0, j = start; i < dim0; ++i, j += inc) {
-      EXPECT_EQ(arr[i], data[j]);
+    {
+      // test operator=(T t) and "operator[](int32_t i) const"
+      Array1<T> array(context, 5);
+      ASSERT_EQ(array.Dim(), 5);
+      // operator=(T t)
+      array = 2;
+      for (int32_t i = 0; i < array.Dim(); ++i) {
+        EXPECT_EQ(array[i], 2);
+      }
     }
-  }
 
-  {
-    // test ToTensor
-    int32_t size = 20;
-    std::vector<T> data(size);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> array(context, data);
-    Tensor tensor = array.ToTensor();
-    Dtype type = DtypeOf<T>::dtype;
-    EXPECT_EQ(tensor.GetDtype(), type);
-    Shape shape = tensor.GetShape();
-    EXPECT_EQ(shape.NumAxes(), 1);
-    EXPECT_EQ(shape.Nelement(), size);
-    EXPECT_EQ(shape.StorageSize(), size);
-    EXPECT_EQ(shape.Dim(0), size);
-    EXPECT_EQ(shape.Stride(0), 1);
-    // copy data from CPU/GPU to CPU
-    const T *tensor_data = tensor.Data<T>();
-    auto kind = GetMemoryCopyKind(*(tensor.GetRegion()->context), *cpu);
-    std::vector<T> cpu_data(shape.StorageSize());
-    MemoryCopy(static_cast<void *>(cpu_data.data()),
-               static_cast<const void *>(tensor_data),
-               shape.StorageSize() * TraitsOf(tensor.GetDtype()).NumBytes(),
-               kind, nullptr);
-    int32_t dim0 = shape.Dim(0);
-    int32_t stride0 = shape.Stride(0);
-    for (int32_t i = 0, j = 0; i < dim0; ++i, ++j) {
-      EXPECT_EQ(cpu_data[i * stride0], data[j]);
+    {
+      // test Back()"
+      std::vector<T> data(5);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> array(context, data);
+      EXPECT_EQ(array.Back(), 4);
     }
-  }
 
-  {
-    // test To(context)
-    std::vector<T> data = {0, 1, 2, 3};
-    Array1<T> cpu_array(cpu, data);
-    Array1<T> cuda_array(GetCudaContext(), data);
-
-    Array1<T> src(context, data);
-    auto cpu_dst = src.To(cpu);
-    auto cuda_dst = src.To(GetCudaContext());
-
-    CheckArrayEqual(cpu_array, cpu_dst);
-    CheckArrayEqual(cuda_array, cuda_dst);
-  }
-
-  {
-    // test operator <<
-    std::vector<T> data = {0, 1, 2, 3};
-    Array1<T> src(context, data);
-    K2_LOG(INFO) << src;
-  }
-
-  {
-    // test operator[](const Array1<int32_t> &indexes) const
-    std::vector<T> data(20);
-    std::iota(data.begin(), data.end(), 1);
-    Array1<T> array(context, data);
-    std::vector<int32_t> indexes = {0, 1, 2, 5, 1, 6, 8, 9, 2, 4, 6, 3};
-    Array1<int32_t> indexes_array(context, indexes);
-    std::vector<T> expected_data = {1, 2, 3, 6, 2, 7, 9, 10, 3, 5, 7, 4};
-    Array1<T> ans_array = array[indexes_array];
-    ASSERT_EQ(ans_array.Dim(), expected_data.size());
-    for (int32_t i = 0; i < ans_array.Dim(); ++i) {
-      EXPECT_EQ(ans_array[i], expected_data[i]);
+    {
+      // created with Array1(ContextPtr, int32_t size, T elem)
+      Array1<T> array(context, 5, T(2));
+      ASSERT_EQ(array.Dim(), 5);
+      // copy data from CPU/GPU to CPU
+      for (int32_t i = 0; i < array.Dim(); ++i) {
+        EXPECT_EQ(array[i], 2);
+      }
     }
-  }
 
-  {
-    // test Resize
-    std::vector<T> data(5);
-    std::iota(data.begin(), data.end(), 1);
-    Array1<T> array(context, data);
-    EXPECT_EQ(array.Dim(), data.size());
+    {
+      // created with Array1(ContextPtr, int32_t size, Callable &&callable)
+      auto lambda_set_values = [] __host__ __device__(int32_t i) -> T {
+        return i * i;
+      };
+      Array1<T> array(context, 5, lambda_set_values);
+      ASSERT_EQ(array.Dim(), 5);
+      for (int32_t i = 0; i < array.Dim(); ++i) {
+        EXPECT_EQ(array[i], i * i);
+      }
+    }
 
-    // new_size <= array.Dim()
-    int32_t new_size = 3;
-    array.Resize(new_size);
-    EXPECT_EQ(array.Dim(), new_size);
+    {
+      // created with Array(ContextPtr, const std:vector<T>&)
+      std::vector<T> data(5);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> array(context, data);
+      ASSERT_EQ(array.Dim(), 5);
+      for (int32_t i = 0; i < array.Dim(); ++i) {
+        EXPECT_EQ(array[i], data[i]);
+      }
+    }
 
-    // re-initialize...
-    array = Array1<T>(context, data);
-    // new_size > array.Dim()
-    new_size = 7;
-    array.Resize(new_size);
-    EXPECT_EQ(array.Dim(), new_size);
-    // new_size > array.Dim()
-    new_size = 8;
-    array.Resize(new_size);
-    EXPECT_EQ(array.Dim(), new_size);
-    // copy data from CPU/GPU to CPU
-    const T *array_data = array.Data();
-    // data.size() == 5, array.Dim() == 8, there are 3 uninitialized elements.
-    for (int32_t i = 0; i < data.size(); ++i) {
-      EXPECT_EQ(array[i], data[i]);
+    {
+      // test Range(start, size)
+      std::vector<T> data(10);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> array(context, data);
+      int32_t start = 2;
+      int32_t size = 6;
+      Array1<T> sub_array = array.Range(start, size);
+      ASSERT_EQ(sub_array.Dim(), size);
+      for (int32_t i = 0; i < sub_array.Dim(); ++i) {
+        EXPECT_EQ(sub_array[i], data[i + start]);
+      }
+    }
+
+    {
+      // test Range(start, size, inc)
+      std::vector<T> data(20);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> array(context, data);
+      int32_t start = 3;
+      int32_t size = 8;
+      int32_t inc = 2;
+      Tensor sub_tensor = array.Range(start, size, inc);
+      Dtype type = DtypeOf<T>::dtype;
+      EXPECT_EQ(sub_tensor.GetDtype(), type);
+      Shape shape = sub_tensor.GetShape();
+      EXPECT_EQ(shape.NumAxes(), 1);
+      EXPECT_EQ(shape.Nelement(), size);
+      EXPECT_EQ(shape.StorageSize(), (size - 1) * inc + 1);
+      EXPECT_EQ(shape.Dim(0), size);
+      EXPECT_EQ(shape.Stride(0), inc);
+      // copy data from CPU/GPU to CPU
+      const T *sub_tensor_data = sub_tensor.Data<T>();
+      auto kind = GetMemoryCopyKind(*(sub_tensor.GetRegion()->context), *cpu);
+      std::vector<T> cpu_data(shape.StorageSize());
+      MemoryCopy(
+          static_cast<void *>(cpu_data.data()),
+          static_cast<const void *>(sub_tensor_data),
+          shape.StorageSize() * TraitsOf(sub_tensor.GetDtype()).NumBytes(),
+          kind, nullptr);
+      int32_t dim0 = shape.Dim(0);
+      int32_t stride0 = shape.Stride(0);
+      for (int32_t i = 0, j = start; i < dim0; ++i, j += inc) {
+        EXPECT_EQ(cpu_data[i * stride0], data[j]);
+      }
+
+      Array1<T> arr(sub_tensor);
+      ASSERT_EQ(arr.Dim(), dim0);
+      for (int32_t i = 0, j = start; i < dim0; ++i, j += inc) {
+        EXPECT_EQ(arr[i], data[j]);
+      }
+    }
+
+    {
+      // test ToTensor
+      int32_t size = 20;
+      std::vector<T> data(size);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> array(context, data);
+      Tensor tensor = array.ToTensor();
+      Dtype type = DtypeOf<T>::dtype;
+      EXPECT_EQ(tensor.GetDtype(), type);
+      Shape shape = tensor.GetShape();
+      EXPECT_EQ(shape.NumAxes(), 1);
+      EXPECT_EQ(shape.Nelement(), size);
+      EXPECT_EQ(shape.StorageSize(), size);
+      EXPECT_EQ(shape.Dim(0), size);
+      EXPECT_EQ(shape.Stride(0), 1);
+      // copy data from CPU/GPU to CPU
+      const T *tensor_data = tensor.Data<T>();
+      auto kind = GetMemoryCopyKind(*(tensor.GetRegion()->context), *cpu);
+      std::vector<T> cpu_data(shape.StorageSize());
+      MemoryCopy(static_cast<void *>(cpu_data.data()),
+                 static_cast<const void *>(tensor_data),
+                 shape.StorageSize() * TraitsOf(tensor.GetDtype()).NumBytes(),
+                 kind, nullptr);
+      int32_t dim0 = shape.Dim(0);
+      int32_t stride0 = shape.Stride(0);
+      for (int32_t i = 0, j = 0; i < dim0; ++i, ++j) {
+        EXPECT_EQ(cpu_data[i * stride0], data[j]);
+      }
+    }
+
+    {
+      // test To(context)
+      std::vector<T> data = {0, 1, 2, 3};
+      Array1<T> cpu_array(cpu, data);
+      Array1<T> cuda_array(GetCudaContext(), data);
+
+      Array1<T> src(context, data);
+      auto cpu_dst = src.To(cpu);
+      auto cuda_dst = src.To(GetCudaContext());
+
+      CheckArrayEqual(cpu_array, cpu_dst);
+      CheckArrayEqual(cuda_array, cuda_dst);
+    }
+
+    {
+      // test operator <<
+      std::vector<T> data = {0, 1, 2, 3};
+      Array1<T> src(context, data);
+      K2_LOG(INFO) << src;
+    }
+
+    {
+      // test operator[](const Array1<int32_t> &indexes) const
+      std::vector<T> data(20);
+      std::iota(data.begin(), data.end(), 1);
+      Array1<T> array(context, data);
+      std::vector<int32_t> indexes = {0, 1, 2, 5, 1, 6, 8, 9, 2, 4, 6, 3};
+      Array1<int32_t> indexes_array(context, indexes);
+      std::vector<T> expected_data = {1, 2, 3, 6, 2, 7, 9, 10, 3, 5, 7, 4};
+      Array1<T> ans_array = array[indexes_array];
+      ASSERT_EQ(ans_array.Dim(), expected_data.size());
+      for (int32_t i = 0; i < ans_array.Dim(); ++i) {
+        EXPECT_EQ(ans_array[i], expected_data[i]);
+      }
+    }
+
+    {
+      // test Resize
+      std::vector<T> data(5);
+      std::iota(data.begin(), data.end(), 1);
+      Array1<T> array(context, data);
+      EXPECT_EQ(array.Dim(), data.size());
+
+      // new_size <= array.Dim()
+      int32_t new_size = 3;
+      array.Resize(new_size);
+      EXPECT_EQ(array.Dim(), new_size);
+
+      // re-initialize...
+      array = Array1<T>(context, data);
+      // new_size > array.Dim()
+      new_size = 7;
+      array.Resize(new_size);
+      EXPECT_EQ(array.Dim(), new_size);
+      // new_size > array.Dim()
+      new_size = 8;
+      array.Resize(new_size);
+      EXPECT_EQ(array.Dim(), new_size);
+      // copy data from CPU/GPU to CPU
+      const T *array_data = array.Data();
+      // data.size() == 5, array.Dim() == 8, there are 3 uninitialized elements.
+      for (int32_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(array[i], data[i]);
+      }
     }
   }
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestArray2() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // test To(context)
-    // case 1: contiguous
-    //
-    // 0 1 2
-    // 3 4 5
-    //
-    constexpr auto kDim0 = 2;
-    constexpr auto kDim1 = 3;
-    std::vector<T> data = {0, 1, 2, 3, 4, 5};
-    ASSERT_EQ(static_cast<int32_t>(data.size()), kDim0 * kDim1);
-
-    Array1<T> arr1(context, data);
-    Array2<T> array(arr1, kDim0, kDim1);
-
-    auto cpu_array = array.To(cpu);
-    auto cuda_array = array.To(GetCudaContext());
-
-    ASSERT_EQ(cpu_array.ElemStride0(), cpu_array.Dim1());
-    ASSERT_EQ(cuda_array.ElemStride0(), cuda_array.Dim1());
-
-    auto k = 0;
-    for (auto r = 0; r != kDim0; ++r)
-      for (auto c = 0; c != kDim1; ++c) {
-        // WARNING: it's inefficient to access elements of Array2
-        // with operator [][]
-        EXPECT_EQ(cpu_array[r][c], k);
-        EXPECT_EQ(cuda_array[r][c], k);
-        ++k;
-      }
-
-    // test operator <<
-    K2_LOG(INFO) << array;
-  }
-
-  {
-    // test To(context)
-    // case 2: non-contiguous
-    //
-    // 0 1 2 x x
-    // 3 4 5 x x
-    //
-    constexpr auto kDim0 = 2;
-    constexpr auto kDim1 = 3;
-    constexpr auto kElemStride0 = 5;
-    std::vector<T> data = {0, 1, 2, -1, -1, 3, 4, 5, -1, -1};
-    EXPECT_EQ(static_cast<int32_t>(data.size()), kDim0 * kElemStride0);
-
-    auto region = NewRegion(context, data.size() * sizeof(T));
-
-    auto dst = region->template GetData<T>();
-    auto kind = GetMemoryCopyKind(*cpu, *context);
-    MemoryCopy(static_cast<void *>(dst), static_cast<const void *>(data.data()),
-               data.size() * sizeof(T), kind, region->context.get());
-
-    Array2<T> array(kDim0, kDim1, kElemStride0, 0, region);
-
-    auto cpu_array = array.To(cpu);
-    auto cuda_array = array.To(GetCudaContext());
-
-    auto k = 0;
-    for (auto r = 0; r != kDim0; ++r)
-      for (auto c = 0; c != kDim1; ++c) {
-        // WARNING: it's inefficient to access elements of Array2
-        // with operator [][]
-        EXPECT_EQ(cpu_array[r][c], k);
-        EXPECT_EQ(cuda_array[r][c], k);
-        ++k;
-      }
-
-    // test operator <<
-    K2_LOG(INFO) << array;
-  }
-
-  {
-    // created with Array2(Array1, dim0, dim1), contiguous
-    std::vector<T> data(20);
-    std::iota(data.begin(), data.end(), 0);
-    Array1<T> array1(context, data);
-    Array2<T> array(array1, 4, 5);
-    EXPECT_EQ(array.Dim0(), 4);
-    EXPECT_EQ(array.Dim1(), 5);
-    EXPECT_EQ(array.ElemStride0(), 5);
-    T *array_data = array.Data();
-
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     {
-      // test Data()
-      const T *array_data = array.Data();
-      // copy data from CPU/GPU to CPU
-      int32_t elem_stride0 = array.ElemStride0();
-      int32_t num_element_copy = array.Dim0() * array.ElemStride0();
-      std::vector<T> cpu_data(num_element_copy);
-      auto kind = GetMemoryCopyKind(*array.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(array_data),
-                 num_element_copy * array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(cpu_data[i * elem_stride0 + j], data[n++]);
+      // test To(context)
+      // case 1: contiguous
+      //
+      // 0 1 2
+      // 3 4 5
+      //
+      constexpr auto kDim0 = 2;
+      constexpr auto kDim1 = 3;
+      std::vector<T> data = {0, 1, 2, 3, 4, 5};
+      ASSERT_EQ(static_cast<int32_t>(data.size()), kDim0 * kDim1);
+
+      Array1<T> arr1(context, data);
+      Array2<T> array(arr1, kDim0, kDim1);
+
+      auto cpu_array = array.To(cpu);
+      auto cuda_array = array.To(GetCudaContext());
+
+      ASSERT_EQ(cpu_array.ElemStride0(), cpu_array.Dim1());
+      ASSERT_EQ(cuda_array.ElemStride0(), cuda_array.Dim1());
+
+      auto k = 0;
+      for (auto r = 0; r != kDim0; ++r)
+        for (auto c = 0; c != kDim1; ++c) {
+          // WARNING: it's inefficient to access elements of Array2
+          // with operator [][]
+          EXPECT_EQ(cpu_array[r][c], k);
+          EXPECT_EQ(cuda_array[r][c], k);
+          ++k;
         }
-      }
+
+      // test operator <<
+      K2_LOG(INFO) << array;
     }
 
     {
-      // test operator[]
-      for (int32_t i = 0; i < array.Dim0(); ++i) {
-        Array1<T> sub_array = array[i];
+      // test To(context)
+      // case 2: non-contiguous
+      //
+      // 0 1 2 x x
+      // 3 4 5 x x
+      //
+      constexpr auto kDim0 = 2;
+      constexpr auto kDim1 = 3;
+      constexpr auto kElemStride0 = 5;
+      std::vector<T> data = {0, 1, 2, -1, -1, 3, 4, 5, -1, -1};
+      EXPECT_EQ(static_cast<int32_t>(data.size()), kDim0 * kElemStride0);
+
+      auto region = NewRegion(context, data.size() * sizeof(T));
+
+      auto dst = region->template GetData<T>();
+      auto kind = GetMemoryCopyKind(*cpu, *context);
+      MemoryCopy(static_cast<void *>(dst),
+                 static_cast<const void *>(data.data()),
+                 data.size() * sizeof(T), kind, region->context.get());
+
+      Array2<T> array(kDim0, kDim1, kElemStride0, 0, region);
+
+      auto cpu_array = array.To(cpu);
+      auto cuda_array = array.To(GetCudaContext());
+
+      auto k = 0;
+      for (auto r = 0; r != kDim0; ++r)
+        for (auto c = 0; c != kDim1; ++c) {
+          // WARNING: it's inefficient to access elements of Array2
+          // with operator [][]
+          EXPECT_EQ(cpu_array[r][c], k);
+          EXPECT_EQ(cuda_array[r][c], k);
+          ++k;
+        }
+
+      // test operator <<
+      K2_LOG(INFO) << array;
+    }
+
+    {
+      // created with Array2(Array1, dim0, dim1), contiguous
+      std::vector<T> data(20);
+      std::iota(data.begin(), data.end(), 0);
+      Array1<T> array1(context, data);
+      Array2<T> array(array1, 4, 5);
+      EXPECT_EQ(array.Dim0(), 4);
+      EXPECT_EQ(array.Dim1(), 5);
+      EXPECT_EQ(array.ElemStride0(), 5);
+      T *array_data = array.Data();
+
+      {
+        // test Data()
+        const T *array_data = array.Data();
+        // copy data from CPU/GPU to CPU
+        int32_t elem_stride0 = array.ElemStride0();
+        int32_t num_element_copy = array.Dim0() * array.ElemStride0();
+        std::vector<T> cpu_data(num_element_copy);
+        auto kind = GetMemoryCopyKind(*array.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(array_data),
+                   num_element_copy * array.ElementSize(), kind, nullptr);
+        for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
+          for (int32_t j = 0; j < array.Dim1(); ++j) {
+            EXPECT_EQ(cpu_data[i * elem_stride0 + j], data[n++]);
+          }
+        }
+      }
+
+      {
+        // test operator[]
+        for (int32_t i = 0; i < array.Dim0(); ++i) {
+          Array1<T> sub_array = array[i];
+          const T *sub_array_data = sub_array.Data();
+          ASSERT_EQ(sub_array.Dim(), array.Dim1());
+          auto kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
+          std::vector<T> sub_array_cpu_data(sub_array.Dim());
+          MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
+                     static_cast<const void *>(sub_array_data),
+                     sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
+          for (int32_t j = 0; j < sub_array.Dim(); ++j) {
+            EXPECT_EQ(sub_array_cpu_data[j], data[i * array.ElemStride0() + j]);
+          }
+        }
+      }
+
+      {
+        // test Flatten()
+        Array1<T> sub_array = array.Flatten();
         const T *sub_array_data = sub_array.Data();
-        ASSERT_EQ(sub_array.Dim(), array.Dim1());
+        ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
         auto kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
         std::vector<T> sub_array_cpu_data(sub_array.Dim());
         MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
                    static_cast<const void *>(sub_array_data),
                    sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
-        for (int32_t j = 0; j < sub_array.Dim(); ++j) {
-          EXPECT_EQ(sub_array_cpu_data[j], data[i * array.ElemStride0() + j]);
-        }
-      }
-    }
-
-    {
-      // test Flatten()
-      Array1<T> sub_array = array.Flatten();
-      const T *sub_array_data = sub_array.Data();
-      ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
-      auto kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
-      std::vector<T> sub_array_cpu_data(sub_array.Dim());
-      MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
-                 static_cast<const void *>(sub_array_data),
-                 sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0; i < sub_array.Dim(); ++i) {
-        EXPECT_EQ(sub_array_cpu_data[i], data[i]);
-      }
-    }
-
-    {
-      // test ToTensor()
-      Tensor tensor = array.ToTensor();
-      Dtype array_dtype = DtypeOf<T>::dtype;
-      EXPECT_EQ(tensor.GetDtype(), array_dtype);
-      Shape shape = tensor.GetShape();
-      EXPECT_EQ(shape.NumAxes(), 2);
-      EXPECT_EQ(shape.Nelement(), array.Dim0() * array.Dim1());
-      EXPECT_EQ(shape.Dim(0), array.Dim0());
-      EXPECT_EQ(shape.Dim(1), array.Dim1());
-      EXPECT_EQ(shape.Stride(0), array.ElemStride0());
-      EXPECT_EQ(shape.Stride(1), 1);
-      const T *tensor_data = tensor.Data<T>();
-      auto kind = GetMemoryCopyKind(*tensor.GetRegion()->context, *cpu);
-      std::vector<T> cpu_tensor_data(shape.StorageSize());
-      MemoryCopy(static_cast<void *>(cpu_tensor_data.data()),
-                 static_cast<const void *>(tensor_data),
-                 shape.StorageSize() * TraitsOf(tensor.GetDtype()).NumBytes(),
-                 kind, nullptr);
-      for (int32_t m = 0; m < shape.Dim(0); ++m) {
-        for (int32_t n = 0; n < shape.Dim(1); ++n) {
-          int32_t value =
-              cpu_tensor_data[m * shape.Stride(0) + n * shape.Stride(1)];
-          EXPECT_EQ(value, data[m * array.ElemStride0() + n]);
-        }
-      }
-    }
-
-    {
-      // test constAccessor
-      const auto &const_array = array;
-      ConstArray2Accessor<T> accessor = const_array.Accessor();
-      if (array.Context()->GetDeviceType() == kCpu) {
-        EXPECT_EQ(accessor(0, 0), data[0 * array.ElemStride0() + 0]);
-        EXPECT_EQ(accessor(2, 3), data[2 * array.ElemStride0() + 3]);
-      }
-    }
-
-    {
-      Array2Accessor<T> accessor = array.Accessor();
-      if (array.Context()->GetDeviceType() == kCpu) {
-        EXPECT_EQ(accessor(0, 0), 0);
-        accessor(0, 0) = -10;
-        EXPECT_EQ(accessor(0, 0), -10);
-        EXPECT_EQ(array.Data()[0], -10);
-      }
-    }
-  }
-
-  {
-    // created with region
-    const int32_t element_size = TraitsOf(DtypeOf<T>::dtype).NumBytes();
-    const int32_t num_element = 20;
-    RegionPtr region = NewRegion(context, num_element * element_size);
-    std::vector<T> src_data(num_element);
-    std::iota(src_data.begin(), src_data.end(), 0);
-    T *data = region->GetData<T>();
-    auto kind = GetMemoryCopyKind(*cpu, *region->context);
-    MemoryCopy(static_cast<void *>(data),
-               static_cast<const void *>(src_data.data()),
-               num_element * element_size, kind, nullptr);
-
-    {
-      // created with region, contiguous on 0 aixs
-      Array2<T> array(4, 5, 5, 0, region);
-      EXPECT_EQ(array.Dim0(), 4);
-      EXPECT_EQ(array.Dim1(), 5);
-      EXPECT_EQ(array.ElemStride0(), 5);
-      EXPECT_EQ(array.ElementSize(), element_size);
-      // test Data()
-      const T *array_data = array.Data();
-      // copy data from CPU/GPU to CPU
-      int32_t elem_stride0 = array.ElemStride0();
-      int32_t num_element_copy = array.Dim0() * array.ElemStride0();
-      std::vector<T> cpu_data(num_element_copy);
-      kind = GetMemoryCopyKind(*array.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(array_data),
-                 num_element_copy * array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(cpu_data[i * elem_stride0 + j], src_data[n++]);
+        for (int32_t i = 0; i < sub_array.Dim(); ++i) {
+          EXPECT_EQ(sub_array_cpu_data[i], data[i]);
         }
       }
 
       {
-        // test Flatten()
-        Array1<T> sub_array = array.Flatten();
-        const T *sub_array_data = sub_array.Data();
-        ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
-        kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
-        std::vector<T> sub_array_cpu_data(sub_array.Dim());
-        MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
-                   static_cast<const void *>(sub_array_data),
-                   sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
-        for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
-          for (int32_t j = 0; j < array.Dim1(); ++j) {
-            EXPECT_EQ(sub_array_cpu_data[n++], src_data[i * elem_stride0 + j]);
+        // test ToTensor()
+        Tensor tensor = array.ToTensor();
+        Dtype array_dtype = DtypeOf<T>::dtype;
+        EXPECT_EQ(tensor.GetDtype(), array_dtype);
+        Shape shape = tensor.GetShape();
+        EXPECT_EQ(shape.NumAxes(), 2);
+        EXPECT_EQ(shape.Nelement(), array.Dim0() * array.Dim1());
+        EXPECT_EQ(shape.Dim(0), array.Dim0());
+        EXPECT_EQ(shape.Dim(1), array.Dim1());
+        EXPECT_EQ(shape.Stride(0), array.ElemStride0());
+        EXPECT_EQ(shape.Stride(1), 1);
+        const T *tensor_data = tensor.Data<T>();
+        auto kind = GetMemoryCopyKind(*tensor.GetRegion()->context, *cpu);
+        std::vector<T> cpu_tensor_data(shape.StorageSize());
+        MemoryCopy(static_cast<void *>(cpu_tensor_data.data()),
+                   static_cast<const void *>(tensor_data),
+                   shape.StorageSize() * TraitsOf(tensor.GetDtype()).NumBytes(),
+                   kind, nullptr);
+        for (int32_t m = 0; m < shape.Dim(0); ++m) {
+          for (int32_t n = 0; n < shape.Dim(1); ++n) {
+            int32_t value =
+                cpu_tensor_data[m * shape.Stride(0) + n * shape.Stride(1)];
+            EXPECT_EQ(value, data[m * array.ElemStride0() + n]);
           }
         }
       }
-    }
 
-    {
-      // created with region, non-contiguous on 0 aixs
-      int32_t element_offset = 2;
-      Array2<T> array(3, 5, 6, element_offset * element_size, region);
-      EXPECT_EQ(array.Dim0(), 3);
-      EXPECT_EQ(array.Dim1(), 5);
-      EXPECT_EQ(array.ElemStride0(), 6);
-      EXPECT_EQ(array.ElementSize(), element_size);
-      // test Data()
-      const T *array_data = array.Data();
-      // copy data from CPU/GPU to CPU
-      int32_t elem_stride0 = array.ElemStride0();
-      int32_t num_element_copy = array.Dim0() * array.ElemStride0();
-      std::vector<T> cpu_data(num_element_copy);
-      kind = GetMemoryCopyKind(*array.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(array_data),
-                 num_element_copy * array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(cpu_data[i * elem_stride0 + j],
-                    src_data[element_offset + i * elem_stride0 + j]);
+      {
+        // test constAccessor
+        const auto &const_array = array;
+        ConstArray2Accessor<T> accessor = const_array.Accessor();
+        if (array.Context()->GetDeviceType() == kCpu) {
+          EXPECT_EQ(accessor(0, 0), data[0 * array.ElemStride0() + 0]);
+          EXPECT_EQ(accessor(2, 3), data[2 * array.ElemStride0() + 3]);
         }
       }
 
       {
-        // test Flatten()
-        Array1<T> sub_array = array.Flatten();
-        const T *sub_array_data = sub_array.Data();
-        ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
-        kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
-        std::vector<T> sub_array_cpu_data(sub_array.Dim());
-        MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
-                   static_cast<const void *>(sub_array_data),
-                   sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
+        Array2Accessor<T> accessor = array.Accessor();
+        if (array.Context()->GetDeviceType() == kCpu) {
+          EXPECT_EQ(accessor(0, 0), 0);
+          accessor(0, 0) = -10;
+          EXPECT_EQ(accessor(0, 0), -10);
+          EXPECT_EQ(array.Data()[0], -10);
+        }
+      }
+    }
+
+    {
+      // created with region
+      const int32_t element_size = TraitsOf(DtypeOf<T>::dtype).NumBytes();
+      const int32_t num_element = 20;
+      RegionPtr region = NewRegion(context, num_element * element_size);
+      std::vector<T> src_data(num_element);
+      std::iota(src_data.begin(), src_data.end(), 0);
+      T *data = region->GetData<T>();
+      auto kind = GetMemoryCopyKind(*cpu, *region->context);
+      MemoryCopy(static_cast<void *>(data),
+                 static_cast<const void *>(src_data.data()),
+                 num_element * element_size, kind, nullptr);
+
+      {
+        // created with region, contiguous on 0 aixs
+        Array2<T> array(4, 5, 5, 0, region);
+        EXPECT_EQ(array.Dim0(), 4);
+        EXPECT_EQ(array.Dim1(), 5);
+        EXPECT_EQ(array.ElemStride0(), 5);
+        EXPECT_EQ(array.ElementSize(), element_size);
+        // test Data()
+        const T *array_data = array.Data();
+        // copy data from CPU/GPU to CPU
+        int32_t elem_stride0 = array.ElemStride0();
+        int32_t num_element_copy = array.Dim0() * array.ElemStride0();
+        std::vector<T> cpu_data(num_element_copy);
+        kind = GetMemoryCopyKind(*array.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(array_data),
+                   num_element_copy * array.ElementSize(), kind, nullptr);
         for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
           for (int32_t j = 0; j < array.Dim1(); ++j) {
-            EXPECT_EQ(sub_array_cpu_data[n++],
+            EXPECT_EQ(cpu_data[i * elem_stride0 + j], src_data[n++]);
+          }
+        }
+
+        {
+          // test Flatten()
+          Array1<T> sub_array = array.Flatten();
+          const T *sub_array_data = sub_array.Data();
+          ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
+          kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
+          std::vector<T> sub_array_cpu_data(sub_array.Dim());
+          MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
+                     static_cast<const void *>(sub_array_data),
+                     sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
+          for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
+            for (int32_t j = 0; j < array.Dim1(); ++j) {
+              EXPECT_EQ(sub_array_cpu_data[n++],
+                        src_data[i * elem_stride0 + j]);
+            }
+          }
+        }
+      }
+
+      {
+        // created with region, non-contiguous on 0 aixs
+        int32_t element_offset = 2;
+        Array2<T> array(3, 5, 6, element_offset * element_size, region);
+        EXPECT_EQ(array.Dim0(), 3);
+        EXPECT_EQ(array.Dim1(), 5);
+        EXPECT_EQ(array.ElemStride0(), 6);
+        EXPECT_EQ(array.ElementSize(), element_size);
+        // test Data()
+        const T *array_data = array.Data();
+        // copy data from CPU/GPU to CPU
+        int32_t elem_stride0 = array.ElemStride0();
+        int32_t num_element_copy = array.Dim0() * array.ElemStride0();
+        std::vector<T> cpu_data(num_element_copy);
+        kind = GetMemoryCopyKind(*array.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(array_data),
+                   num_element_copy * array.ElementSize(), kind, nullptr);
+        for (int32_t i = 0; i < array.Dim0(); ++i) {
+          for (int32_t j = 0; j < array.Dim1(); ++j) {
+            EXPECT_EQ(cpu_data[i * elem_stride0 + j],
                       src_data[element_offset + i * elem_stride0 + j]);
           }
         }
-      }
-    }
-  }
 
-  {
-    // created with tensor, stride on 1st axis is 1
-    const int32_t element_size = TraitsOf(DtypeOf<T>::dtype).NumBytes();
-    const int32_t num_element = 24;
-    RegionPtr region = NewRegion(context, num_element * element_size);
-    std::vector<T> src_data(num_element);
-    std::iota(src_data.begin(), src_data.end(), 0);
-    T *data = region->GetData<T>();
-    auto kind = GetMemoryCopyKind(*cpu, *region->context);
-    MemoryCopy(static_cast<void *>(data),
-               static_cast<const void *>(src_data.data()),
-               num_element * element_size, kind, nullptr);
-    std::vector<int32_t> dims = {2, 4};
-    std::vector<int32_t> strides = {10, 1};
-    Shape shape(dims, strides);
-    const int32_t element_offset = 4;
-    const int32_t bytes_offset = element_offset * element_size;
-    Tensor tensor(DtypeOf<T>::dtype, shape, region, bytes_offset);
-    Array2<T> array(tensor, false);
-    int32_t elem_stride0 = array.ElemStride0();
-    int32_t elem_stride1 = tensor.GetShape().Stride(1);
-    EXPECT_EQ(elem_stride1, 1);
-    {
-      // check_data
-      const T *array_data = array.Data();
-      int32_t num_element_copy = array.Dim0() * array.ElemStride0();
-      std::vector<T> cpu_data(num_element_copy);
-      kind = GetMemoryCopyKind(*array.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(array_data),
-                 num_element_copy * array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(
-              cpu_data[i * elem_stride0 + j],
-              src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+        {
+          // test Flatten()
+          Array1<T> sub_array = array.Flatten();
+          const T *sub_array_data = sub_array.Data();
+          ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
+          kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
+          std::vector<T> sub_array_cpu_data(sub_array.Dim());
+          MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
+                     static_cast<const void *>(sub_array_data),
+                     sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
+          for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
+            for (int32_t j = 0; j < array.Dim1(); ++j) {
+              EXPECT_EQ(sub_array_cpu_data[n++],
+                        src_data[element_offset + i * elem_stride0 + j]);
+            }
+          }
         }
       }
     }
 
     {
-      // test Flatten()
-      Array1<T> sub_array = array.Flatten();
-      const T *sub_array_data = sub_array.Data();
-      ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
-      kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
-      std::vector<T> sub_array_cpu_data(sub_array.Dim());
-      MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
-                 static_cast<const void *>(sub_array_data),
-                 sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(
-              sub_array_cpu_data[n++],
-              src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+      // created with tensor, stride on 1st axis is 1
+      const int32_t element_size = TraitsOf(DtypeOf<T>::dtype).NumBytes();
+      const int32_t num_element = 24;
+      RegionPtr region = NewRegion(context, num_element * element_size);
+      std::vector<T> src_data(num_element);
+      std::iota(src_data.begin(), src_data.end(), 0);
+      T *data = region->GetData<T>();
+      auto kind = GetMemoryCopyKind(*cpu, *region->context);
+      MemoryCopy(static_cast<void *>(data),
+                 static_cast<const void *>(src_data.data()),
+                 num_element * element_size, kind, nullptr);
+      std::vector<int32_t> dims = {2, 4};
+      std::vector<int32_t> strides = {10, 1};
+      Shape shape(dims, strides);
+      const int32_t element_offset = 4;
+      const int32_t bytes_offset = element_offset * element_size;
+      Tensor tensor(DtypeOf<T>::dtype, shape, region, bytes_offset);
+      Array2<T> array(tensor, false);
+      int32_t elem_stride0 = array.ElemStride0();
+      int32_t elem_stride1 = tensor.GetShape().Stride(1);
+      EXPECT_EQ(elem_stride1, 1);
+      {
+        // check_data
+        const T *array_data = array.Data();
+        int32_t num_element_copy = array.Dim0() * array.ElemStride0();
+        std::vector<T> cpu_data(num_element_copy);
+        kind = GetMemoryCopyKind(*array.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(array_data),
+                   num_element_copy * array.ElementSize(), kind, nullptr);
+        for (int32_t i = 0; i < array.Dim0(); ++i) {
+          for (int32_t j = 0; j < array.Dim1(); ++j) {
+            EXPECT_EQ(
+                cpu_data[i * elem_stride0 + j],
+                src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+          }
+        }
+      }
+
+      {
+        // test Flatten()
+        Array1<T> sub_array = array.Flatten();
+        const T *sub_array_data = sub_array.Data();
+        ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
+        kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
+        std::vector<T> sub_array_cpu_data(sub_array.Dim());
+        MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
+                   static_cast<const void *>(sub_array_data),
+                   sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
+        for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
+          for (int32_t j = 0; j < array.Dim1(); ++j) {
+            EXPECT_EQ(
+                sub_array_cpu_data[n++],
+                src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+          }
         }
       }
     }
-  }
 
-  {
-    // created with tensor, stride on 1st axis is not 1
-    const int32_t element_size = TraitsOf(DtypeOf<T>::dtype).NumBytes();
-    const int32_t num_element = 24;
-    RegionPtr region = NewRegion(context, num_element * element_size);
-    std::vector<T> src_data(num_element);
-    std::iota(src_data.begin(), src_data.end(), 0);
-    T *data = region->GetData<T>();
-    auto kind = GetMemoryCopyKind(*cpu, *region->context);
-    MemoryCopy(static_cast<void *>(data),
-               static_cast<const void *>(src_data.data()),
-               num_element * element_size, kind, nullptr);
-    std::vector<int32_t> dims = {2, 4};
-    std::vector<int32_t> strides = {10, 2};
-    Shape shape(dims, strides);
-    const int32_t element_offset = 4;
-    const int32_t bytes_offset = element_offset * element_size;
-    Tensor tensor(DtypeOf<T>::dtype, shape, region, bytes_offset);
-    Array2<T> array(tensor, true);
-    int32_t elem_stride0 = array.ElemStride0();
-    int32_t elem_stride1 = tensor.GetShape().Stride(1);
     {
-      // check_data
-      const T *array_data = array.Data();
-      int32_t num_element_copy = array.Dim0() * array.ElemStride0();
-      std::vector<T> cpu_data(num_element_copy);
-      kind = GetMemoryCopyKind(*array.Context(), *cpu);
-      MemoryCopy(static_cast<void *>(cpu_data.data()),
-                 static_cast<const void *>(array_data),
-                 num_element_copy * array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(
-              cpu_data[i * elem_stride0 + j],
-              src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+      // created with tensor, stride on 1st axis is not 1
+      const int32_t element_size = TraitsOf(DtypeOf<T>::dtype).NumBytes();
+      const int32_t num_element = 24;
+      RegionPtr region = NewRegion(context, num_element * element_size);
+      std::vector<T> src_data(num_element);
+      std::iota(src_data.begin(), src_data.end(), 0);
+      T *data = region->GetData<T>();
+      auto kind = GetMemoryCopyKind(*cpu, *region->context);
+      MemoryCopy(static_cast<void *>(data),
+                 static_cast<const void *>(src_data.data()),
+                 num_element * element_size, kind, nullptr);
+      std::vector<int32_t> dims = {2, 4};
+      std::vector<int32_t> strides = {10, 2};
+      Shape shape(dims, strides);
+      const int32_t element_offset = 4;
+      const int32_t bytes_offset = element_offset * element_size;
+      Tensor tensor(DtypeOf<T>::dtype, shape, region, bytes_offset);
+      Array2<T> array(tensor, true);
+      int32_t elem_stride0 = array.ElemStride0();
+      int32_t elem_stride1 = tensor.GetShape().Stride(1);
+      {
+        // check_data
+        const T *array_data = array.Data();
+        int32_t num_element_copy = array.Dim0() * array.ElemStride0();
+        std::vector<T> cpu_data(num_element_copy);
+        kind = GetMemoryCopyKind(*array.Context(), *cpu);
+        MemoryCopy(static_cast<void *>(cpu_data.data()),
+                   static_cast<const void *>(array_data),
+                   num_element_copy * array.ElementSize(), kind, nullptr);
+        for (int32_t i = 0; i < array.Dim0(); ++i) {
+          for (int32_t j = 0; j < array.Dim1(); ++j) {
+            EXPECT_EQ(
+                cpu_data[i * elem_stride0 + j],
+                src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+          }
         }
       }
-    }
 
-    {
-      // test Flatten()
-      Array1<T> sub_array = array.Flatten();
-      const T *sub_array_data = sub_array.Data();
-      ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
-      kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
-      std::vector<T> sub_array_cpu_data(sub_array.Dim());
-      MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
-                 static_cast<const void *>(sub_array_data),
-                 sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
-      for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
-        for (int32_t j = 0; j < array.Dim1(); ++j) {
-          EXPECT_EQ(
-              sub_array_cpu_data[n++],
-              src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+      {
+        // test Flatten()
+        Array1<T> sub_array = array.Flatten();
+        const T *sub_array_data = sub_array.Data();
+        ASSERT_EQ(sub_array.Dim(), array.Dim0() * array.Dim1());
+        kind = GetMemoryCopyKind(*sub_array.Context(), *cpu);
+        std::vector<T> sub_array_cpu_data(sub_array.Dim());
+        MemoryCopy(static_cast<void *>(sub_array_cpu_data.data()),
+                   static_cast<const void *>(sub_array_data),
+                   sub_array.Dim() * sub_array.ElementSize(), kind, nullptr);
+        for (int32_t i = 0, n = 0; i < array.Dim0(); ++i) {
+          for (int32_t j = 0; j < array.Dim1(); ++j) {
+            EXPECT_EQ(
+                sub_array_cpu_data[n++],
+                src_data[element_offset + i * elem_stride0 + j * elem_stride1]);
+          }
         }
       }
     }
@@ -713,17 +704,13 @@ TEST(ArrayTest, TestArray2Io) {
 }
 
 TEST(ArrayTest, Array1Test) {
-  TestArray1<int32_t, kCpu>();
-  TestArray1<int32_t, kCuda>();
-  TestArray1<double, kCpu>();
-  TestArray1<double, kCuda>();
+  TestArray1<int32_t>();
+  TestArray1<double>();
 }
 
 TEST(ArrayTest, Array2Test) {
-  TestArray2<int32_t, kCpu>();
-  TestArray2<int32_t, kCuda>();
-  TestArray2<double, kCpu>();
-  TestArray2<double, kCuda>();
+  TestArray2<int32_t>();
+  TestArray2<double>();
 }
 
 }  // namespace k2

--- a/k2/csrc/context.cu
+++ b/k2/csrc/context.cu
@@ -15,7 +15,7 @@
 
 namespace k2 {
 
-RegionPtr NewRegion(ContextPtr &context, std::size_t num_bytes) {
+RegionPtr NewRegion(ContextPtr context, std::size_t num_bytes) {
   // .. fairly straightforward.  Sets bytes_used to num_bytes, caller can
   // overwrite if needed.
   auto ans = std::make_shared<Region>();
@@ -56,8 +56,7 @@ cudaStream_t ParallelRunnerActive::NewStream() {
 }
 
 void ParallelRunnerActive::Finish() {
-  if (c_.get() == nullptr)
-    return;
+  if (c_.get() == nullptr) return;
   if (c_->GetDeviceType() == kCuda) {
     for (std::size_t i = 0; i != streams_.size(); ++i) {
       // create and record event on `stream_[i]`, and wait on c_->GetCudaStream
@@ -80,10 +79,8 @@ void ParallelRunnerActive::Finish() {
   c_ = nullptr;
 }
 
-void GetBlockSizesForLambda2(int32_t m, int32_t n,
-                             dim3 *block_dim,
-                             dim3 *grid_dim,
-                             Lambda2KernelType *kernel_type) {
+void GetBlockSizesForLambda2(int32_t m, int32_t n, dim3 *block_dim,
+                             dim3 *grid_dim, Lambda2KernelType *kernel_type) {
   // Note: 'n' is the 'inner-loop' one, the one which is supposed to vary the
   // fastest.
   int32_t n_block_size = (n <= 256 ? n : 256);
@@ -93,8 +90,8 @@ void GetBlockSizesForLambda2(int32_t m, int32_t n,
                         // 512.  (128 * 4 = 512).
   *block_dim = dim3(n_block_size, m_block_size, 1);
   int32_t n_grid_size = NumBlocks(n, n_block_size),
-      m_grid_size = NumBlocks(m, m_block_size);
-  if (n_grid_size < 65536 &&  m_grid_size < 65536) {
+          m_grid_size = NumBlocks(m, m_block_size);
+  if (n_grid_size < 65536 && m_grid_size < 65536) {
     *grid_dim = dim3(n_grid_size, m_grid_size, 1);
     *kernel_type = Lambda2KernelType::Simple;
   } else if (n_grid_size < 65536) {
@@ -111,7 +108,5 @@ void GetBlockSizesForLambda2(int32_t m, int32_t n,
     *kernel_type = Lambda2KernelType::UseZForN;
   }
 }
-
-
 
 }  // namespace k2

--- a/k2/csrc/context.h
+++ b/k2/csrc/context.h
@@ -343,7 +343,7 @@ ContextPtr GetPinnedContext();
                           region will have bytes_used == num_bytes; if the user
                           wants to change this they can do it afterward.
 */
-RegionPtr NewRegion(ContextPtr &context, std::size_t num_bytes);
+RegionPtr NewRegion(ContextPtr context, std::size_t num_bytes);
 
 /*
   Convenience wrapper for NewRegion() that takes the context from a provided
@@ -461,9 +461,10 @@ class ParallelRunnerActive {
 // cudaEventRecord() are too slow to make this worthwhile.
 class ParallelRunnerDummy {
  public:
-  explicit ParallelRunnerDummy(ContextPtr c): stream_(c->GetCudaStream()) { }
+  explicit ParallelRunnerDummy(ContextPtr c) : stream_(c->GetCudaStream()) {}
   cudaStream_t NewStream() { return stream_; }
-  void Finish() { }
+  void Finish() {}
+
  private:
   cudaStream_t stream_;
 };

--- a/k2/csrc/fsa_utils_test.cu
+++ b/k2/csrc/fsa_utils_test.cu
@@ -213,19 +213,11 @@ TEST(FsaToString, Transducer) {
   K2_LOG(INFO) << "\n---negating---\n" << str;
 }
 
-template <DeviceType d>
-void TestGetDestStates() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  // test with simple case should be good enough
-  std::string s1 = R"(0 1 1 0
+TEST(FsaUtilsTest, TestGetDestStates) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    // test with simple case should be good enough
+    std::string s1 = R"(0 1 1 0
 0 2  1 0
 0 3  1 0
 0 3  2 0
@@ -237,7 +229,7 @@ void TestGetDestStates() {
 5
 )";
 
-  std::string s2 = R"(0 1 1 0
+    std::string s2 = R"(0 1 1 0
 0 2  1 0
 1 2  1 0
 1 3  1 0
@@ -246,36 +238,34 @@ void TestGetDestStates() {
 4
 )";
 
-  Fsa fsa1 = FsaFromString(s1);
-  Fsa fsa2 = FsaFromString(s2);
-  Fsa *fsa_array[] = {&fsa1, &fsa2};
-  FsaVec fsa_vec = CreateFsaVec(2, &fsa_array[0]);
-  fsa_vec = fsa_vec.To(context);
+    Fsa fsa1 = FsaFromString(s1);
+    Fsa fsa2 = FsaFromString(s2);
+    Fsa *fsa_array[] = {&fsa1, &fsa2};
+    FsaVec fsa_vec = CreateFsaVec(2, &fsa_array[0]);
+    fsa_vec = fsa_vec.To(context);
 
-  {
-    // as_idx01 = false
-    Array1<int32_t> result = GetDestStates(fsa_vec, false);
-    ASSERT_EQ(result.Dim(), fsa_vec.NumElements());
-    result = result.To(cpu);
-    std::vector<int32_t> cpu_data(result.Data(), result.Data() + result.Dim());
-    EXPECT_THAT(cpu_data, ::testing::ElementsAre(1, 2, 3, 3, 2, 3, 4, 5, 5, 1,
-                                                 2, 2, 3, 3, 4));
+    {
+      // as_idx01 = false
+      Array1<int32_t> result = GetDestStates(fsa_vec, false);
+      ASSERT_EQ(result.Dim(), fsa_vec.NumElements());
+      result = result.To(cpu);
+      std::vector<int32_t> cpu_data(result.Data(),
+                                    result.Data() + result.Dim());
+      EXPECT_THAT(cpu_data, ::testing::ElementsAre(1, 2, 3, 3, 2, 3, 4, 5, 5, 1,
+                                                   2, 2, 3, 3, 4));
+    }
+
+    {
+      // as_idx01 = true
+      Array1<int32_t> result = GetDestStates(fsa_vec, true);
+      ASSERT_EQ(result.Dim(), fsa_vec.NumElements());
+      result = result.To(cpu);
+      std::vector<int32_t> cpu_data(result.Data(),
+                                    result.Data() + result.Dim());
+      EXPECT_THAT(cpu_data, ::testing::ElementsAre(1, 2, 3, 3, 2, 3, 4, 5, 5, 7,
+                                                   8, 8, 9, 9, 10));
+    }
   }
-
-  {
-    // as_idx01 = true
-    Array1<int32_t> result = GetDestStates(fsa_vec, true);
-    ASSERT_EQ(result.Dim(), fsa_vec.NumElements());
-    result = result.To(cpu);
-    std::vector<int32_t> cpu_data(result.Data(), result.Data() + result.Dim());
-    EXPECT_THAT(cpu_data, ::testing::ElementsAre(1, 2, 3, 3, 2, 3, 4, 5, 5, 7,
-                                                 8, 8, 9, 9, 10));
-  }
-}
-
-TEST(FsaUtilsTest, TestGetDestStates) {
-  TestGetDestStates<kCpu>();
-  TestGetDestStates<kCuda>();
 }
 
 class StatesBatchSuiteTest : public ::testing::Test {

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -222,7 +222,7 @@ RaggedShape RaggedShape3(Array1<int32_t> *row_splits1,
   return RaggedShape(axes);
 }
 
-RaggedShape RaggedShapeFromTotSizes(ContextPtr &c, int32_t num_axes,
+RaggedShape RaggedShapeFromTotSizes(ContextPtr c, int32_t num_axes,
                                     int32_t *tot_sizes) {
   NVTX_RANGE(__func__);
   K2_CHECK_GE(num_axes, 2);
@@ -319,8 +319,7 @@ std::vector<RaggedShape> UnsqueezeParallel(int32_t num_srcs, RaggedShape **src,
   NVTX_RANGE(__func__);
   K2_CHECK_EQ(axis, 0);
   std::vector<RaggedShape> ans;
-  if (num_srcs == 0)
-    return ans;
+  if (num_srcs == 0) return ans;
   ans.reserve(num_srcs);
   ContextPtr c = src[0]->Context();
 
@@ -330,8 +329,7 @@ std::vector<RaggedShape> UnsqueezeParallel(int32_t num_srcs, RaggedShape **src,
   // where d0 == src[0]->Dim0(), d1 == src[1]->Dim0()..
   for (int32_t i = 0; i < num_srcs; i++) {
     int32_t this_dim0 = src[i]->Dim0();
-    if (this_dim0 > max_dim)
-      max_dim = this_dim0;
+    if (this_dim0 > max_dim) max_dim = this_dim0;
     all_row_splits_vec[i * 2] = 0;
     all_row_splits_vec[i * 2 + 1] = this_dim0;
   }
@@ -353,7 +351,6 @@ std::vector<RaggedShape> UnsqueezeParallel(int32_t num_srcs, RaggedShape **src,
   }
   return ans;
 }
-
 
 /*
   Internal function used in Index(), which gets certain arrays used internally.
@@ -938,11 +935,9 @@ RaggedShape Stack(int32_t axis, int32_t num_srcs, RaggedShape **src) {
     K2_CHECK(c->IsCompatible(*src[i]->Context()));
   }
 
-  std::vector<RaggedShape> unsqueezed = UnsqueezeParallel(
-      num_srcs, src, 0);
+  std::vector<RaggedShape> unsqueezed = UnsqueezeParallel(num_srcs, src, 0);
   std::vector<RaggedShape *> unsqueezed_ptrs(num_srcs);
-  for (int32_t i = 0; i < num_srcs; i++)
-    unsqueezed_ptrs[i] = &(unsqueezed[i]);
+  for (int32_t i = 0; i < num_srcs; i++) unsqueezed_ptrs[i] = &(unsqueezed[i]);
   RaggedShape ans = Append(0, num_srcs, unsqueezed_ptrs.data());
   // Transpose will check if all src->Dim0() has the same value.
   if (axis == 1) ans = Transpose(ans);

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -549,7 +549,7 @@ RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1);
                        filled in, and its cached_tot_size elements
                        set.
  */
-RaggedShape RaggedShapeFromTotSizes(ContextPtr &c, int32_t num_axes,
+RaggedShape RaggedShapeFromTotSizes(ContextPtr c, int32_t num_axes,
                                     int32_t *tot_sizes);
 
 /*

--- a/k2/csrc/ragged_shape_test.cu
+++ b/k2/csrc/ragged_shape_test.cu
@@ -36,235 +36,224 @@ static void CheckRowSplitsOrIds(k2::RaggedShape &shape,
     std::vector<int32_t> cpu_data(curr_row_splits.Dim());
     k2::MemoryCopy(static_cast<void *>(cpu_data.data()),
                    static_cast<const void *>(curr_row_splits.Data()),
-                   curr_row_splits.Dim() * curr_row_splits.ElementSize(),
-                   kind, nullptr);
+                   curr_row_splits.Dim() * curr_row_splits.ElementSize(), kind,
+                   nullptr);
     EXPECT_EQ(cpu_data, target[i - 1]);
   }
 }
 }  // namespace
 
 namespace k2 {
-template <DeviceType d>
-void TestShape() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // constructed with row_splits and row_ids
-    // RaggedTensor4 t = [
-    //  [ [[ 1, 2], [4]],  [[3, 0]] ],
-    //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
-    //  [ [[3, 4], [], [8]] ]
-    // ]
-    const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-    const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
-    const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-    const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
-    const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
-                                              12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
-                                           4, 5, 5, 5, 6, 7, 7, 9};
-    std::vector<RaggedShapeDim> axes;
-    axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits1),
-                                     Array1<int32_t>(context, row_ids1),
-                                     static_cast<int32_t>(row_ids1.size())});
-    axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits2),
-                                     Array1<int32_t>(context, row_ids2),
-                                     static_cast<int32_t>(row_ids2.size())});
-    axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits3),
-                                     Array1<int32_t>(context, row_ids3),
-                                     static_cast<int32_t>(row_ids3.size())});
-
-    RaggedShape shape(axes, true);
-
-    // test NumAxes()
-    EXPECT_EQ(shape.NumAxes(), 4);
-    // test Dim0()
-    EXPECT_EQ(shape.Dim0(), 3);
-    // test TotSize()
-    EXPECT_EQ(shape.TotSize(0), 3);
-    EXPECT_EQ(shape.TotSize(1), row_ids1.size());
-    EXPECT_EQ(shape.TotSize(2), row_ids2.size());
-    EXPECT_EQ(shape.TotSize(3), row_ids3.size());
-    // test NumElements()
-    EXPECT_EQ(shape.NumElements(), row_ids3.size());
-
-    // test RowSplits()
-    const std::vector<std::vector<int32_t>> row_splits_vec = {
-        row_splits1, row_splits2, row_splits3};
-    CheckRowSplitsOrIds(shape, row_splits_vec, true);
-
-    // test RowIds()
-    const std::vector<std::vector<int32_t>> row_ids_vec = {row_ids1, row_ids2,
-                                                           row_ids3};
-    CheckRowSplitsOrIds(shape, row_ids_vec, false);
-
-    // test MaxSize()
-    EXPECT_EQ(shape.MaxSize(1), 3);
-    EXPECT_EQ(shape.MaxSize(2), 3);
-    EXPECT_EQ(shape.MaxSize(3), 3);
-
-    // test Index(axis, i)
-    {
-      // values: [[[ 1, 2], [4]], [[3, 0]]]
-      RaggedShape sub_shape = shape.Index(0, 0);
-      EXPECT_EQ(sub_shape.NumAxes(), 3);
-      const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
-          {0, 2, 3}, {0, 2, 3, 5}};
-      CheckRowSplitsOrIds(sub_shape, sub_row_splits_vec, true);
-    }
-    {
-      // values: [[[7, 8, 9]], [[6], [3, 5, 7]], [[2]]]
-      RaggedShape sub_shape = shape.Index(0, 1);
-      EXPECT_EQ(sub_shape.NumAxes(), 3);
-      const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
-          {0, 1, 3, 4}, {0, 3, 4, 7, 8}};
-      CheckRowSplitsOrIds(sub_shape, sub_row_splits_vec, true);
-    }
-
-    {
-      // values: [[[3, 4], [], [8]]]
-      RaggedShape sub_shape = shape.Index(0, 2);
-      EXPECT_EQ(sub_shape.NumAxes(), 3);
-      const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
-          {0, 3}, {0, 2, 2, 3}};
-      CheckRowSplitsOrIds(sub_shape, sub_row_splits_vec, true);
-    }
-
-    // test operator[](indexes)
-    if (d == kCpu) {
-      {
-        std::vector<int32_t> indexes = {0, 0, 0, 0};
-        EXPECT_EQ(shape[indexes], 0);
-      }
-      {
-        std::vector<int32_t> indexes = {0, 1, 0, 0};
-        EXPECT_EQ(shape[indexes], 3);
-      }
-      {
-        std::vector<int32_t> indexes = {1, 0, 0, 1};
-        EXPECT_EQ(shape[indexes], 6);
-      }
-      {
-        std::vector<int32_t> indexes = {1, 1, 1, 0};
-        EXPECT_EQ(shape[indexes], 9);
-      }
-      {
-        std::vector<int32_t> indexes = {2, 0, 0, 1};
-        EXPECT_EQ(shape[indexes], 14);
-      }
-      {
-        std::vector<int32_t> indexes = {2, 0, 2, 0};
-        EXPECT_EQ(shape[indexes], 15);
-      }
-    }
-
-    // test To(ctx)
-    {
-      // to GPU
-      RaggedShape other = shape.To(GetCudaContext());
-      CheckRowSplitsOrIds(other, row_splits_vec, true);
-    }
-    {
-      // to CPU
-      RaggedShape other = shape.To(GetCpuContext());
-      CheckRowSplitsOrIds(other, row_splits_vec, true);
-    }
-  }
-
-  {
-    // constructed with row_splits
-    // RaggedTensor4 t = [
-    //  [ [[ 1, 2], [4]],  [[3, 0]] ],
-    //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
-    //  [ [[3, 4], [], [8]] ]
-    // ]
-    const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-    const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-    const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
-                                              12, 13, 15, 15, 16};
-    Array1<int32_t> row_ids;  // invalid row_ids as it has no context,
-                              // shape.RowIds(axis) will create it.
-    std::vector<RaggedShapeDim> axes;
-    axes.emplace_back(
-        RaggedShapeDim{Array1<int32_t>(context, row_splits1), row_ids, -1});
-    axes.emplace_back(
-        RaggedShapeDim{Array1<int32_t>(context, row_splits2), row_ids, -1});
-    axes.emplace_back(
-        RaggedShapeDim{Array1<int32_t>(context, row_splits3), row_ids, -1});
-    RaggedShape shape(axes, true);
-
-    EXPECT_EQ(shape.NumAxes(), 4);
-    EXPECT_EQ(shape.Dim0(), 3);
-    EXPECT_EQ(shape.NumElements(), row_splits3.back());
-
-    // test RowIds()
-    const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
-    const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
-    const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
-                                           4, 5, 5, 5, 6, 7, 7, 9};
-    const std::vector<std::vector<int32_t>> row_ids_vec = {row_ids1, row_ids2,
-                                                           row_ids3};
-    CheckRowSplitsOrIds(shape, row_ids_vec, false);
-  }
-
-  {
-    // constructed with row_splits and test Populate()
-    // RaggedTensor4 t = [
-    //  [ [[ 1, 2], [4]],  [[3, 0]] ],
-    //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
-    //  [ [[3, 4], [], [8]] ]
-    // ]
-    const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-    const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-    const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
-                                              12, 13, 15, 15, 16};
-    Array1<int32_t> row_ids;  // invalid row_ids as it has no context,
-                              // shape.RowIds(axis) will create it.
-    std::vector<RaggedShapeDim> axes;
-    axes.emplace_back(
-        RaggedShapeDim{Array1<int32_t>(context, row_splits1), row_ids, -1});
-    axes.emplace_back(
-        RaggedShapeDim{Array1<int32_t>(context, row_splits2), row_ids, -1});
-    axes.emplace_back(
-        RaggedShapeDim{Array1<int32_t>(context, row_splits3), row_ids, -1});
-    RaggedShape shape(axes, true);
-
-    // test Populate(), it will create row_ids and cached_tot_size from
-    // row_splits
-    shape.Populate();
-
-    const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
-    const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
-    const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
-                                           4, 5, 5, 5, 6, 7, 7, 9};
-    const std::vector<std::vector<int32_t>> row_ids_vec = {row_ids1, row_ids2,
-                                                           row_ids3};
-
-    const auto &curr_axes = shape.Axes();
-    for (int32_t i = 1; i < shape.NumAxes(); ++i) {
-      const Array1<int32_t> &curr_row_ids = curr_axes[i - 1].row_ids;
-      // copy data from CPU/GPU to CPU
-      auto kind = GetMemoryCopyKind(*curr_row_ids.Context(), *cpu);
-      std::vector<int32_t> cpu_data(curr_row_ids.Dim());
-      k2::MemoryCopy(static_cast<void *>(cpu_data.data()),
-                     static_cast<const void *>(curr_row_ids.Data()),
-                     curr_row_ids.Dim() * curr_row_ids.ElementSize(),
-                     kind, nullptr);
-      EXPECT_EQ(cpu_data, row_ids_vec[i - 1]);
-      EXPECT_EQ(curr_axes[i - 1].cached_tot_size, row_ids_vec[i - 1].size());
-    }
-  }
-}
 TEST(RaggedShapeTest, RaggedShape) {
-  TestShape<kCuda>();
-  TestShape<kCpu>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // constructed with row_splits and row_ids
+      // RaggedTensor4 t = [
+      //  [ [[ 1, 2], [4]],  [[3, 0]] ],
+      //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
+      //  [ [[3, 4], [], [8]] ]
+      // ]
+      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+      const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
+      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+      const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+      const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
+                                                12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
+                                             4, 5, 5, 5, 6, 7, 7, 9};
+      std::vector<RaggedShapeDim> axes;
+      axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits1),
+                                       Array1<int32_t>(context, row_ids1),
+                                       static_cast<int32_t>(row_ids1.size())});
+      axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits2),
+                                       Array1<int32_t>(context, row_ids2),
+                                       static_cast<int32_t>(row_ids2.size())});
+      axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits3),
+                                       Array1<int32_t>(context, row_ids3),
+                                       static_cast<int32_t>(row_ids3.size())});
+
+      RaggedShape shape(axes, true);
+
+      // test NumAxes()
+      EXPECT_EQ(shape.NumAxes(), 4);
+      // test Dim0()
+      EXPECT_EQ(shape.Dim0(), 3);
+      // test TotSize()
+      EXPECT_EQ(shape.TotSize(0), 3);
+      EXPECT_EQ(shape.TotSize(1), row_ids1.size());
+      EXPECT_EQ(shape.TotSize(2), row_ids2.size());
+      EXPECT_EQ(shape.TotSize(3), row_ids3.size());
+      // test NumElements()
+      EXPECT_EQ(shape.NumElements(), row_ids3.size());
+
+      // test RowSplits()
+      const std::vector<std::vector<int32_t>> row_splits_vec = {
+          row_splits1, row_splits2, row_splits3};
+      CheckRowSplitsOrIds(shape, row_splits_vec, true);
+
+      // test RowIds()
+      const std::vector<std::vector<int32_t>> row_ids_vec = {row_ids1, row_ids2,
+                                                             row_ids3};
+      CheckRowSplitsOrIds(shape, row_ids_vec, false);
+
+      // test MaxSize()
+      EXPECT_EQ(shape.MaxSize(1), 3);
+      EXPECT_EQ(shape.MaxSize(2), 3);
+      EXPECT_EQ(shape.MaxSize(3), 3);
+
+      // test Index(axis, i)
+      {
+        // values: [[[ 1, 2], [4]], [[3, 0]]]
+        RaggedShape sub_shape = shape.Index(0, 0);
+        EXPECT_EQ(sub_shape.NumAxes(), 3);
+        const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
+            {0, 2, 3}, {0, 2, 3, 5}};
+        CheckRowSplitsOrIds(sub_shape, sub_row_splits_vec, true);
+      }
+      {
+        // values: [[[7, 8, 9]], [[6], [3, 5, 7]], [[2]]]
+        RaggedShape sub_shape = shape.Index(0, 1);
+        EXPECT_EQ(sub_shape.NumAxes(), 3);
+        const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
+            {0, 1, 3, 4}, {0, 3, 4, 7, 8}};
+        CheckRowSplitsOrIds(sub_shape, sub_row_splits_vec, true);
+      }
+
+      {
+        // values: [[[3, 4], [], [8]]]
+        RaggedShape sub_shape = shape.Index(0, 2);
+        EXPECT_EQ(sub_shape.NumAxes(), 3);
+        const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
+            {0, 3}, {0, 2, 2, 3}};
+        CheckRowSplitsOrIds(sub_shape, sub_row_splits_vec, true);
+      }
+
+      // test operator[](indexes)
+      if (context->GetDeviceType() == kCpu) {
+        {
+          std::vector<int32_t> indexes = {0, 0, 0, 0};
+          EXPECT_EQ(shape[indexes], 0);
+        }
+        {
+          std::vector<int32_t> indexes = {0, 1, 0, 0};
+          EXPECT_EQ(shape[indexes], 3);
+        }
+        {
+          std::vector<int32_t> indexes = {1, 0, 0, 1};
+          EXPECT_EQ(shape[indexes], 6);
+        }
+        {
+          std::vector<int32_t> indexes = {1, 1, 1, 0};
+          EXPECT_EQ(shape[indexes], 9);
+        }
+        {
+          std::vector<int32_t> indexes = {2, 0, 0, 1};
+          EXPECT_EQ(shape[indexes], 14);
+        }
+        {
+          std::vector<int32_t> indexes = {2, 0, 2, 0};
+          EXPECT_EQ(shape[indexes], 15);
+        }
+      }
+
+      // test To(ctx)
+      {
+        // to GPU
+        RaggedShape other = shape.To(GetCudaContext());
+        CheckRowSplitsOrIds(other, row_splits_vec, true);
+      }
+      {
+        // to CPU
+        RaggedShape other = shape.To(GetCpuContext());
+        CheckRowSplitsOrIds(other, row_splits_vec, true);
+      }
+    }
+
+    {
+      // constructed with row_splits
+      // RaggedTensor4 t = [
+      //  [ [[ 1, 2], [4]],  [[3, 0]] ],
+      //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
+      //  [ [[3, 4], [], [8]] ]
+      // ]
+      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+      const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
+                                                12, 13, 15, 15, 16};
+      Array1<int32_t> row_ids;  // invalid row_ids as it has no context,
+                                // shape.RowIds(axis) will create it.
+      std::vector<RaggedShapeDim> axes;
+      axes.emplace_back(
+          RaggedShapeDim{Array1<int32_t>(context, row_splits1), row_ids, -1});
+      axes.emplace_back(
+          RaggedShapeDim{Array1<int32_t>(context, row_splits2), row_ids, -1});
+      axes.emplace_back(
+          RaggedShapeDim{Array1<int32_t>(context, row_splits3), row_ids, -1});
+      RaggedShape shape(axes, true);
+
+      EXPECT_EQ(shape.NumAxes(), 4);
+      EXPECT_EQ(shape.Dim0(), 3);
+      EXPECT_EQ(shape.NumElements(), row_splits3.back());
+
+      // test RowIds()
+      const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
+      const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+      const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
+                                             4, 5, 5, 5, 6, 7, 7, 9};
+      const std::vector<std::vector<int32_t>> row_ids_vec = {row_ids1, row_ids2,
+                                                             row_ids3};
+      CheckRowSplitsOrIds(shape, row_ids_vec, false);
+    }
+
+    {
+      // constructed with row_splits and test Populate()
+      // RaggedTensor4 t = [
+      //  [ [[ 1, 2], [4]],  [[3, 0]] ],
+      //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
+      //  [ [[3, 4], [], [8]] ]
+      // ]
+      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+      const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
+                                                12, 13, 15, 15, 16};
+      Array1<int32_t> row_ids;  // invalid row_ids as it has no context,
+                                // shape.RowIds(axis) will create it.
+      std::vector<RaggedShapeDim> axes;
+      axes.emplace_back(
+          RaggedShapeDim{Array1<int32_t>(context, row_splits1), row_ids, -1});
+      axes.emplace_back(
+          RaggedShapeDim{Array1<int32_t>(context, row_splits2), row_ids, -1});
+      axes.emplace_back(
+          RaggedShapeDim{Array1<int32_t>(context, row_splits3), row_ids, -1});
+      RaggedShape shape(axes, true);
+
+      // test Populate(), it will create row_ids and cached_tot_size from
+      // row_splits
+      shape.Populate();
+
+      const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
+      const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+      const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
+                                             4, 5, 5, 5, 6, 7, 7, 9};
+      const std::vector<std::vector<int32_t>> row_ids_vec = {row_ids1, row_ids2,
+                                                             row_ids3};
+
+      const auto &curr_axes = shape.Axes();
+      for (int32_t i = 1; i < shape.NumAxes(); ++i) {
+        const Array1<int32_t> &curr_row_ids = curr_axes[i - 1].row_ids;
+        // copy data from CPU/GPU to CPU
+        auto kind = GetMemoryCopyKind(*curr_row_ids.Context(), *cpu);
+        std::vector<int32_t> cpu_data(curr_row_ids.Dim());
+        k2::MemoryCopy(static_cast<void *>(cpu_data.data()),
+                       static_cast<const void *>(curr_row_ids.Data()),
+                       curr_row_ids.Dim() * curr_row_ids.ElementSize(), kind,
+                       nullptr);
+        EXPECT_EQ(cpu_data, row_ids_vec[i - 1]);
+        EXPECT_EQ(curr_axes[i - 1].cached_tot_size, row_ids_vec[i - 1].size());
+      }
+    }
+  }
 }
 TEST(RaggedShapeTest, RaggedShapeIterator) {
   // note RaggedShapeIndexIterator works only for CPU

--- a/k2/csrc/ragged_test.cu
+++ b/k2/csrc/ragged_test.cu
@@ -132,317 +132,296 @@ TEST(RaggedTest, TestRaggedFromString) {
   }
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestMaxPerSubListTest() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // empty case
-    const std::vector<int32_t> row_splits = {0};
-    RaggedShapeDim shape_dim;
-    shape_dim.row_splits = Array1<int32_t>(context, row_splits);
-    shape_dim.cached_tot_size = 0;
-    std::vector<RaggedShapeDim> axes = {shape_dim};
-    RaggedShape shape(axes, true);
-    Array1<T> values(context, 0);
-    Ragged<T> ragged(shape, values);
-
-    int32_t num_rows = ragged.shape.Dim0();
-    ASSERT_EQ(num_rows, 0);
-    Array1<T> max_values(context, num_rows);
-    // just run to check if there's any error
-    MaxPerSublist(ragged, 1, &max_values);
-    EXPECT_EQ(max_values.Dim(), 0);
-  }
-
-  {
-    const std::vector<int32_t> row_splits = {0, 2, 2, 5, 6};
-    RaggedShapeDim shape_dim;
-    shape_dim.row_splits = Array1<int32_t>(context, row_splits);
-    shape_dim.cached_tot_size = row_splits.back();
-    std::vector<RaggedShapeDim> axes = {shape_dim};
-    RaggedShape shape(axes, true);
-    const std::vector<T> values_vec = {1, 3, 2, 8, 0, -1};
-    Array1<T> values(context, values_vec);
-    Ragged<T> ragged(shape, values);
-
-    int32_t num_rows = ragged.shape.Dim0();
-    Array1<T> max_values(context, num_rows);
-    T default_value = 2;
-    MaxPerSublist(ragged, default_value, &max_values);
-    // copy memory from GPU/CPU to CPU
-    std::vector<T> cpu_data(max_values.Dim());
-    auto kind = GetMemoryCopyKind(*max_values.Context(), *cpu);
-    MemoryCopy(static_cast<void *>(cpu_data.data()),
-               static_cast<const void *>(max_values.Data()),
-               max_values.Dim() * max_values.ElementSize(), kind, nullptr);
-    std::vector<T> expected_data = {3, default_value, 8, default_value};
-    EXPECT_EQ(cpu_data, expected_data);
-  }
-
-  {
-    // test with random large size
-    const int32_t min_num_elements = 2000;
-    // not random shape is on CPU
-    RaggedShape shape = RandomRaggedShape(false, 2, 2, min_num_elements, 5000);
-    ASSERT_EQ(shape.NumAxes(), 2);
-    RaggedShape gpu_shape;
-    if (d == kCuda) {
-      // copy shape to GPU
-      const Array1<T> &row_splits = shape.RowSplits(1);
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // empty case
+      const std::vector<int32_t> row_splits = {0};
       RaggedShapeDim shape_dim;
-      shape_dim.row_splits = row_splits.To(GetCudaContext());
-      shape_dim.cached_tot_size = shape.NumElements();
+      shape_dim.row_splits = Array1<int32_t>(context, row_splits);
+      shape_dim.cached_tot_size = 0;
       std::vector<RaggedShapeDim> axes = {shape_dim};
-      gpu_shape = RaggedShape(axes, true);
+      RaggedShape shape(axes, true);
+      Array1<T> values(context, 0);
+      Ragged<T> ragged(shape, values);
+
+      int32_t num_rows = ragged.shape.Dim0();
+      ASSERT_EQ(num_rows, 0);
+      Array1<T> max_values(context, num_rows);
+      // just run to check if there's any error
+      MaxPerSublist(ragged, 1, &max_values);
+      EXPECT_EQ(max_values.Dim(), 0);
     }
 
-    int32_t num_elems = shape.NumElements();
-    std::vector<T> data(num_elems);
-    for (int32_t i = 0; i != 10; ++i) {
-      std::iota(data.begin(), data.end(), 0);
-      // randomly set data[pos] = num_elems which is
-      // greater than any element in data
-      int32_t pos = RandInt(0, num_elems - 1);
-      data[pos] = num_elems;
-      // find the corresponding row
-      int32_t num_rows = shape.Dim0();
-      const int32_t *row_splits_data = shape.RowSplits(1).Data();
-      int32_t row = 0;
-      for (int32_t i = 0; i < num_rows; ++i) {
-        if (pos >= row_splits_data[i] && pos < row_splits_data[i + 1]) {
-          row = i;
-          break;
-        }
+    {
+      const std::vector<int32_t> row_splits = {0, 2, 2, 5, 6};
+      RaggedShapeDim shape_dim;
+      shape_dim.row_splits = Array1<int32_t>(context, row_splits);
+      shape_dim.cached_tot_size = row_splits.back();
+      std::vector<RaggedShapeDim> axes = {shape_dim};
+      RaggedShape shape(axes, true);
+      const std::vector<T> values_vec = {1, 3, 2, 8, 0, -1};
+      Array1<T> values(context, values_vec);
+      Ragged<T> ragged(shape, values);
+
+      int32_t num_rows = ragged.shape.Dim0();
+      Array1<T> max_values(context, num_rows);
+      T default_value = 2;
+      MaxPerSublist(ragged, default_value, &max_values);
+      // copy memory from GPU/CPU to CPU
+      std::vector<T> cpu_data(max_values.Dim());
+      auto kind = GetMemoryCopyKind(*max_values.Context(), *cpu);
+      MemoryCopy(static_cast<void *>(cpu_data.data()),
+                 static_cast<const void *>(max_values.Data()),
+                 max_values.Dim() * max_values.ElementSize(), kind, nullptr);
+      std::vector<T> expected_data = {3, default_value, 8, default_value};
+      EXPECT_EQ(cpu_data, expected_data);
+    }
+
+    {
+      // test with random large size
+      const int32_t min_num_elements = 2000;
+      // not random shape is on CPU
+      RaggedShape shape =
+          RandomRaggedShape(false, 2, 2, min_num_elements, 5000);
+      ASSERT_EQ(shape.NumAxes(), 2);
+      RaggedShape gpu_shape;
+      if (context->GetDeviceType() == kCuda) {
+        // copy shape to GPU
+        const Array1<T> &row_splits = shape.RowSplits(1);
+        RaggedShapeDim shape_dim;
+        shape_dim.row_splits = row_splits.To(GetCudaContext());
+        shape_dim.cached_tot_size = shape.NumElements();
+        std::vector<RaggedShapeDim> axes = {shape_dim};
+        gpu_shape = RaggedShape(axes, true);
       }
 
-      Array1<T> values(context, data);
-      Ragged<T> ragged(d == kCuda ? gpu_shape : shape, values);
-      Array1<T> max_values(context, num_rows);
-      T default_value = 0;
-      MaxPerSublist(ragged, default_value, &max_values);
-      EXPECT_EQ(max_values[row], num_elems);
+      int32_t num_elems = shape.NumElements();
+      std::vector<T> data(num_elems);
+      for (int32_t i = 0; i != 10; ++i) {
+        std::iota(data.begin(), data.end(), 0);
+        // randomly set data[pos] = num_elems which is
+        // greater than any element in data
+        int32_t pos = RandInt(0, num_elems - 1);
+        data[pos] = num_elems;
+        // find the corresponding row
+        int32_t num_rows = shape.Dim0();
+        const int32_t *row_splits_data = shape.RowSplits(1).Data();
+        int32_t row = 0;
+        for (int32_t i = 0; i < num_rows; ++i) {
+          if (pos >= row_splits_data[i] && pos < row_splits_data[i + 1]) {
+            row = i;
+            break;
+          }
+        }
+
+        Array1<T> values(context, data);
+        Ragged<T> ragged(context->GetDeviceType() == kCuda ? gpu_shape : shape,
+                         values);
+        Array1<T> max_values(context, num_rows);
+        T default_value = 0;
+        MaxPerSublist(ragged, default_value, &max_values);
+        EXPECT_EQ(max_values[row], num_elems);
+      }
     }
   }
 }
 
 TEST(RaggedShapeOpsTest, MaxPerSubListTest) {
-  TestMaxPerSubListTest<int32_t, kCpu>();
-  TestMaxPerSubListTest<int32_t, kCuda>();
+  TestMaxPerSubListTest<int32_t>();
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestMinPerSubListTest() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // empty case
+      std::vector<int32_t> row_splits_vec = {0};
+      Array1<T> row_splits(context, row_splits_vec);
+      RaggedShape shape = RaggedShape2(&row_splits, nullptr, -1);
+      Array1<T> values(context, 0);
+      Ragged<T> ragged(shape, values);
+
+      int32_t num_rows = ragged.shape.Dim0();
+      ASSERT_EQ(num_rows, 0);
+      Array1<T> min_values(context, num_rows);
+      // just run to check if there's any error
+      MinPerSublist(ragged, 1, &min_values);
+      EXPECT_EQ(min_values.Dim(), 0);
+    }
+
+    {
+      std::vector<int32_t> row_splits_vec = {0, 2, 2, 5, 6};
+      Array1<T> row_splits(context, row_splits_vec);
+      RaggedShape shape = RaggedShape2(&row_splits, nullptr, -1);
+      const std::vector<T> values_vec = {1, 3, 3, 8, 4, -1};
+      Array1<T> values(context, values_vec);
+      Ragged<T> ragged(shape, values);
+
+      int32_t num_rows = ragged.shape.Dim0();
+      Array1<T> min_values(context, num_rows);
+      T default_value = 2;
+      MinPerSublist(ragged, default_value, &min_values);
+      // copy memory from GPU/CPU to CPU
+      min_values = min_values.To(cpu);
+      std::vector<T> cpu_data(min_values.Data(),
+                              min_values.Data() + min_values.Dim());
+      std::vector<T> expected_data = {1, default_value, default_value, -1};
+      EXPECT_EQ(cpu_data, expected_data);
+    }
+
+    // May add tests for random large size? (but maybe it's fine to not add as
+    // we have tested large cases in MaxPerSubList)
   }
-
-  {
-    // empty case
-    std::vector<int32_t> row_splits_vec = {0};
-    Array1<T> row_splits(context, row_splits_vec);
-    RaggedShape shape = RaggedShape2(&row_splits, nullptr, -1);
-    Array1<T> values(context, 0);
-    Ragged<T> ragged(shape, values);
-
-    int32_t num_rows = ragged.shape.Dim0();
-    ASSERT_EQ(num_rows, 0);
-    Array1<T> min_values(context, num_rows);
-    // just run to check if there's any error
-    MinPerSublist(ragged, 1, &min_values);
-    EXPECT_EQ(min_values.Dim(), 0);
-  }
-
-  {
-    std::vector<int32_t> row_splits_vec = {0, 2, 2, 5, 6};
-    Array1<T> row_splits(context, row_splits_vec);
-    RaggedShape shape = RaggedShape2(&row_splits, nullptr, -1);
-    const std::vector<T> values_vec = {1, 3, 3, 8, 4, -1};
-    Array1<T> values(context, values_vec);
-    Ragged<T> ragged(shape, values);
-
-    int32_t num_rows = ragged.shape.Dim0();
-    Array1<T> min_values(context, num_rows);
-    T default_value = 2;
-    MinPerSublist(ragged, default_value, &min_values);
-    // copy memory from GPU/CPU to CPU
-    min_values = min_values.To(cpu);
-    std::vector<T> cpu_data(min_values.Data(),
-                            min_values.Data() + min_values.Dim());
-    std::vector<T> expected_data = {1, default_value, default_value, -1};
-    EXPECT_EQ(cpu_data, expected_data);
-  }
-
-  // May add tests for random large size? (but maybe it's fine to not add as we
-  // have tested large cases in MaxPerSubList)
 }
 
 TEST(RaggedShapeOpsTest, MinPerSubListTest) {
-  TestMinPerSubListTest<int32_t, kCpu>();
-  TestMinPerSubListTest<int32_t, kCuda>();
+  TestMinPerSubListTest<int32_t>();
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestAndOrPerSubListTest() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // And
+      const std::vector<int32_t> row_splits = {0, 2, 2, 5, 6};
+      RaggedShapeDim shape_dim;
+      shape_dim.row_splits = Array1<int32_t>(context, row_splits);
+      shape_dim.cached_tot_size = row_splits.back();
+      std::vector<RaggedShapeDim> axes = {shape_dim};
+      RaggedShape shape(axes, true);
+      const std::vector<T> values_vec = {1, 3, 3, 6, 11, 0};
+      Array1<T> values(context, values_vec);
+      Ragged<T> ragged(shape, values);
 
-  {
-    // And
-    const std::vector<int32_t> row_splits = {0, 2, 2, 5, 6};
-    RaggedShapeDim shape_dim;
-    shape_dim.row_splits = Array1<int32_t>(context, row_splits);
-    shape_dim.cached_tot_size = row_splits.back();
-    std::vector<RaggedShapeDim> axes = {shape_dim};
-    RaggedShape shape(axes, true);
-    const std::vector<T> values_vec = {1, 3, 3, 6, 11, 0};
-    Array1<T> values(context, values_vec);
-    Ragged<T> ragged(shape, values);
+      int32_t num_rows = ragged.shape.Dim0();
+      Array1<T> dst(context, num_rows);
+      T default_value = -1;
+      AndPerSublist(ragged, default_value, &dst);
+      // copy memory from GPU/CPU to CPU
+      dst = dst.To(cpu);
+      std::vector<T> cpu_data(dst.Data(), dst.Data() + dst.Dim());
+      std::vector<T> expected_data = {1, -1, 2, 0};
+      EXPECT_EQ(cpu_data, expected_data);
+    }
 
-    int32_t num_rows = ragged.shape.Dim0();
-    Array1<T> dst(context, num_rows);
-    T default_value = -1;
-    AndPerSublist(ragged, default_value, &dst);
-    // copy memory from GPU/CPU to CPU
-    dst = dst.To(cpu);
-    std::vector<T> cpu_data(dst.Data(), dst.Data() + dst.Dim());
-    std::vector<T> expected_data = {1, -1, 2, 0};
-    EXPECT_EQ(cpu_data, expected_data);
-  }
+    {
+      // Or
+      const std::vector<int32_t> row_splits = {0, 2, 2, 5, 6};
+      RaggedShapeDim shape_dim;
+      shape_dim.row_splits = Array1<int32_t>(context, row_splits);
+      shape_dim.cached_tot_size = row_splits.back();
+      std::vector<RaggedShapeDim> axes = {shape_dim};
+      RaggedShape shape(axes, true);
+      const std::vector<T> values_vec = {1, 3, 3, 4, 6, 0};
+      Array1<T> values(context, values_vec);
+      Ragged<T> ragged(shape, values);
 
-  {
-    // Or
-    const std::vector<int32_t> row_splits = {0, 2, 2, 5, 6};
-    RaggedShapeDim shape_dim;
-    shape_dim.row_splits = Array1<int32_t>(context, row_splits);
-    shape_dim.cached_tot_size = row_splits.back();
-    std::vector<RaggedShapeDim> axes = {shape_dim};
-    RaggedShape shape(axes, true);
-    const std::vector<T> values_vec = {1, 3, 3, 4, 6, 0};
-    Array1<T> values(context, values_vec);
-    Ragged<T> ragged(shape, values);
-
-    int32_t num_rows = ragged.shape.Dim0();
-    Array1<T> dst(context, num_rows);
-    T default_value = 0;
-    OrPerSublist(ragged, default_value, &dst);
-    // copy memory from GPU/CPU to CPU
-    dst = dst.To(cpu);
-    std::vector<T> cpu_data(dst.Data(), dst.Data() + dst.Dim());
-    std::vector<T> expected_data = {3, 0, 7, 0};
-    EXPECT_EQ(cpu_data, expected_data);
+      int32_t num_rows = ragged.shape.Dim0();
+      Array1<T> dst(context, num_rows);
+      T default_value = 0;
+      OrPerSublist(ragged, default_value, &dst);
+      // copy memory from GPU/CPU to CPU
+      dst = dst.To(cpu);
+      std::vector<T> cpu_data(dst.Data(), dst.Data() + dst.Dim());
+      std::vector<T> expected_data = {3, 0, 7, 0};
+      EXPECT_EQ(cpu_data, expected_data);
+    }
   }
 }
 
 TEST(RaggedShapeOpsTest, AndOrPerSubListTest) {
-  TestAndOrPerSubListTest<int32_t, kCpu>();
-  TestAndOrPerSubListTest<int32_t, kCuda>();
+  TestAndOrPerSubListTest<int32_t>();
 }
 
-void TestUnsqueeze(ContextPtr context, const RaggedShape &input_shape) {
-  RaggedShape src_shape = input_shape.To(context);
-  src_shape.Populate();  // set row_ids
-  {
-    // axis = 0.
-    RaggedShape shape = Unsqueeze(src_shape, 0);
-    int32_t dim0 = src_shape.Dim0();
-    const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
-    const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
-
+void TestUnsqueeze(const RaggedShape &input_shape) {
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape src_shape = input_shape.To(context);
+    src_shape.Populate();  // set row_ids
     {
-      const Array1<int32_t> &row_splits0 = dest_axes[0].row_splits;
-      std::vector<int32_t> data = {0, dim0};
-      CheckArrayData(row_splits0, data);
+      // axis = 0.
+      RaggedShape shape = Unsqueeze(src_shape, 0);
+      int32_t dim0 = src_shape.Dim0();
+      const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
+      const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
+
+      {
+        const Array1<int32_t> &row_splits0 = dest_axes[0].row_splits;
+        std::vector<int32_t> data = {0, dim0};
+        CheckArrayData(row_splits0, data);
+      }
+
+      {
+        const Array1<int32_t> &row_ids0 = dest_axes[0].row_ids;
+        std::vector<int32_t> data(dim0, 0);
+        CheckArrayData(row_ids0, data);
+      }
+
+      {
+        for (auto i = 0; i != src_axes.size(); ++i) {
+          CheckArrayData(src_axes[i].row_splits, dest_axes[i + 1].row_splits);
+          CheckArrayData(src_axes[i].row_ids, dest_axes[i + 1].row_ids);
+        }
+      }
     }
 
     {
-      const Array1<int32_t> &row_ids0 = dest_axes[0].row_ids;
-      std::vector<int32_t> data(dim0, 0);
-      CheckArrayData(row_ids0, data);
-    }
+      // axis = 1
+      int32_t axis = 1;
+      RaggedShape shape = Unsqueeze(src_shape, axis);
+      int32_t tot_size = shape.TotSize(axis);
+      const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
+      const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
 
-    {
-      for (auto i = 0; i != src_axes.size(); ++i) {
-        CheckArrayData(src_axes[i].row_splits, dest_axes[i + 1].row_splits);
-        CheckArrayData(src_axes[i].row_ids, dest_axes[i + 1].row_ids);
+      {
+        for (auto i = 0; i < axis; ++i) {
+          CheckArrayData(src_axes[i].row_splits, dest_axes[i].row_splits);
+          CheckArrayData(src_axes[i].row_ids, dest_axes[i].row_ids);
+        }
+      }
+
+      {
+        const Array1<int32_t> &row_splits = dest_axes[axis].row_splits;
+        std::vector<int32_t> data(tot_size + 1);
+        std::iota(data.begin(), data.end(), 0);
+        CheckArrayData(row_splits, data);
+      }
+
+      {
+        const Array1<int32_t> &row_ids = dest_axes[axis].row_ids;
+        std::vector<int32_t> data(tot_size);
+        std::iota(data.begin(), data.end(), 0);
+        CheckArrayData(row_ids, data);
+      }
+
+      {
+        for (auto i = axis; i < src_axes.size(); ++i) {
+          CheckArrayData(src_axes[i].row_splits, dest_axes[i + 1].row_splits);
+          CheckArrayData(src_axes[i].row_ids, dest_axes[i + 1].row_ids);
+        }
       }
     }
   }
-
-  {
-    // axis = 1
-    int32_t axis = 1;
-    RaggedShape shape = Unsqueeze(src_shape, axis);
-    int32_t tot_size = shape.TotSize(axis);
-    const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
-    const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
-
-    {
-      for (auto i = 0; i < axis; ++i) {
-        CheckArrayData(src_axes[i].row_splits, dest_axes[i].row_splits);
-        CheckArrayData(src_axes[i].row_ids, dest_axes[i].row_ids);
-      }
-    }
-
-    {
-      const Array1<int32_t> &row_splits = dest_axes[axis].row_splits;
-      std::vector<int32_t> data(tot_size + 1);
-      std::iota(data.begin(), data.end(), 0);
-      CheckArrayData(row_splits, data);
-    }
-
-    {
-      const Array1<int32_t> &row_ids = dest_axes[axis].row_ids;
-      std::vector<int32_t> data(tot_size);
-      std::iota(data.begin(), data.end(), 0);
-      CheckArrayData(row_ids, data);
-    }
-
-    {
-      for (auto i = axis; i < src_axes.size(); ++i) {
-        CheckArrayData(src_axes[i].row_splits, dest_axes[i + 1].row_splits);
-        CheckArrayData(src_axes[i].row_ids, dest_axes[i + 1].row_ids);
-      }
-    }
-  }
 }
 
-TEST_F(RaggedShapeOpsSuiteTest, TestUnsqueezeCpu) {
-  TestUnsqueeze(GetCpuContext(), simple_shape_);
-  TestUnsqueeze(GetCpuContext(), random_shape_);
+TEST_F(RaggedShapeOpsSuiteTest, TestUnsqueeze) {
+  TestUnsqueeze(simple_shape_);
+  TestUnsqueeze(random_shape_);
 }
-TEST_F(RaggedShapeOpsSuiteTest, TestUnsqueezeGpu) {
-  TestUnsqueeze(GetCudaContext(), simple_shape_);
-  TestUnsqueeze(GetCudaContext(), random_shape_);
-}
-
 
 TEST(RaggedShapeOpsTest, TestUnsqueezeParallel) {
   for (int32_t i = 0; i < 10; i++) {
     ContextPtr c = (i % 2 == 0 ? GetCpuContext() : GetCudaContext());
     int32_t num_shapes = RandInt(0, 10);
 
-    std::vector<RaggedShape*> orig_shapes;
+    std::vector<RaggedShape *> orig_shapes;
     for (int32_t i = 0; i < num_shapes; i++)
-      orig_shapes.push_back(new RaggedShape(RandomRaggedShape(false, 2, 5, 0, 1000).To(c)));
+      orig_shapes.push_back(
+          new RaggedShape(RandomRaggedShape(false, 2, 5, 0, 1000).To(c)));
     int32_t axis = 0;  // only one supported for now.
     std::vector<RaggedShape> unsqueezed =
         UnsqueezeParallel(num_shapes, orig_shapes.data(), axis);
@@ -455,113 +434,107 @@ TEST(RaggedShapeOpsTest, TestUnsqueezeParallel) {
   }
 }
 
-
-
-void TestRemoveAxis(ContextPtr context, const RaggedShape &input_shape) {
-  RaggedShape src_shape = input_shape.To(context);
-  ASSERT_EQ(src_shape.NumAxes(), 4);
-  {
-    // axis = 0.
-    int32_t axis = 0;
-    RaggedShape shape = RemoveAxis(src_shape, axis);
-    const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
-    const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
-    ASSERT_EQ(src_axes.size(), 3);
-    ASSERT_EQ(dest_axes.size(), 2);
-
+void TestRemoveAxis(const RaggedShape &input_shape) {
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape src_shape = input_shape.To(context);
+    ASSERT_EQ(src_shape.NumAxes(), 4);
     {
-      for (auto i = 0; i != dest_axes.size(); ++i) {
-        CheckArrayData(dest_axes[i].row_splits, src_axes[i + 1].row_splits);
-        CheckArrayData(dest_axes[i].row_ids, src_axes[i + 1].row_ids);
+      // axis = 0.
+      int32_t axis = 0;
+      RaggedShape shape = RemoveAxis(src_shape, axis);
+      const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
+      const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
+      ASSERT_EQ(src_axes.size(), 3);
+      ASSERT_EQ(dest_axes.size(), 2);
+
+      {
+        for (auto i = 0; i != dest_axes.size(); ++i) {
+          CheckArrayData(dest_axes[i].row_splits, src_axes[i + 1].row_splits);
+          CheckArrayData(dest_axes[i].row_ids, src_axes[i + 1].row_ids);
+        }
       }
     }
-  }
-
-  {
-    // axis = 1
-    int32_t axis = 1;
-    RaggedShape shape = RemoveAxis(src_shape, axis);
-    const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
-    const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
-    ASSERT_EQ(src_axes.size(), 3);
-    ASSERT_EQ(dest_axes.size(), 2);
 
     {
-      const Array1<int32_t> &row_splits0 = dest_axes[0].row_splits;
-      std::vector<int32_t> data = {0, 3, 7, 10};
-      CheckArrayData(row_splits0, data);
-    }
+      // axis = 1
+      int32_t axis = 1;
+      RaggedShape shape = RemoveAxis(src_shape, axis);
+      const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
+      const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
+      ASSERT_EQ(src_axes.size(), 3);
+      ASSERT_EQ(dest_axes.size(), 2);
 
-    {
-      const Array1<int32_t> &row_ids0 = dest_axes[0].row_ids;
-      std::vector<int32_t> data = {0, 0, 0, 1, 1, 1, 1, 2, 2, 2};
-      CheckArrayData(row_ids0, data);
-    }
+      {
+        const Array1<int32_t> &row_splits0 = dest_axes[0].row_splits;
+        std::vector<int32_t> data = {0, 3, 7, 10};
+        CheckArrayData(row_splits0, data);
+      }
 
-    {
-      for (auto i = 1; i != dest_axes.size(); ++i) {
-        CheckArrayData(dest_axes[i].row_splits, src_axes[i + 1].row_splits);
-        CheckArrayData(dest_axes[i].row_ids, src_axes[i + 1].row_ids);
+      {
+        const Array1<int32_t> &row_ids0 = dest_axes[0].row_ids;
+        std::vector<int32_t> data = {0, 0, 0, 1, 1, 1, 1, 2, 2, 2};
+        CheckArrayData(row_ids0, data);
+      }
+
+      {
+        for (auto i = 1; i != dest_axes.size(); ++i) {
+          CheckArrayData(dest_axes[i].row_splits, src_axes[i + 1].row_splits);
+          CheckArrayData(dest_axes[i].row_ids, src_axes[i + 1].row_ids);
+        }
       }
     }
-  }
-
-  {
-    // axis = 3
-    int32_t axis = 3;  // the last axis
-    RaggedShape shape = RemoveAxis(src_shape, axis);
-    const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
-    const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
-    ASSERT_EQ(src_axes.size(), 3);
-    ASSERT_EQ(dest_axes.size(), 2);
 
     {
-      for (auto i = 0; i != dest_axes.size(); ++i) {
-        CheckArrayData(dest_axes[i].row_splits, src_axes[i].row_splits);
-        CheckArrayData(dest_axes[i].row_ids, src_axes[i].row_ids);
-      }
-    }
-  }
-}
+      // axis = 3
+      int32_t axis = 3;  // the last axis
+      RaggedShape shape = RemoveAxis(src_shape, axis);
+      const std::vector<RaggedShapeDim> &src_axes = src_shape.Axes();
+      const std::vector<RaggedShapeDim> &dest_axes = shape.Axes();
+      ASSERT_EQ(src_axes.size(), 3);
+      ASSERT_EQ(dest_axes.size(), 2);
 
-TEST_F(RaggedShapeOpsSuiteTest, TestRemoveAxisCpu) {
-  TestRemoveAxis(GetCpuContext(), simple_shape_);
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestRemoveAxisGpu) {
-  TestRemoveAxis(GetCudaContext(), simple_shape_);
-}
-
-void TestGetOffsets(ContextPtr context) {
-  for (int32_t i = 0; i != 2; ++i) {
-    int32_t num_shape = RandInt(10, 100);
-    int32_t num_axes = RandInt(2, 4);
-    std::vector<RaggedShape> shape_vec(num_shape);
-    std::vector<RaggedShape *> shapes(num_shape);
-    for (int32_t j = 0; j != num_shape; ++j) {
-      shape_vec[j] =
-          RandomRaggedShape(false, num_axes, num_axes, 0, 1000).To(context);
-      shapes[j] = &shape_vec[j];
-    }
-    RaggedShape **shapes_ptr = shapes.data();
-    Array2<int32_t> offsets = GetOffsets(num_shape, shapes_ptr);
-    ASSERT_EQ(offsets.Dim0(), num_axes + 1);
-    ASSERT_EQ(offsets.Dim1(), num_shape + 1);
-    auto acc = offsets.Accessor();
-    for (int32_t axis = 0; axis <= num_axes; ++axis) {
-      int32_t sum = 0;
-      for (int32_t j = 0; j <= num_shape; ++j) {
-        EXPECT_EQ(acc(axis, j), sum);
-        if (j < num_shape) {
-          sum += (axis == 0 ? 1 : shape_vec[j].TotSize(axis - 1));
+      {
+        for (auto i = 0; i != dest_axes.size(); ++i) {
+          CheckArrayData(dest_axes[i].row_splits, src_axes[i].row_splits);
+          CheckArrayData(dest_axes[i].row_ids, src_axes[i].row_ids);
         }
       }
     }
   }
 }
 
+TEST_F(RaggedShapeOpsSuiteTest, TestRemoveAxis) {
+  TestRemoveAxis(simple_shape_);
+}
+
 TEST(RaggedShapeOpsTest, TestGetOffsets) {
-  TestGetOffsets(GetCpuContext());
-  TestGetOffsets(GetCudaContext());
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    for (int32_t i = 0; i != 2; ++i) {
+      int32_t num_shape = RandInt(10, 100);
+      int32_t num_axes = RandInt(2, 4);
+      std::vector<RaggedShape> shape_vec(num_shape);
+      std::vector<RaggedShape *> shapes(num_shape);
+      for (int32_t j = 0; j != num_shape; ++j) {
+        shape_vec[j] =
+            RandomRaggedShape(false, num_axes, num_axes, 0, 1000).To(context);
+        shapes[j] = &shape_vec[j];
+      }
+      RaggedShape **shapes_ptr = shapes.data();
+      Array2<int32_t> offsets = GetOffsets(num_shape, shapes_ptr);
+      ASSERT_EQ(offsets.Dim0(), num_axes + 1);
+      ASSERT_EQ(offsets.Dim1(), num_shape + 1);
+      auto acc = offsets.Accessor();
+      for (int32_t axis = 0; axis <= num_axes; ++axis) {
+        int32_t sum = 0;
+        for (int32_t j = 0; j <= num_shape; ++j) {
+          EXPECT_EQ(acc(axis, j), sum);
+          if (j < num_shape) {
+            sum += (axis == 0 ? 1 : shape_vec[j].TotSize(axis - 1));
+          }
+        }
+      }
+    }
+  }
 }
 
 // returns a random ragged shape where the dims on axis 1 are all the same
@@ -587,486 +560,448 @@ RaggedShape RandomRaggedShapeToTranspose(ContextPtr c) {
   return ComposeRaggedShapes(top_level_shape, random);
 }
 
-template <DeviceType d>
-void TestTranspose() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+TEST(RaggedShapeOpsTest, TestTranspose) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      const std::vector<int32_t> row_splits1_vec = {0, 2, 4, 6};
+      const std::vector<int32_t> row_splits2_vec = {0, 3, 4, 7, 8, 10, 12};
+      Array1<int32_t> row_splits1(context, row_splits1_vec);
+      Array1<int32_t> row_splits2(context, row_splits2_vec);
+      RaggedShape src_shape =
+          RaggedShape3(&row_splits1, nullptr, -1, &row_splits2, nullptr, -1);
+      ASSERT_EQ(src_shape.Dim0(), 3);
+      ASSERT_EQ(src_shape.TotSize(1), 6);
+      RaggedShape shape = Transpose(src_shape);
+      EXPECT_EQ(shape.Dim0(), 2);
+      ASSERT_EQ(shape.TotSize(1), 6);
+      const std::vector<int32_t> expected_row_splits = {0, 3, 6};
+      const std::vector<int32_t> expected_row_ids = {0, 0, 0, 1, 1, 1};
+      CheckArrayData(shape.RowSplits(1), expected_row_splits);
+      CheckArrayData(shape.RowIds(1), expected_row_ids);
+      CheckArrayData(shape.RowSplits(2), {0, 3, 6, 8, 9, 10, 12});
+      CheckArrayData(shape.RowIds(2), {0, 0, 0, 1, 1, 1, 2, 2, 3, 4, 5, 5});
+    }
 
-  {
-    const std::vector<int32_t> row_splits1_vec = {0, 2, 4, 6};
-    const std::vector<int32_t> row_splits2_vec = {0, 3, 4, 7, 8, 10, 12};
-    Array1<int32_t> row_splits1(context, row_splits1_vec);
-    Array1<int32_t> row_splits2(context, row_splits2_vec);
-    RaggedShape src_shape =
-        RaggedShape3(&row_splits1, nullptr, -1, &row_splits2, nullptr, -1);
-    ASSERT_EQ(src_shape.Dim0(), 3);
-    ASSERT_EQ(src_shape.TotSize(1), 6);
-    RaggedShape shape = Transpose(src_shape);
-    EXPECT_EQ(shape.Dim0(), 2);
-    ASSERT_EQ(shape.TotSize(1), 6);
-    const std::vector<int32_t> expected_row_splits = {0, 3, 6};
-    const std::vector<int32_t> expected_row_ids = {0, 0, 0, 1, 1, 1};
-    CheckArrayData(shape.RowSplits(1), expected_row_splits);
-    CheckArrayData(shape.RowIds(1), expected_row_ids);
-    CheckArrayData(shape.RowSplits(2), {0, 3, 6, 8, 9, 10, 12});
-    CheckArrayData(shape.RowIds(2), {0, 0, 0, 1, 1, 1, 2, 2, 3, 4, 5, 5});
-  }
+    {
+      // random case
+      for (int32_t j = 0; j != 2; ++j) {
+        RaggedShape to_transpose = RandomRaggedShapeToTranspose(context);
+        RaggedShape transposed = Transpose(to_transpose);
 
-  {
-    // random case
-    for (int32_t j = 0; j != 2; ++j) {
-      RaggedShape to_transpose = RandomRaggedShapeToTranspose(context);
-      RaggedShape transposed = Transpose(to_transpose);
+        if (context->GetDeviceType() != kCpu) {
+          to_transpose = to_transpose.To(cpu);
+          transposed = transposed.To(cpu);
+        }
 
-      if (d != kCpu) {
-        to_transpose = to_transpose.To(cpu);
-        transposed = transposed.To(cpu);
-      }
-
-      for (auto iter = transposed.Iterator(); !iter.Done(); iter.Next()) {
-        std::vector<int32_t> index = iter.Value();
-        int32_t i = transposed[index];  // Just make sure this doesn't crash,
-                                        // dont need the value.
-        std::swap(index[0], index[1]);
-        i = to_transpose[index];  // don't need the value, just need to make
-                                  // sure it's an allowable index.
-      }
-      for (auto iter = to_transpose.Iterator(); !iter.Done(); iter.Next()) {
-        std::vector<int32_t> index = iter.Value();
-        std::swap(index[0], index[1]);
-        int32_t i = transposed[index];  // don't need the value, just need to
-                                        // make sure it's an allowable index.
+        for (auto iter = transposed.Iterator(); !iter.Done(); iter.Next()) {
+          std::vector<int32_t> index = iter.Value();
+          int32_t i = transposed[index];  // Just make sure this doesn't crash,
+                                          // dont need the value.
+          std::swap(index[0], index[1]);
+          i = to_transpose[index];  // don't need the value, just need to make
+                                    // sure it's an allowable index.
+        }
+        for (auto iter = to_transpose.Iterator(); !iter.Done(); iter.Next()) {
+          std::vector<int32_t> index = iter.Value();
+          std::swap(index[0], index[1]);
+          int32_t i = transposed[index];  // don't need the value, just need to
+                                          // make sure it's an allowable index.
+        }
       }
     }
   }
 }
-TEST(RaggedShapeOpsTest, TestTranspose) {
-  TestTranspose<kCpu>();
-  TestTranspose<kCuda>();
-}
 
-template <DeviceType d, typename T>
+template <typename T>
 void TestTransposeRagged() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      const std::vector<int32_t> row_splits1_vec = {0, 2, 4, 6};
+      const std::vector<int32_t> row_splits2_vec = {0, 3, 4, 7, 8, 10, 12};
+      Array1<int32_t> row_splits1(context, row_splits1_vec);
+      Array1<int32_t> row_splits2(context, row_splits2_vec);
+      RaggedShape src_shape =
+          RaggedShape3(&row_splits1, nullptr, -1, &row_splits2, nullptr, -1);
+      ASSERT_EQ(src_shape.Dim0(), 3);
+      ASSERT_EQ(src_shape.TotSize(1), 6);
+      std::vector<T> values = {0, 1, 2, 3, 4, 5, 8, 7, 6, 9, 10, 15};
+      ASSERT_EQ(values.size(), src_shape.NumElements());
+      Array1<T> values_array(context, values);
+      Ragged<T> ragged(src_shape, values_array);
+      Ragged<T> ans = Transpose(ragged);
+      RaggedShape shape = ans.shape;
+      // Check shape
+      ASSERT_EQ(shape.Dim0(), 2);
+      ASSERT_EQ(shape.TotSize(1), 6);
+      const std::vector<int32_t> expected_row_splits = {0, 3, 6};
+      const std::vector<int32_t> expected_row_ids = {0, 0, 0, 1, 1, 1};
+      CheckArrayData(shape.RowSplits(1), expected_row_splits);
+      CheckArrayData(shape.RowIds(1), expected_row_ids);
+      CheckArrayData(shape.RowSplits(2), {0, 3, 6, 8, 9, 10, 12});
+      CheckArrayData(shape.RowIds(2), {0, 0, 0, 1, 1, 1, 2, 2, 3, 4, 5, 5});
+      // Check values
+      CheckArrayData(ans.values, {0, 1, 2, 4, 5, 8, 6, 9, 3, 7, 10, 15});
+    }
 
-  {
-    const std::vector<int32_t> row_splits1_vec = {0, 2, 4, 6};
-    const std::vector<int32_t> row_splits2_vec = {0, 3, 4, 7, 8, 10, 12};
-    Array1<int32_t> row_splits1(context, row_splits1_vec);
-    Array1<int32_t> row_splits2(context, row_splits2_vec);
-    RaggedShape src_shape =
-        RaggedShape3(&row_splits1, nullptr, -1, &row_splits2, nullptr, -1);
-    ASSERT_EQ(src_shape.Dim0(), 3);
-    ASSERT_EQ(src_shape.TotSize(1), 6);
-    std::vector<T> values = {0, 1, 2, 3, 4, 5, 8, 7, 6, 9, 10, 15};
-    ASSERT_EQ(values.size(), src_shape.NumElements());
-    Array1<T> values_array(context, values);
-    Ragged<T> ragged(src_shape, values_array);
-    Ragged<T> ans = Transpose(ragged);
-    RaggedShape shape = ans.shape;
-    // Check shape
-    ASSERT_EQ(shape.Dim0(), 2);
-    ASSERT_EQ(shape.TotSize(1), 6);
-    const std::vector<int32_t> expected_row_splits = {0, 3, 6};
-    const std::vector<int32_t> expected_row_ids = {0, 0, 0, 1, 1, 1};
-    CheckArrayData(shape.RowSplits(1), expected_row_splits);
-    CheckArrayData(shape.RowIds(1), expected_row_ids);
-    CheckArrayData(shape.RowSplits(2), {0, 3, 6, 8, 9, 10, 12});
-    CheckArrayData(shape.RowIds(2), {0, 0, 0, 1, 1, 1, 2, 2, 3, 4, 5, 5});
-    // Check values
-    CheckArrayData(ans.values, {0, 1, 2, 4, 5, 8, 6, 9, 3, 7, 10, 15});
-  }
+    {
+      // random case
+      for (int32_t j = 0; j != 2; ++j) {
+        RaggedShape to_transpose = RandomRaggedShapeToTranspose(context);
+        int32_t num_elems = to_transpose.NumElements();
+        Array1<T> src_values =
+            RandUniformArray1<T>(context, num_elems, 0, 10000);
+        Ragged<T> src(to_transpose, src_values);
+        Ragged<T> ans = Transpose(src);
+        if (context->GetDeviceType() == kCuda) {
+          src = src.To(cpu);
+          ans = ans.To(cpu);
+          to_transpose = to_transpose.To(cpu);
+        }
+        RaggedShape transposed = ans.shape;
 
-  {
-    // random case
-    for (int32_t j = 0; j != 2; ++j) {
-      RaggedShape to_transpose = RandomRaggedShapeToTranspose(context);
-      int32_t num_elems = to_transpose.NumElements();
-      Array1<T> src_values = RandUniformArray1<T>(context, num_elems, 0, 10000);
-      Ragged<T> src(to_transpose, src_values);
-      Ragged<T> ans = Transpose(src);
-      if (d != kCpu) {
-        src = src.To(cpu);
-        ans = ans.To(cpu);
-        to_transpose = to_transpose.To(cpu);
-      }
-      RaggedShape transposed = ans.shape;
-
-      for (auto iter = transposed.Iterator(); !iter.Done(); iter.Next()) {
-        std::vector<int32_t> index = iter.Value();
-        T value = ans[index];
-        std::swap(index[0], index[1]);
-        EXPECT_EQ(value, src[index]);
-      }
-      for (auto iter = to_transpose.Iterator(); !iter.Done(); iter.Next()) {
-        std::vector<int32_t> index = iter.Value();
-        T value = src[index];
-        std::swap(index[0], index[1]);
-        EXPECT_EQ(value, ans[index]);
+        for (auto iter = transposed.Iterator(); !iter.Done(); iter.Next()) {
+          std::vector<int32_t> index = iter.Value();
+          T value = ans[index];
+          std::swap(index[0], index[1]);
+          EXPECT_EQ(value, src[index]);
+        }
+        for (auto iter = to_transpose.Iterator(); !iter.Done(); iter.Next()) {
+          std::vector<int32_t> index = iter.Value();
+          T value = src[index];
+          std::swap(index[0], index[1]);
+          EXPECT_EQ(value, ans[index]);
+        }
       }
     }
   }
 }
 TEST(RaggedTest, TestTransposeRagged) {
-  TestTransposeRagged<kCpu, int32_t>();
-  TestTransposeRagged<kCuda, int32_t>();
-  TestTransposeRagged<kCpu, double>();
-  TestTransposeRagged<kCuda, double>();
+  TestTransposeRagged<int32_t>();
+  TestTransposeRagged<double>();
 }
 
-template <DeviceType d>
-void TestRowSplitsPtr() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-  RaggedShape shape = RandomRaggedShape().To(context);
-  ASSERT_GE(shape.NumAxes(), 2);
-  Array1<int32_t *> ptrs = GetRowSplitsPtr(shape);
-  ASSERT_EQ(ptrs.Dim(), shape.NumAxes() - 1);
-  // as num_axes is not so big, access (may copy memory) it in a loop is fine.
-  for (int32_t i = 0; i != ptrs.Dim(); ++i) {
-    EXPECT_EQ(ptrs[i], shape.RowSplits(i + 1).Data());
-  }
-}
 TEST(RaggedShapeOpsTest, TestRowSplitsPtr) {
-  TestRowSplitsPtr<kCpu>();
-  TestRowSplitsPtr<kCuda>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape shape = RandomRaggedShape().To(context);
+    ASSERT_GE(shape.NumAxes(), 2);
+    Array1<int32_t *> ptrs = GetRowSplitsPtr(shape);
+    ASSERT_EQ(ptrs.Dim(), shape.NumAxes() - 1);
+    // as num_axes is not so big, access (may copy memory) it in a loop is fine.
+    for (int32_t i = 0; i != ptrs.Dim(); ++i) {
+      EXPECT_EQ(ptrs[i], shape.RowSplits(i + 1).Data());
+    }
+  }
 }
 
-void TestRaggedShape2(ContextPtr context, const RaggedShape &shape) {
-  RaggedShape src_shape = shape.To(context);
-  src_shape.Populate();
-  ASSERT_GE(src_shape.NumAxes(), 2);
-  Array1<int32_t> row_splits = src_shape.RowSplits(1);
-  Array1<int32_t> row_ids = src_shape.RowIds(1);
-  int32_t cached_tot_size = src_shape.TotSize(1);
+void TestRaggedShape2(const RaggedShape &shape) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape src_shape = shape.To(context);
+    src_shape.Populate();
+    ASSERT_GE(src_shape.NumAxes(), 2);
+    Array1<int32_t> row_splits = src_shape.RowSplits(1);
+    Array1<int32_t> row_ids = src_shape.RowIds(1);
+    int32_t cached_tot_size = src_shape.TotSize(1);
 
-  {
-    // both row_splits and row_ids are non-null
-    RaggedShape result = RaggedShape2(&row_splits, &row_ids, cached_tot_size);
-    CheckArrayData(result.RowSplits(1), row_splits);
-    CheckArrayData(result.RowIds(1), row_ids);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size);
-  }
-  {
-    // both row_splits and row_ids are non-null, cached_tot_size = -1
-    RaggedShape result = RaggedShape2(&row_splits, &row_ids, -1);
-    CheckArrayData(result.RowSplits(1), row_splits);
-    CheckArrayData(result.RowIds(1), row_ids);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size);
-  }
-  {
-    // row_ids is null
-    RaggedShape result = RaggedShape2(&row_splits, nullptr, cached_tot_size);
-    CheckArrayData(result.RowSplits(1), row_splits);
-    CheckArrayData(result.RowIds(1), row_ids);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size);
-  }
-  {
-    // row_ids is null, cached_tot_size = -1
-    RaggedShape result = RaggedShape2(&row_splits, nullptr, -1);
-    CheckArrayData(result.RowSplits(1), row_splits);
-    CheckArrayData(result.RowIds(1), row_ids);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size);
-  }
-
-  // note if row_splits == null, then we suppose there's no empty rows after the
-  // last row-id in row_ids
-  if (row_splits.Dim() == (row_ids.Dim() == 0 ? 1 : row_ids.Back() + 2)) {
     {
-      // row_splits is null
-      RaggedShape result = RaggedShape2(nullptr, &row_ids, cached_tot_size);
+      // both row_splits and row_ids are non-null
+      RaggedShape result = RaggedShape2(&row_splits, &row_ids, cached_tot_size);
       CheckArrayData(result.RowSplits(1), row_splits);
       CheckArrayData(result.RowIds(1), row_ids);
       EXPECT_EQ(result.TotSize(1), cached_tot_size);
     }
     {
-      // row_splits is null, cached_tot_size = -1
-      RaggedShape result = RaggedShape2(nullptr, &row_ids, -1);
+      // both row_splits and row_ids are non-null, cached_tot_size = -1
+      RaggedShape result = RaggedShape2(&row_splits, &row_ids, -1);
       CheckArrayData(result.RowSplits(1), row_splits);
       CheckArrayData(result.RowIds(1), row_ids);
       EXPECT_EQ(result.TotSize(1), cached_tot_size);
     }
-  }
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestRaggedShape2Cpu) {
-  TestRaggedShape2(GetCpuContext(), simple_shape_);
-  TestRaggedShape2(GetCpuContext(), random_shape_);
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestRaggedShape2Gpu) {
-  TestRaggedShape2(GetCudaContext(), simple_shape_);
-  TestRaggedShape2(GetCudaContext(), random_shape_);
-}
+    {
+      // row_ids is null
+      RaggedShape result = RaggedShape2(&row_splits, nullptr, cached_tot_size);
+      CheckArrayData(result.RowSplits(1), row_splits);
+      CheckArrayData(result.RowIds(1), row_ids);
+      EXPECT_EQ(result.TotSize(1), cached_tot_size);
+    }
+    {
+      // row_ids is null, cached_tot_size = -1
+      RaggedShape result = RaggedShape2(&row_splits, nullptr, -1);
+      CheckArrayData(result.RowSplits(1), row_splits);
+      CheckArrayData(result.RowIds(1), row_ids);
+      EXPECT_EQ(result.TotSize(1), cached_tot_size);
+    }
 
-void TestRaggedShape3(ContextPtr context, const RaggedShape &shape) {
-  RaggedShape src_shape = shape.To(context);
-  src_shape.Populate();
-  ASSERT_GE(src_shape.NumAxes(), 3);
-  Array1<int32_t> row_splits1 = src_shape.RowSplits(1);
-  Array1<int32_t> row_ids1 = src_shape.RowIds(1);
-  int32_t cached_tot_size1 = src_shape.TotSize(1);
-  Array1<int32_t> row_splits2 = src_shape.RowSplits(2);
-  Array1<int32_t> row_ids2 = src_shape.RowIds(2);
-  int32_t cached_tot_size2 = src_shape.TotSize(2);
-
-  {
-    // both row_splits and row_ids are non-null
-    RaggedShape result =
-        RaggedShape3(&row_splits1, &row_ids1, cached_tot_size1, &row_splits2,
-                     &row_ids2, cached_tot_size2);
-    CheckArrayData(result.RowSplits(1), row_splits1);
-    CheckArrayData(result.RowIds(1), row_ids1);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size1);
-    CheckArrayData(result.RowSplits(2), row_splits2);
-    CheckArrayData(result.RowIds(2), row_ids2);
-    EXPECT_EQ(result.TotSize(2), cached_tot_size2);
-  }
-  {
-    // row_ids is non-null, cached_tot_size = -1
-    RaggedShape result =
-        RaggedShape3(&row_splits1, nullptr, -1, &row_splits2, nullptr, -1);
-    CheckArrayData(result.RowSplits(1), row_splits1);
-    CheckArrayData(result.RowIds(1), row_ids1);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size1);
-    CheckArrayData(result.RowSplits(2), row_splits2);
-    CheckArrayData(result.RowIds(2), row_ids2);
-    EXPECT_EQ(result.TotSize(2), cached_tot_size2);
-  }
-
-  // note if row_splits == null, then we suppose there's no empty rows after the
-  // last row-id in row_ids
-  bool valid1 =
-      (row_splits1.Dim() == (row_ids1.Dim() == 0 ? 1 : row_ids1.Back() + 2));
-  bool valid2 =
-      (row_splits2.Dim() == (row_ids2.Dim() == 0 ? 1 : row_ids2.Back() + 2));
-  if (valid1 && valid2) {
-    RaggedShape result =
-        RaggedShape3(nullptr, &row_ids1, -1, nullptr, &row_ids2, -1);
-    CheckArrayData(result.RowSplits(1), row_splits1);
-    CheckArrayData(result.RowIds(1), row_ids1);
-    EXPECT_EQ(result.TotSize(1), cached_tot_size1);
-    CheckArrayData(result.RowSplits(2), row_splits2);
-    CheckArrayData(result.RowIds(2), row_ids2);
-    EXPECT_EQ(result.TotSize(2), cached_tot_size2);
-  }
-  // TODO(haowen): add more cases for other branches
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestRaggedShape3Cpu) {
-  TestRaggedShape3(GetCpuContext(), simple_shape_);
-  TestRaggedShape3(GetCpuContext(), random_shape_);
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestRaggedShape3Gpu) {
-  TestRaggedShape3(GetCudaContext(), simple_shape_);
-  TestRaggedShape3(GetCudaContext(), random_shape_);
-}
-
-void TestComposeShape(ContextPtr context, const RaggedShape &shape) {
-  RaggedShape src_shape = shape.To(context);
-  ASSERT_GE(src_shape.NumAxes(), 3);
-  Array1<int32_t> row_splits1 = src_shape.RowSplits(1);
-  Array1<int32_t> row_ids1 = src_shape.RowIds(1);
-  Array1<int32_t> row_splits2 = src_shape.RowSplits(2);
-  Array1<int32_t> row_ids2 = src_shape.RowIds(2);
-
-  RaggedShape shape1 = RaggedShape2(&row_splits1, nullptr, -1);
-  RaggedShape shape2 = RaggedShape2(&row_splits2, nullptr, -1);
-
-  RaggedShape result = ComposeRaggedShapes(shape1, shape2);
-
-  ASSERT_EQ(result.NumAxes(), 3);
-
-  CheckArrayData(result.RowSplits(1), row_splits1);
-  CheckArrayData(result.RowIds(1), row_ids1);
-  CheckArrayData(result.RowSplits(2), row_splits2);
-  CheckArrayData(result.RowIds(2), row_ids2);
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestComposeShapeCpu) {
-  TestComposeShape(GetCpuContext(), simple_shape_);
-  TestComposeShape(GetCpuContext(), random_shape_);
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestComposeShapeGpu) {
-  TestComposeShape(GetCudaContext(), simple_shape_);
-  TestComposeShape(GetCudaContext(), random_shape_);
-}
-
-void TestShapeFromTotSize(ContextPtr context, const RaggedShape &shape) {
-  RaggedShape src_shape = shape.To(context);
-  ASSERT_GE(src_shape.NumAxes(), 2);
-
-  int32_t num_axes = src_shape.NumAxes();
-  std::vector<int32_t> tot_sizes(num_axes);
-  for (int32_t i = 0; i != num_axes; ++i) {
-    tot_sizes[i] = src_shape.TotSize(i);
-  }
-
-  RaggedShape result =
-      RaggedShapeFromTotSizes(context, num_axes, tot_sizes.data());
-
-  ASSERT_EQ(result.NumAxes(), num_axes);
-  for (int32_t i = 0; i < num_axes; ++i) {
-    EXPECT_EQ(result.TotSize(i), src_shape.TotSize(i));
-    if (i > 0) {
-      EXPECT_EQ(result.RowSplits(i).Dim(), src_shape.RowSplits(i).Dim());
-      EXPECT_EQ(result.RowIds(i).Dim(), src_shape.RowIds(i).Dim());
+    // note if row_splits == null, then we suppose there's no empty rows after
+    // the last row-id in row_ids
+    if (row_splits.Dim() == (row_ids.Dim() == 0 ? 1 : row_ids.Back() + 2)) {
+      {
+        // row_splits is null
+        RaggedShape result = RaggedShape2(nullptr, &row_ids, cached_tot_size);
+        CheckArrayData(result.RowSplits(1), row_splits);
+        CheckArrayData(result.RowIds(1), row_ids);
+        EXPECT_EQ(result.TotSize(1), cached_tot_size);
+      }
+      {
+        // row_splits is null, cached_tot_size = -1
+        RaggedShape result = RaggedShape2(nullptr, &row_ids, -1);
+        CheckArrayData(result.RowSplits(1), row_splits);
+        CheckArrayData(result.RowIds(1), row_ids);
+        EXPECT_EQ(result.TotSize(1), cached_tot_size);
+      }
     }
   }
 }
-TEST_F(RaggedShapeOpsSuiteTest, TestShapeFromTotSizeCpu) {
-  TestShapeFromTotSize(GetCpuContext(), simple_shape_);
-  TestShapeFromTotSize(GetCpuContext(), random_shape_);
-}
-TEST_F(RaggedShapeOpsSuiteTest, TestShapeFromTotSizeGpu) {
-  TestShapeFromTotSize(GetCudaContext(), simple_shape_);
-  TestShapeFromTotSize(GetCudaContext(), random_shape_);
+TEST_F(RaggedShapeOpsSuiteTest, TestRaggedShape2) {
+  TestRaggedShape2(simple_shape_);
+  TestRaggedShape2(random_shape_);
 }
 
-template <typename T, DeviceType d>
+void TestRaggedShape3(const RaggedShape &shape) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape src_shape = shape.To(context);
+    src_shape.Populate();
+    ASSERT_GE(src_shape.NumAxes(), 3);
+    Array1<int32_t> row_splits1 = src_shape.RowSplits(1);
+    Array1<int32_t> row_ids1 = src_shape.RowIds(1);
+    int32_t cached_tot_size1 = src_shape.TotSize(1);
+    Array1<int32_t> row_splits2 = src_shape.RowSplits(2);
+    Array1<int32_t> row_ids2 = src_shape.RowIds(2);
+    int32_t cached_tot_size2 = src_shape.TotSize(2);
+
+    {
+      // both row_splits and row_ids are non-null
+      RaggedShape result =
+          RaggedShape3(&row_splits1, &row_ids1, cached_tot_size1, &row_splits2,
+                       &row_ids2, cached_tot_size2);
+      CheckArrayData(result.RowSplits(1), row_splits1);
+      CheckArrayData(result.RowIds(1), row_ids1);
+      EXPECT_EQ(result.TotSize(1), cached_tot_size1);
+      CheckArrayData(result.RowSplits(2), row_splits2);
+      CheckArrayData(result.RowIds(2), row_ids2);
+      EXPECT_EQ(result.TotSize(2), cached_tot_size2);
+    }
+    {
+      // row_ids is non-null, cached_tot_size = -1
+      RaggedShape result =
+          RaggedShape3(&row_splits1, nullptr, -1, &row_splits2, nullptr, -1);
+      CheckArrayData(result.RowSplits(1), row_splits1);
+      CheckArrayData(result.RowIds(1), row_ids1);
+      EXPECT_EQ(result.TotSize(1), cached_tot_size1);
+      CheckArrayData(result.RowSplits(2), row_splits2);
+      CheckArrayData(result.RowIds(2), row_ids2);
+      EXPECT_EQ(result.TotSize(2), cached_tot_size2);
+    }
+
+    // note if row_splits == null, then we suppose there's no empty rows after
+    // the last row-id in row_ids
+    bool valid1 =
+        (row_splits1.Dim() == (row_ids1.Dim() == 0 ? 1 : row_ids1.Back() + 2));
+    bool valid2 =
+        (row_splits2.Dim() == (row_ids2.Dim() == 0 ? 1 : row_ids2.Back() + 2));
+    if (valid1 && valid2) {
+      RaggedShape result =
+          RaggedShape3(nullptr, &row_ids1, -1, nullptr, &row_ids2, -1);
+      CheckArrayData(result.RowSplits(1), row_splits1);
+      CheckArrayData(result.RowIds(1), row_ids1);
+      EXPECT_EQ(result.TotSize(1), cached_tot_size1);
+      CheckArrayData(result.RowSplits(2), row_splits2);
+      CheckArrayData(result.RowIds(2), row_ids2);
+      EXPECT_EQ(result.TotSize(2), cached_tot_size2);
+    }
+    // TODO(haowen): add more cases for other branches
+  }
+}
+TEST_F(RaggedShapeOpsSuiteTest, TestRaggedShape3) {
+  TestRaggedShape3(simple_shape_);
+  TestRaggedShape3(random_shape_);
+}
+
+void TestComposeShape(const RaggedShape &shape) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape src_shape = shape.To(context);
+    ASSERT_GE(src_shape.NumAxes(), 3);
+    Array1<int32_t> row_splits1 = src_shape.RowSplits(1);
+    Array1<int32_t> row_ids1 = src_shape.RowIds(1);
+    Array1<int32_t> row_splits2 = src_shape.RowSplits(2);
+    Array1<int32_t> row_ids2 = src_shape.RowIds(2);
+
+    RaggedShape shape1 = RaggedShape2(&row_splits1, nullptr, -1);
+    RaggedShape shape2 = RaggedShape2(&row_splits2, nullptr, -1);
+
+    RaggedShape result = ComposeRaggedShapes(shape1, shape2);
+
+    ASSERT_EQ(result.NumAxes(), 3);
+
+    CheckArrayData(result.RowSplits(1), row_splits1);
+    CheckArrayData(result.RowIds(1), row_ids1);
+    CheckArrayData(result.RowSplits(2), row_splits2);
+    CheckArrayData(result.RowIds(2), row_ids2);
+  }
+}
+TEST_F(RaggedShapeOpsSuiteTest, TestComposeShape) {
+  TestComposeShape(simple_shape_);
+  TestComposeShape(random_shape_);
+}
+
+void TestShapeFromTotSize(const RaggedShape &shape) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    RaggedShape src_shape = shape.To(context);
+    ASSERT_GE(src_shape.NumAxes(), 2);
+
+    int32_t num_axes = src_shape.NumAxes();
+    std::vector<int32_t> tot_sizes(num_axes);
+    for (int32_t i = 0; i != num_axes; ++i) {
+      tot_sizes[i] = src_shape.TotSize(i);
+    }
+
+    RaggedShape result =
+        RaggedShapeFromTotSizes(context, num_axes, tot_sizes.data());
+
+    ASSERT_EQ(result.NumAxes(), num_axes);
+    for (int32_t i = 0; i < num_axes; ++i) {
+      EXPECT_EQ(result.TotSize(i), src_shape.TotSize(i));
+      if (i > 0) {
+        EXPECT_EQ(result.RowSplits(i).Dim(), src_shape.RowSplits(i).Dim());
+        EXPECT_EQ(result.RowIds(i).Dim(), src_shape.RowIds(i).Dim());
+      }
+    }
+  }
+}
+TEST_F(RaggedShapeOpsSuiteTest, TestShapeFromTotSize) {
+  TestShapeFromTotSize(simple_shape_);
+  TestShapeFromTotSize(random_shape_);
+}
+
+template <typename T>
 void TestRagged() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // constructed with row_splits and row_ids
-    // RaggedTensor4 t = [
-    //  [ [[ 1, 2], [4]],  [[3, 0]] ],
-    //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
-    //  [ [[3, 4], [], [8]] ]
-    // ]
-    const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-    const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
-    const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-    const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
-    const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
-                                              12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
-                                           4, 5, 5, 5, 6, 7, 7, 9};
-    const std::vector<T> values_vec = {1, 2, 4, 3, 0, 7, 8, 9,
-                                       6, 3, 5, 7, 2, 3, 4, 8};
-    std::vector<RaggedShapeDim> axes;
-    axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits1),
-                                     Array1<int32_t>(context, row_ids1),
-                                     static_cast<int32_t>(row_ids1.size())});
-    axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits2),
-                                     Array1<int32_t>(context, row_ids2),
-                                     static_cast<int32_t>(row_ids2.size())});
-    axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits3),
-                                     Array1<int32_t>(context, row_ids3),
-                                     static_cast<int32_t>(row_ids3.size())});
-
-    RaggedShape shape(axes, true);
-    Array1<T> values(context, values_vec);
-    Ragged<T> ragged(shape, values);
-
-    // test Index(axis, i)
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     {
-      // values: [[[ 1, 2], [4]], [[3, 0]]]
-      Ragged<T> sub_raggged = ragged.Index(0, 0);
-      RaggedShape &sub_shape = sub_raggged.shape;
-      EXPECT_EQ(sub_shape.NumAxes(), 3);
-      const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
-          {0, 2, 3}, {0, 2, 3, 5}};
-      CheckRowSplits(sub_shape, sub_row_splits_vec);
-      const Array1<T> &sub_values = sub_raggged.values;
-      const std::vector<T> sub_values_vec = {1, 2, 4, 3, 0};
-      CheckArrayData<T>(sub_values, sub_values_vec);
-    }
-    {
-      // values: [[[7, 8, 9]], [[6], [3, 5, 7]], [[2]]]
-      Ragged<T> sub_raggged = ragged.Index(0, 1);
-      RaggedShape &sub_shape = sub_raggged.shape;
-      EXPECT_EQ(sub_shape.NumAxes(), 3);
-      const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
-          {0, 1, 3, 4}, {0, 3, 4, 7, 8}};
-      CheckRowSplits(sub_shape, sub_row_splits_vec);
-      const Array1<T> &sub_values = sub_raggged.values;
-      const std::vector<T> sub_values_vec = {7, 8, 9, 6, 3, 5, 7, 2};
-      CheckArrayData<T>(sub_values, sub_values_vec);
-    }
-    {
-      // values: [[[3, 4], [], [8]]]
-      Ragged<T> sub_raggged = ragged.Index(0, 2);
-      RaggedShape &sub_shape = sub_raggged.shape;
-      EXPECT_EQ(sub_shape.NumAxes(), 3);
-      const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
-          {0, 3}, {0, 2, 2, 3}};
-      CheckRowSplits(sub_shape, sub_row_splits_vec);
-      const Array1<T> &sub_values = sub_raggged.values;
-      const std::vector<T> sub_values_vec = {3, 4, 8};
-      CheckArrayData<T>(sub_values, sub_values_vec);
-    }
+      // constructed with row_splits and row_ids
+      // RaggedTensor4 t = [
+      //  [ [[ 1, 2], [4]],  [[3, 0]] ],
+      //  [ [[7, 8, 9]], [[6], [3, 5, 7]], [[2]] ],
+      //  [ [[3, 4], [], [8]] ]
+      // ]
+      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+      const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
+      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+      const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+      const std::vector<int32_t> row_splits3 = {0,  2,  3,  5,  8, 9,
+                                                12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids3 = {0, 0, 1, 2, 2, 3, 3, 3,
+                                             4, 5, 5, 5, 6, 7, 7, 9};
+      const std::vector<T> values_vec = {1, 2, 4, 3, 0, 7, 8, 9,
+                                         6, 3, 5, 7, 2, 3, 4, 8};
+      std::vector<RaggedShapeDim> axes;
+      axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits1),
+                                       Array1<int32_t>(context, row_ids1),
+                                       static_cast<int32_t>(row_ids1.size())});
+      axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits2),
+                                       Array1<int32_t>(context, row_ids2),
+                                       static_cast<int32_t>(row_ids2.size())});
+      axes.emplace_back(RaggedShapeDim{Array1<int32_t>(context, row_splits3),
+                                       Array1<int32_t>(context, row_ids3),
+                                       static_cast<int32_t>(row_ids3.size())});
 
-    // test operator[](const std::vector<int32_t> &indexes)
-    if (d == kCpu) {
-      {
-        std::vector<int32_t> indexes = {0, 0, 0, 0};
-        EXPECT_EQ(ragged.shape[indexes], 0);
-        EXPECT_EQ(ragged[indexes], 1);
-      }
-      {
-        std::vector<int32_t> indexes = {0, 1, 0, 0};
-        EXPECT_EQ(ragged.shape[indexes], 3);
-        EXPECT_EQ(ragged[indexes], 3);
-      }
-      {
-        std::vector<int32_t> indexes = {1, 0, 0, 1};
-        EXPECT_EQ(ragged.shape[indexes], 6);
-        EXPECT_EQ(ragged[indexes], 8);
-      }
-      {
-        std::vector<int32_t> indexes = {1, 1, 1, 0};
-        EXPECT_EQ(ragged.shape[indexes], 9);
-        EXPECT_EQ(ragged[indexes], 3);
-      }
-      {
-        std::vector<int32_t> indexes = {2, 0, 0, 1};
-        EXPECT_EQ(ragged.shape[indexes], 14);
-        EXPECT_EQ(ragged[indexes], 4);
-      }
-      {
-        std::vector<int32_t> indexes = {2, 0, 2, 0};
-        EXPECT_EQ(ragged.shape[indexes], 15);
-        EXPECT_EQ(ragged[indexes], 8);
-      }
-    }
+      RaggedShape shape(axes, true);
+      Array1<T> values(context, values_vec);
+      Ragged<T> ragged(shape, values);
 
-    const std::vector<std::vector<int32_t>> row_splits_vec = {
-        row_splits1, row_splits2, row_splits3};
-    // test To(ctx)
-    {
-      // to GPU
-      Ragged<T> other = ragged.To(GetCudaContext());
-      CheckRowSplits(other.shape, row_splits_vec);
-      CheckArrayData<T>(other.values, values_vec);
-    }
-    {
-      // to CPU
-      Ragged<T> other = ragged.To(GetCpuContext());
-      CheckRowSplits(other.shape, row_splits_vec);
-      CheckArrayData<T>(other.values, values_vec);
+      // test Index(axis, i)
+      {
+        // values: [[[ 1, 2], [4]], [[3, 0]]]
+        Ragged<T> sub_raggged = ragged.Index(0, 0);
+        RaggedShape &sub_shape = sub_raggged.shape;
+        EXPECT_EQ(sub_shape.NumAxes(), 3);
+        const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
+            {0, 2, 3}, {0, 2, 3, 5}};
+        CheckRowSplits(sub_shape, sub_row_splits_vec);
+        const Array1<T> &sub_values = sub_raggged.values;
+        const std::vector<T> sub_values_vec = {1, 2, 4, 3, 0};
+        CheckArrayData<T>(sub_values, sub_values_vec);
+      }
+      {
+        // values: [[[7, 8, 9]], [[6], [3, 5, 7]], [[2]]]
+        Ragged<T> sub_raggged = ragged.Index(0, 1);
+        RaggedShape &sub_shape = sub_raggged.shape;
+        EXPECT_EQ(sub_shape.NumAxes(), 3);
+        const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
+            {0, 1, 3, 4}, {0, 3, 4, 7, 8}};
+        CheckRowSplits(sub_shape, sub_row_splits_vec);
+        const Array1<T> &sub_values = sub_raggged.values;
+        const std::vector<T> sub_values_vec = {7, 8, 9, 6, 3, 5, 7, 2};
+        CheckArrayData<T>(sub_values, sub_values_vec);
+      }
+      {
+        // values: [[[3, 4], [], [8]]]
+        Ragged<T> sub_raggged = ragged.Index(0, 2);
+        RaggedShape &sub_shape = sub_raggged.shape;
+        EXPECT_EQ(sub_shape.NumAxes(), 3);
+        const std::vector<std::vector<int32_t>> sub_row_splits_vec = {
+            {0, 3}, {0, 2, 2, 3}};
+        CheckRowSplits(sub_shape, sub_row_splits_vec);
+        const Array1<T> &sub_values = sub_raggged.values;
+        const std::vector<T> sub_values_vec = {3, 4, 8};
+        CheckArrayData<T>(sub_values, sub_values_vec);
+      }
+
+      // test operator[](const std::vector<int32_t> &indexes)
+      if (context->GetDeviceType() == kCpu) {
+        {
+          std::vector<int32_t> indexes = {0, 0, 0, 0};
+          EXPECT_EQ(ragged.shape[indexes], 0);
+          EXPECT_EQ(ragged[indexes], 1);
+        }
+        {
+          std::vector<int32_t> indexes = {0, 1, 0, 0};
+          EXPECT_EQ(ragged.shape[indexes], 3);
+          EXPECT_EQ(ragged[indexes], 3);
+        }
+        {
+          std::vector<int32_t> indexes = {1, 0, 0, 1};
+          EXPECT_EQ(ragged.shape[indexes], 6);
+          EXPECT_EQ(ragged[indexes], 8);
+        }
+        {
+          std::vector<int32_t> indexes = {1, 1, 1, 0};
+          EXPECT_EQ(ragged.shape[indexes], 9);
+          EXPECT_EQ(ragged[indexes], 3);
+        }
+        {
+          std::vector<int32_t> indexes = {2, 0, 0, 1};
+          EXPECT_EQ(ragged.shape[indexes], 14);
+          EXPECT_EQ(ragged[indexes], 4);
+        }
+        {
+          std::vector<int32_t> indexes = {2, 0, 2, 0};
+          EXPECT_EQ(ragged.shape[indexes], 15);
+          EXPECT_EQ(ragged[indexes], 8);
+        }
+      }
+
+      const std::vector<std::vector<int32_t>> row_splits_vec = {
+          row_splits1, row_splits2, row_splits3};
+      // test To(ctx)
+      {
+        // to GPU
+        Ragged<T> other = ragged.To(GetCudaContext());
+        CheckRowSplits(other.shape, row_splits_vec);
+        CheckArrayData<T>(other.values, values_vec);
+      }
+      {
+        // to CPU
+        Ragged<T> other = ragged.To(GetCpuContext());
+        CheckRowSplits(other.shape, row_splits_vec);
+        CheckArrayData<T>(other.values, values_vec);
+      }
     }
   }
 }
@@ -1116,67 +1051,203 @@ static void TestSortSublists() {
 }
 
 TEST(RaggedTest, Ragged) {
-  TestRagged<int32_t, kCuda>();
-  TestRagged<int32_t, kCpu>();
-  TestRagged<double, kCuda>();
-  TestRagged<double, kCpu>();
+  TestRagged<int32_t>();
+  TestRagged<double>();
 
   TestSortSublists<int32_t>();
   TestSortSublists<double>();
 }
 
-template <DeviceType d>
-void TestAppend() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+TEST(RaggedShapeOpsTest, TestAppend) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // simple case
+      std::vector<RaggedShape> shapes(2);
+      std::vector<RaggedShape *> shapes_ptr(2);
+      std::vector<std::vector<Array1<int32_t>>> row_splits_vec(2);
+      {
+        const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+        const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
+        const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+        const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+        Array1<int32_t> splits1(context, row_splits1);
+        Array1<int32_t> ids1(context, row_ids1);
+        Array1<int32_t> splits2(context, row_splits2);
+        Array1<int32_t> ids2(context, row_ids2);
+        row_splits_vec[0].push_back(splits1);
+        row_splits_vec[1].push_back(splits2);
+        shapes[0] = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2, &ids2,
+                                 ids2.Dim());
+        shapes_ptr[0] = &shapes[0];
+      }
+      {
+        const std::vector<int32_t> row_splits1 = {0, 1, 3, 4};
+        const std::vector<int32_t> row_ids1 = {0, 1, 1, 2};
+        const std::vector<int32_t> row_splits2 = {0, 3, 4, 5, 7};
+        const std::vector<int32_t> row_ids2 = {0, 0, 0, 1, 2, 3, 3};
+        Array1<int32_t> splits1(context, row_splits1);
+        Array1<int32_t> ids1(context, row_ids1);
+        Array1<int32_t> splits2(context, row_splits2);
+        Array1<int32_t> ids2(context, row_ids2);
+        row_splits_vec[0].push_back(splits1);
+        row_splits_vec[1].push_back(splits2);
+        RaggedShape shape = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2,
+                                         &ids2, ids2.Dim());
+        shapes[1] = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2, &ids2,
+                                 ids2.Dim());
+        shapes_ptr[1] = &shapes[1];
+      }
 
-  {
-    // simple case
-    std::vector<RaggedShape> shapes(2);
-    std::vector<RaggedShape *> shapes_ptr(2);
+      {
+        // axis == 1
+        RaggedShape result = Append(1, 2, shapes_ptr.data());
+        std::vector<std::vector<int32_t>> expected_row_splits = {
+            {0, 3, 8, 10}, {0, 2, 3, 6, 7, 9, 10, 11, 12, 15, 17}};
+        std::vector<std::vector<int32_t>> expected_row_ids = {
+            {0, 0, 0, 1, 1, 1, 1, 1, 2, 2},
+            {0, 0, 1, 2, 2, 2, 3, 4, 4, 5, 6, 7, 8, 8, 8, 9, 9}};
+        for (int32_t i = 0; i < 2; ++i) {
+          CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
+          CheckArrayData(result.RowIds(i + 1), expected_row_ids[i]);
+        }
+      }
+
+      {
+        // axis == 0
+        RaggedShape result = Append(0, 2, shapes_ptr.data());
+
+        // get result splits with `SpliceRowSplits` and get result row-ids with
+        // `RowSplitsToRowIds``
+        std::vector<Array1<int32_t>> result_splits;
+        std::vector<Array1<int32_t>> result_ids;
+        for (auto i = 0; i < 2; ++i) {
+          std::vector<const Array1<int32_t> *> splits_ptr = {
+              &row_splits_vec[i][0], &row_splits_vec[i][1]};
+          Array1<int32_t> curr_row_splits =
+              SpliceRowSplits(2, splits_ptr.data());
+          result_splits.push_back(curr_row_splits);
+          Array1<int32_t> curr_row_ids(context, curr_row_splits.Back());
+          RowSplitsToRowIds(curr_row_splits, &curr_row_ids);
+          result_ids.push_back(curr_row_ids);
+        }
+        for (int32_t i = 0; i < 2; ++i) {
+          CheckArrayData(result.RowSplits(i + 1), result_splits[i]);
+          CheckArrayData(result.RowIds(i + 1), result_ids[i]);
+        }
+      }
+    }
+
+    {
+      // test with random large size
+      for (int32_t i = 0; i < 2; ++i) {
+        int32_t num_shape = RandInt(2, 100);
+        int32_t num_axes = RandInt(2, 4);
+        std::vector<RaggedShape> shape_vec(num_shape);
+        std::vector<RaggedShape *> shapes(num_shape);
+        for (int32_t j = 0; j != num_shape; ++j) {
+          shape_vec[j] =
+              RandomRaggedShape(true, num_axes, num_axes, 0, 1000).To(context);
+          shapes[j] = &shape_vec[j];
+        }
+        // only test case axis == 0, test axis==1 with simple case is good
+        // enough as it just calls Stack
+        RaggedShape result = Append(0, num_shape, shapes.data());
+        ASSERT_EQ(result.NumAxes(), num_axes);
+
+        // get result splits with `SpliceRowSplits` and get result row-ids with
+        // `RowSplitsToRowIds``
+        std::vector<Array1<int32_t>> result_splits;
+        std::vector<Array1<int32_t>> result_ids;
+        for (int32_t axis = 1; axis < num_axes; ++axis) {
+          std::vector<Array1<int32_t>> splits_vec(num_shape);
+          std::vector<const Array1<int32_t> *> splits_vec_ptr(num_shape);
+          for (int32_t n = 0; n != num_shape; ++n) {
+            splits_vec[n] = shape_vec[n].RowSplits(axis);
+            splits_vec_ptr[n] = &splits_vec[n];
+          }
+          Array1<int32_t> curr_row_splits =
+              SpliceRowSplits(num_shape, splits_vec_ptr.data());
+          result_splits.push_back(curr_row_splits);
+          Array1<int32_t> curr_row_ids(context, curr_row_splits.Back());
+          RowSplitsToRowIds(curr_row_splits, &curr_row_ids);
+          result_ids.push_back(curr_row_ids);
+        }
+
+        // check data
+        for (int32_t axis = 1; axis < num_axes; ++axis) {
+          CheckArrayData(result.RowSplits(axis), result_splits[axis - 1]);
+          CheckArrayData(result.RowIds(axis), result_ids[axis - 1]);
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+void TestAppendRagged() {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    // TODO(haowen): remove duplicate code in TestAppend above.
+    // test with simple case could be good enough, as we have tested
+    // Append(RaggedShape&) already.
+    std::vector<Ragged<T>> ragged_vec(2);
+    std::vector<Ragged<T> *> ragged(2);
     std::vector<std::vector<Array1<int32_t>>> row_splits_vec(2);
     {
       const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
       const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
       const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
       const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+      const std::vector<T> values_vec = {1, 2, 5, 7, 9, 10, 12, 14, 15, 18};
       Array1<int32_t> splits1(context, row_splits1);
       Array1<int32_t> ids1(context, row_ids1);
       Array1<int32_t> splits2(context, row_splits2);
       Array1<int32_t> ids2(context, row_ids2);
-      row_splits_vec[0].push_back(splits1);
-      row_splits_vec[1].push_back(splits2);
-      shapes[0] = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2, &ids2,
-                               ids2.Dim());
-      shapes_ptr[0] = &shapes[0];
+      RaggedShape shape = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2,
+                                       &ids2, ids2.Dim());
+      Array1<T> values(context, values_vec);
+      ragged_vec[0] = Ragged<T>(shape, values);
+      ragged[0] = &ragged_vec[0];
     }
+
     {
       const std::vector<int32_t> row_splits1 = {0, 1, 3, 4};
       const std::vector<int32_t> row_ids1 = {0, 1, 1, 2};
       const std::vector<int32_t> row_splits2 = {0, 3, 4, 5, 7};
       const std::vector<int32_t> row_ids2 = {0, 0, 0, 1, 2, 3, 3};
+      const std::vector<T> values_vec = {20, 21, 23, 28, 30, 32, 35};
       Array1<int32_t> splits1(context, row_splits1);
       Array1<int32_t> ids1(context, row_ids1);
       Array1<int32_t> splits2(context, row_splits2);
       Array1<int32_t> ids2(context, row_ids2);
-      row_splits_vec[0].push_back(splits1);
-      row_splits_vec[1].push_back(splits2);
       RaggedShape shape = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2,
                                        &ids2, ids2.Dim());
-      shapes[1] = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2, &ids2,
-                               ids2.Dim());
-      shapes_ptr[1] = &shapes[1];
+      Array1<T> values(context, values_vec);
+      ragged_vec[1] = Ragged<T>(shape, values);
+      ragged[1] = &ragged_vec[1];
+    }
+
+    {
+      // axis == 0
+      Ragged<T> result = Append(0, 2, ragged.data());
+      std::vector<std::vector<int32_t>> expected_row_splits = {
+          {0, 2, 5, 6, 7, 9, 10}, {0, 2, 3, 4, 6, 7, 10, 13, 14, 15, 17}};
+      std::vector<std::vector<int32_t>> expected_row_ids = {
+          {0, 0, 1, 1, 1, 2, 3, 4, 4, 5},
+          {0, 0, 1, 2, 3, 3, 4, 5, 5, 5, 6, 6, 6, 7, 8, 9, 9}};
+      for (int32_t i = 0; i < 2; ++i) {
+        CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
+        CheckArrayData(result.RowIds(i + 1), expected_row_ids[i]);
+      }
+      std::vector<T> expected_data = {1,  2,  5,  7,  9,  10, 12, 14, 15,
+                                      18, 20, 21, 23, 28, 30, 32, 35};
+      CheckArrayData(result.values, expected_data);
     }
 
     {
       // axis == 1
-      RaggedShape result = Append(1, 2, shapes_ptr.data());
+      Ragged<T> result = Append(1, 2, ragged.data());
       std::vector<std::vector<int32_t>> expected_row_splits = {
           {0, 3, 8, 10}, {0, 2, 3, 6, 7, 9, 10, 11, 12, 15, 17}};
       std::vector<std::vector<int32_t>> expected_row_ids = {
@@ -1186,171 +1257,15 @@ void TestAppend() {
         CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
         CheckArrayData(result.RowIds(i + 1), expected_row_ids[i]);
       }
+      std::vector<T> expected_data = {1,  2,  5,  20, 21, 23, 7,  9, 10,
+                                      12, 28, 30, 14, 15, 18, 32, 35};
+      CheckArrayData(result.values, expected_data);
     }
-
-    {
-      // axis == 0
-      RaggedShape result = Append(0, 2, shapes_ptr.data());
-
-      // get result splits with `SpliceRowSplits` and get result row-ids with
-      // `RowSplitsToRowIds``
-      std::vector<Array1<int32_t>> result_splits;
-      std::vector<Array1<int32_t>> result_ids;
-      for (auto i = 0; i < 2; ++i) {
-        std::vector<const Array1<int32_t> *> splits_ptr = {
-            &row_splits_vec[i][0], &row_splits_vec[i][1]};
-        Array1<int32_t> curr_row_splits = SpliceRowSplits(2, splits_ptr.data());
-        result_splits.push_back(curr_row_splits);
-        Array1<int32_t> curr_row_ids(context, curr_row_splits.Back());
-        RowSplitsToRowIds(curr_row_splits, &curr_row_ids);
-        result_ids.push_back(curr_row_ids);
-      }
-      for (int32_t i = 0; i < 2; ++i) {
-        CheckArrayData(result.RowSplits(i + 1), result_splits[i]);
-        CheckArrayData(result.RowIds(i + 1), result_ids[i]);
-      }
-    }
-  }
-
-  {
-    // test with random large size
-    for (int32_t i = 0; i < 2; ++i) {
-      int32_t num_shape = RandInt(2, 100);
-      int32_t num_axes = RandInt(2, 4);
-      std::vector<RaggedShape> shape_vec(num_shape);
-      std::vector<RaggedShape *> shapes(num_shape);
-      for (int32_t j = 0; j != num_shape; ++j) {
-        shape_vec[j] =
-            RandomRaggedShape(true, num_axes, num_axes, 0, 1000).To(context);
-        shapes[j] = &shape_vec[j];
-      }
-      // only test case axis == 0, test axis==1 with simple case is good enough
-      // as it just calls Stack
-      RaggedShape result = Append(0, num_shape, shapes.data());
-      ASSERT_EQ(result.NumAxes(), num_axes);
-
-      // get result splits with `SpliceRowSplits` and get result row-ids with
-      // `RowSplitsToRowIds``
-      std::vector<Array1<int32_t>> result_splits;
-      std::vector<Array1<int32_t>> result_ids;
-      for (int32_t axis = 1; axis < num_axes; ++axis) {
-        std::vector<Array1<int32_t>> splits_vec(num_shape);
-        std::vector<const Array1<int32_t> *> splits_vec_ptr(num_shape);
-        for (int32_t n = 0; n != num_shape; ++n) {
-          splits_vec[n] = shape_vec[n].RowSplits(axis);
-          splits_vec_ptr[n] = &splits_vec[n];
-        }
-        Array1<int32_t> curr_row_splits =
-            SpliceRowSplits(num_shape, splits_vec_ptr.data());
-        result_splits.push_back(curr_row_splits);
-        Array1<int32_t> curr_row_ids(context, curr_row_splits.Back());
-        RowSplitsToRowIds(curr_row_splits, &curr_row_ids);
-        result_ids.push_back(curr_row_ids);
-      }
-
-      // check data
-      for (int32_t axis = 1; axis < num_axes; ++axis) {
-        CheckArrayData(result.RowSplits(axis), result_splits[axis - 1]);
-        CheckArrayData(result.RowIds(axis), result_ids[axis - 1]);
-      }
-    }
-  }
-}
-TEST(RaggedShapeOpsTest, TestAppend) {
-  TestAppend<kCpu>();
-  TestAppend<kCuda>();
-}
-
-template <DeviceType d, typename T>
-void TestAppendRagged() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  // TODO(haowen): remove duplicate code in TestAppend above.
-  // test with simple case could be good enough, as we have tested
-  // Append(RaggedShape&) already.
-  std::vector<Ragged<T>> ragged_vec(2);
-  std::vector<Ragged<T> *> ragged(2);
-  std::vector<std::vector<Array1<int32_t>>> row_splits_vec(2);
-  {
-    const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-    const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
-    const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-    const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
-    const std::vector<T> values_vec = {1, 2, 5, 7, 9, 10, 12, 14, 15, 18};
-    Array1<int32_t> splits1(context, row_splits1);
-    Array1<int32_t> ids1(context, row_ids1);
-    Array1<int32_t> splits2(context, row_splits2);
-    Array1<int32_t> ids2(context, row_ids2);
-    RaggedShape shape =
-        RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2, &ids2, ids2.Dim());
-    Array1<T> values(context, values_vec);
-    ragged_vec[0] = Ragged<T>(shape, values);
-    ragged[0] = &ragged_vec[0];
-  }
-
-  {
-    const std::vector<int32_t> row_splits1 = {0, 1, 3, 4};
-    const std::vector<int32_t> row_ids1 = {0, 1, 1, 2};
-    const std::vector<int32_t> row_splits2 = {0, 3, 4, 5, 7};
-    const std::vector<int32_t> row_ids2 = {0, 0, 0, 1, 2, 3, 3};
-    const std::vector<T> values_vec = {20, 21, 23, 28, 30, 32, 35};
-    Array1<int32_t> splits1(context, row_splits1);
-    Array1<int32_t> ids1(context, row_ids1);
-    Array1<int32_t> splits2(context, row_splits2);
-    Array1<int32_t> ids2(context, row_ids2);
-    RaggedShape shape =
-        RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2, &ids2, ids2.Dim());
-    Array1<T> values(context, values_vec);
-    ragged_vec[1] = Ragged<T>(shape, values);
-    ragged[1] = &ragged_vec[1];
-  }
-
-  {
-    // axis == 0
-    Ragged<T> result = Append(0, 2, ragged.data());
-    std::vector<std::vector<int32_t>> expected_row_splits = {
-        {0, 2, 5, 6, 7, 9, 10}, {0, 2, 3, 4, 6, 7, 10, 13, 14, 15, 17}};
-    std::vector<std::vector<int32_t>> expected_row_ids = {
-        {0, 0, 1, 1, 1, 2, 3, 4, 4, 5},
-        {0, 0, 1, 2, 3, 3, 4, 5, 5, 5, 6, 6, 6, 7, 8, 9, 9}};
-    for (int32_t i = 0; i < 2; ++i) {
-      CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
-      CheckArrayData(result.RowIds(i + 1), expected_row_ids[i]);
-    }
-    std::vector<T> expected_data = {1,  2,  5,  7,  9,  10, 12, 14, 15,
-                                    18, 20, 21, 23, 28, 30, 32, 35};
-    CheckArrayData(result.values, expected_data);
-  }
-
-  {
-    // axis == 1
-    Ragged<T> result = Append(1, 2, ragged.data());
-    std::vector<std::vector<int32_t>> expected_row_splits = {
-        {0, 3, 8, 10}, {0, 2, 3, 6, 7, 9, 10, 11, 12, 15, 17}};
-    std::vector<std::vector<int32_t>> expected_row_ids = {
-        {0, 0, 0, 1, 1, 1, 1, 1, 2, 2},
-        {0, 0, 1, 2, 2, 2, 3, 4, 4, 5, 6, 7, 8, 8, 8, 9, 9}};
-    for (int32_t i = 0; i < 2; ++i) {
-      CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
-      CheckArrayData(result.RowIds(i + 1), expected_row_ids[i]);
-    }
-    std::vector<T> expected_data = {1,  2,  5,  20, 21, 23, 7,  9, 10,
-                                    12, 28, 30, 14, 15, 18, 32, 35};
-    CheckArrayData(result.values, expected_data);
   }
 }
 TEST(RaggedTest, TestAppendRagged) {
-  TestAppendRagged<kCpu, int32_t>();
-  TestAppendRagged<kCuda, int32_t>();
-  TestAppendRagged<kCpu, double>();
-  TestAppendRagged<kCuda, double>();
+  TestAppendRagged<int32_t>();
+  TestAppendRagged<double>();
 }
 
 void CheckResultOfIndex(const ContextPtr &context, RaggedShape shape,
@@ -1422,66 +1337,55 @@ void CheckResultOfIndex(const ContextPtr &context, RaggedShape shape,
   }
 }
 
-void TestIndex(DeviceType d) {
+TEST(RaggedShapeOpsTest, TestIndex) {
   for (int i = 0; i < 5; i++) {
-    ContextPtr cpu = GetCpuContext();  // will use to copy data
-    ContextPtr context = nullptr;
-    if (d == kCpu) {
-      context = GetCpuContext();
-    } else {
-      K2_CHECK_EQ(d, kCuda);
-      context = GetCudaContext();
-    }
+    ContextPtr cpu = GetCpuContext();  // will be used to copy data
+    for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+      {
+        // simple case
+        const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+        const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
+        const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+        const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
 
-    {
-      // simple case
-      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-      const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2};
-      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-      const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5};
+        Array1<int32_t> splits1(context, row_splits1);
+        Array1<int32_t> ids1(context, row_ids1);
+        Array1<int32_t> splits2(context, row_splits2);
+        Array1<int32_t> ids2(context, row_ids2);
+        RaggedShape shape = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2,
+                                         &ids2, ids2.Dim());
 
-      Array1<int32_t> splits1(context, row_splits1);
-      Array1<int32_t> ids1(context, row_ids1);
-      Array1<int32_t> splits2(context, row_splits2);
-      Array1<int32_t> ids2(context, row_ids2);
-      RaggedShape shape = RaggedShape3(&splits1, &ids1, ids1.Dim(), &splits2,
-                                       &ids2, ids2.Dim());
-
-      std::vector<int32_t> new2old_vec = {2, 1};
-      Array1<int32_t> new2old(context, new2old_vec);
-      Array1<int32_t> value_indexes_out;
-      RaggedShape result = Index(shape, new2old, &value_indexes_out);
-      // fsa 2, state_idx01 {5}, arc_idx012 {7, 8, 9}
-      // fsa 1, state_idx01 {2, 3, 4}, arc_idx012 {{3},{4, 5}, {6}}
-      CheckArrayData(value_indexes_out,
-                     std::vector<int32_t>{7, 8, 9, 3, 4, 5, 6});
-      CheckResultOfIndex(context, shape, new2old, result);
-    }
-
-    {
-      // test with random large size
-      for (int32_t i = 0; i < 2; ++i) {
-        int32_t num_axes = RandInt(2, 4);
-        RaggedShape shape =
-            RandomRaggedShape(true, num_axes, num_axes, 0, 1000).To(context);
-        int32_t dim0 = shape.Dim0(), result_dim0 = RandInt(0, 10);
-        if (dim0 == 0) result_dim0 = 0;
-        std::vector<int32_t> new2old_vec(result_dim0);
-        for (int i = 0; i < result_dim0; i++)
-          new2old_vec[i] = RandInt(0, dim0 - 1);
+        std::vector<int32_t> new2old_vec = {2, 1};
         Array1<int32_t> new2old(context, new2old_vec);
-        Array1<int32_t> value_indexes;
-        RaggedShape result = Index(shape, new2old, &value_indexes);
+        Array1<int32_t> value_indexes_out;
+        RaggedShape result = Index(shape, new2old, &value_indexes_out);
+        // fsa 2, state_idx01 {5}, arc_idx012 {7, 8, 9}
+        // fsa 1, state_idx01 {2, 3, 4}, arc_idx012 {{3},{4, 5}, {6}}
+        CheckArrayData(value_indexes_out,
+                       std::vector<int32_t>{7, 8, 9, 3, 4, 5, 6});
         CheckResultOfIndex(context, shape, new2old, result);
-        K2_LOG(INFO) << "Value_indexes = " << value_indexes;
+      }
+
+      {
+        // test with random large size
+        for (int32_t i = 0; i < 2; ++i) {
+          int32_t num_axes = RandInt(2, 4);
+          RaggedShape shape =
+              RandomRaggedShape(true, num_axes, num_axes, 0, 1000).To(context);
+          int32_t dim0 = shape.Dim0(), result_dim0 = RandInt(0, 10);
+          if (dim0 == 0) result_dim0 = 0;
+          std::vector<int32_t> new2old_vec(result_dim0);
+          for (int i = 0; i < result_dim0; i++)
+            new2old_vec[i] = RandInt(0, dim0 - 1);
+          Array1<int32_t> new2old(context, new2old_vec);
+          Array1<int32_t> value_indexes;
+          RaggedShape result = Index(shape, new2old, &value_indexes);
+          CheckResultOfIndex(context, shape, new2old, result);
+          K2_LOG(INFO) << "Value_indexes = " << value_indexes;
+        }
       }
     }
   }
-}
-
-TEST(RaggedShapeOpsTest, TestIndex) {
-  TestIndex(kCpu);
-  TestIndex(kCuda);
 }
 
 TEST(GetTransposeReordering, NoDuplicates) {
@@ -1635,118 +1539,176 @@ TEST(ChangeSublistSize, ThreeAxes) {
   }
 }
 
-template <DeviceType d>
-void TestGetCountsPartitioned() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  // Testing with simple case is good enough as we have tested GetCounts()
-  // with random large size and GetCountsPartitioned just calls GetCounts.
-  std::vector<int32_t> src_row_splits_vec = {0, 3, 4, 6, 10};
-  Array1<int32_t> src_row_splits(context, src_row_splits_vec);
-  RaggedShape src_shape = RaggedShape2(&src_row_splits, nullptr, -1);
-  std::vector<int32_t> src_values_vec = {0, 1, 0, 2, 5, 5, 7, 7, 9, 7};
-  Array1<int32_t> src_values(context, src_values_vec);
-  Ragged<int32_t> src(src_shape, src_values);
-
-  std::vector<int32_t> ans_row_splits_vec = {0, 2, 4, 7, 10};
-  Array1<int32_t> ans_row_splits(context, ans_row_splits_vec);
-  RaggedShape ans_shape = RaggedShape2(&ans_row_splits, nullptr, -1);
-
-  Ragged<int32_t> result = GetCountsPartitioned(src, ans_shape);
-
-  ASSERT_EQ(result.NumAxes(), 2);
-  // Check row_splits
-  Array1<int32_t> row_splits = result.shape.RowSplits(1).To(cpu);
-  std::vector<int32_t> result_row_splits(row_splits.Data(),
-                                         row_splits.Data() + row_splits.Dim());
-  EXPECT_EQ(result_row_splits, ans_row_splits_vec);
-  // check values
-  std::vector<int32_t> expected_data = {2, 1, 1, 0, 0, 2, 0, 3, 0, 1};
-  Array1<int32_t> values = result.values.To(cpu);
-  std::vector<int32_t> data(values.Data(), values.Data() + values.Dim());
-  EXPECT_EQ(data, expected_data);
-}
-
 TEST(RaggedShapeOpsTest, TestGetCountsPartitioned) {
-  TestGetCountsPartitioned<kCpu>();
-  TestGetCountsPartitioned<kCuda>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    // Testing with simple case is good enough as we have tested GetCounts()
+    // with random large size and GetCountsPartitioned just calls GetCounts.
+    std::vector<int32_t> src_row_splits_vec = {0, 3, 4, 6, 10};
+    Array1<int32_t> src_row_splits(context, src_row_splits_vec);
+    RaggedShape src_shape = RaggedShape2(&src_row_splits, nullptr, -1);
+    std::vector<int32_t> src_values_vec = {0, 1, 0, 2, 5, 5, 7, 7, 9, 7};
+    Array1<int32_t> src_values(context, src_values_vec);
+    Ragged<int32_t> src(src_shape, src_values);
+
+    std::vector<int32_t> ans_row_splits_vec = {0, 2, 4, 7, 10};
+    Array1<int32_t> ans_row_splits(context, ans_row_splits_vec);
+    RaggedShape ans_shape = RaggedShape2(&ans_row_splits, nullptr, -1);
+
+    Ragged<int32_t> result = GetCountsPartitioned(src, ans_shape);
+
+    ASSERT_EQ(result.NumAxes(), 2);
+    // Check row_splits
+    Array1<int32_t> row_splits = result.shape.RowSplits(1).To(cpu);
+    std::vector<int32_t> result_row_splits(
+        row_splits.Data(), row_splits.Data() + row_splits.Dim());
+    EXPECT_EQ(result_row_splits, ans_row_splits_vec);
+    // check values
+    std::vector<int32_t> expected_data = {2, 1, 1, 0, 0, 2, 0, 3, 0, 1};
+    Array1<int32_t> values = result.values.To(cpu);
+    std::vector<int32_t> data(values.Data(), values.Data() + values.Dim());
+    EXPECT_EQ(data, expected_data);
+  }
 }
 
-template <DeviceType d>
-void TestStack() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+TEST(RaggedShapeOpsTest, TestStack) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // simple case
+      std::vector<RaggedShape> shapes(2);
+      std::vector<RaggedShape *> shapes_ptr(2);
+      std::vector<std::vector<Array1<int32_t>>> row_splits_vec(2);
+      {
+        const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
+        const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
+        Array1<int32_t> splits1(context, row_splits1);
+        Array1<int32_t> splits2(context, row_splits2);
+        row_splits_vec[0].push_back(splits1);
+        row_splits_vec[1].push_back(splits2);
+        shapes[0] = RaggedShape3(&splits1, nullptr, -1, &splits2, nullptr, -1);
+        shapes_ptr[0] = &shapes[0];
+      }
+      {
+        const std::vector<int32_t> row_splits1 = {0, 1, 3, 4};
+        const std::vector<int32_t> row_splits2 = {0, 3, 4, 5, 7};
+        Array1<int32_t> splits1(context, row_splits1);
+        Array1<int32_t> splits2(context, row_splits2);
+        row_splits_vec[0].push_back(splits1);
+        row_splits_vec[1].push_back(splits2);
+        shapes[1] = RaggedShape3(&splits1, nullptr, -1, &splits2, nullptr, -1);
+        shapes_ptr[1] = &shapes[1];
+      }
+      std::vector<std::vector<int32_t>> expected_row_splits = {
+          {0, 3, 6},
+          {0, 2, 5, 6, 7, 9, 10},
+          {0, 2, 3, 4, 6, 7, 10, 13, 14, 15, 17}};
 
-  {
-    // simple case
-    std::vector<RaggedShape> shapes(2);
-    std::vector<RaggedShape *> shapes_ptr(2);
-    std::vector<std::vector<Array1<int32_t>>> row_splits_vec(2);
-    {
-      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6};
-      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10};
-      Array1<int32_t> splits1(context, row_splits1);
-      Array1<int32_t> splits2(context, row_splits2);
-      row_splits_vec[0].push_back(splits1);
-      row_splits_vec[1].push_back(splits2);
-      shapes[0] = RaggedShape3(&splits1, nullptr, -1, &splits2, nullptr, -1);
-      shapes_ptr[0] = &shapes[0];
-    }
-    {
-      const std::vector<int32_t> row_splits1 = {0, 1, 3, 4};
-      const std::vector<int32_t> row_splits2 = {0, 3, 4, 5, 7};
-      Array1<int32_t> splits1(context, row_splits1);
-      Array1<int32_t> splits2(context, row_splits2);
-      row_splits_vec[0].push_back(splits1);
-      row_splits_vec[1].push_back(splits2);
-      shapes[1] = RaggedShape3(&splits1, nullptr, -1, &splits2, nullptr, -1);
-      shapes_ptr[1] = &shapes[1];
-    }
-    std::vector<std::vector<int32_t>> expected_row_splits = {
-        {0, 3, 6},
-        {0, 2, 5, 6, 7, 9, 10},
-        {0, 2, 3, 4, 6, 7, 10, 13, 14, 15, 17}};
-
-    {
-      // axis == 0
-      int32_t axis = 0;
-      RaggedShape result = Stack(axis, 2, shapes_ptr.data());
-      for (int32_t i = 0; i != 3; ++i) {
-        CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
+      {
+        // axis == 0
+        int32_t axis = 0;
+        RaggedShape result = Stack(axis, 2, shapes_ptr.data());
+        for (int32_t i = 0; i != 3; ++i) {
+          CheckArrayData(result.RowSplits(i + 1), expected_row_splits[i]);
+        }
+      }
+      {
+        // axis == 1
+        int32_t axis = 1;
+        RaggedShape result = Stack(axis, 2, shapes_ptr.data());
+        RaggedShape transpose = Transpose(result);
+        for (int32_t i = 0; i != 3; ++i) {
+          CheckArrayData(transpose.RowSplits(i + 1), expected_row_splits[i]);
+        }
       }
     }
+
     {
-      // axis == 1
-      int32_t axis = 1;
-      RaggedShape result = Stack(axis, 2, shapes_ptr.data());
-      RaggedShape transpose = Transpose(result);
-      for (int32_t i = 0; i != 3; ++i) {
-        CheckArrayData(transpose.RowSplits(i + 1), expected_row_splits[i]);
+      // test with random large size
+      for (int32_t m = 0; m < 2; ++m) {
+        int32_t num_shape = RandInt(2, 100);
+        int32_t num_axes = RandInt(2, 4);
+        int32_t dim0 = RandInt(1, 100);
+        std::vector<RaggedShape> shape_vec(num_shape);
+        std::vector<RaggedShape *> shapes(num_shape);
+        for (int32_t j = 0; j != num_shape; ++j) {
+          RaggedShape shape =
+              RandomRaggedShape(false, num_axes, num_axes, 0, 1000).To(context);
+          int32_t src_dim0 = shape.Dim0();
+          std::vector<int32_t> row_splits_vec(dim0 + 1);
+          row_splits_vec[0] = 0;
+          for (int32_t n = 1; n < dim0; ++n) {
+            row_splits_vec[n] = RandInt(0, src_dim0);
+          }
+          row_splits_vec[dim0] = src_dim0;
+          std::sort(row_splits_vec.begin(), row_splits_vec.end());
+          Array1<int32_t> row_splits(context, row_splits_vec);
+          RaggedShape first = RaggedShape2(&row_splits, nullptr, -1);
+          RaggedShape new_shape = ComposeRaggedShapes(first, shape);
+          shape_vec[j] = new_shape;
+          shapes[j] = &shape_vec[j];
+        }
+        std::vector<RaggedShape> cpu_shapes(num_shape);
+        for (auto i = 0; i != num_shape; ++i) {
+          cpu_shapes[i] = shape_vec[i].To(cpu);
+        }
+
+        {
+          // axis == 0
+          int32_t axis = 0;
+          RaggedShape result = Stack(axis, num_shape, shapes.data());
+          ASSERT_EQ(result.NumAxes(),
+                    num_axes + 2);  // note we append one axis in each shape in
+                                    // `shapes` before `Stack`
+          ASSERT_EQ(result.Dim0(), num_shape);
+          result = result.To(cpu);
+          for (auto iter = result.Iterator(); !iter.Done(); iter.Next()) {
+            std::vector<int32_t> index = iter.Value();
+            int32_t t = result[index];  // don't need the value, just make sure
+                                        // it's a valid index.
+            int32_t i = index[0];
+            index.erase(index.begin());
+            // result[i,j,k,l] = (shape[i])[j,k,l]
+            i = cpu_shapes[i][index];  // don't need the value, just need to
+                                       // make sure it's an allowable index.
+          }
+        }
+        {
+          // axis == 1
+          int32_t axis = 1;
+          RaggedShape result = Stack(axis, num_shape, shapes.data());
+          ASSERT_EQ(result.NumAxes(),
+                    num_axes + 2);  // note we append one axis in each shape in
+                                    // `shapes` before `Stack`
+          ASSERT_EQ(result.Dim0(), dim0);
+          result = result.To(cpu);
+          for (auto iter = result.Iterator(); !iter.Done(); iter.Next()) {
+            std::vector<int32_t> index = iter.Value();
+            int32_t t = result[index];  // don't need the value, just make sure
+                                        // it's a valid index.
+            int32_t i = index[1];
+            index.erase(index.begin() + 1);
+            // result[i,j,k,l] = (shape[j])[i,k,l]
+            i = cpu_shapes[i][index];  // don't need the value, just need to
+                                       // make sure it's an allowable index.
+          }
+        }
       }
     }
   }
+}
 
-  {
+template <typename T>
+void TestStackRagged() {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     // test with random large size
     for (int32_t m = 0; m < 2; ++m) {
       int32_t num_shape = RandInt(2, 100);
       int32_t num_axes = RandInt(2, 4);
       int32_t dim0 = RandInt(1, 100);
-      std::vector<RaggedShape> shape_vec(num_shape);
-      std::vector<RaggedShape *> shapes(num_shape);
+      std::vector<Ragged<T>> ragged_vec(num_shape);
+      std::vector<Ragged<T> *> ragged(num_shape);
       for (int32_t j = 0; j != num_shape; ++j) {
         RaggedShape shape =
             RandomRaggedShape(false, num_axes, num_axes, 0, 1000).To(context);
@@ -1761,151 +1723,62 @@ void TestStack() {
         Array1<int32_t> row_splits(context, row_splits_vec);
         RaggedShape first = RaggedShape2(&row_splits, nullptr, -1);
         RaggedShape new_shape = ComposeRaggedShapes(first, shape);
-        shape_vec[j] = new_shape;
-        shapes[j] = &shape_vec[j];
+        int32_t num_elems = new_shape.NumElements();
+        Array1<T> src_values =
+            RandUniformArray1<T>(context, num_elems, 0, 10000);
+        ragged_vec[j] = Ragged<T>(new_shape, src_values);
+        ragged[j] = &ragged_vec[j];
       }
-      std::vector<RaggedShape> cpu_shapes(num_shape);
-      for (auto i = 0; i != num_shape; ++i) {
-        cpu_shapes[i] = shape_vec[i].To(cpu);
+      std::vector<Ragged<T>> cpu_ragged_vec(num_shape);
+      for (auto j = 0; j != num_shape; ++j) {
+        cpu_ragged_vec[j] = ragged_vec[j].To(cpu);
       }
 
       {
         // axis == 0
         int32_t axis = 0;
-        RaggedShape result = Stack(axis, num_shape, shapes.data());
+        Ragged<T> result = Stack(axis, num_shape, ragged.data());
         ASSERT_EQ(result.NumAxes(),
                   num_axes + 2);  // note we append one axis in each shape in
                                   // `shapes` before `Stack`
         ASSERT_EQ(result.Dim0(), num_shape);
         result = result.To(cpu);
-        for (auto iter = result.Iterator(); !iter.Done(); iter.Next()) {
+        RaggedShape &shape = result.shape;
+        for (auto iter = shape.Iterator(); !iter.Done(); iter.Next()) {
           std::vector<int32_t> index = iter.Value();
-          int32_t t = result[index];  // don't need the value, just make sure
-                                      // it's a valid index.
+          T value = result[index];
           int32_t i = index[0];
           index.erase(index.begin());
           // result[i,j,k,l] = (shape[i])[j,k,l]
-          i = cpu_shapes[i][index];  // don't need the value, just need to
-                                     // make sure it's an allowable index.
+          EXPECT_EQ(value, cpu_ragged_vec[i][index]);
         }
       }
       {
         // axis == 1
         int32_t axis = 1;
-        RaggedShape result = Stack(axis, num_shape, shapes.data());
+        Ragged<T> result = Stack(axis, num_shape, ragged.data());
         ASSERT_EQ(result.NumAxes(),
                   num_axes + 2);  // note we append one axis in each shape in
                                   // `shapes` before `Stack`
         ASSERT_EQ(result.Dim0(), dim0);
         result = result.To(cpu);
-        for (auto iter = result.Iterator(); !iter.Done(); iter.Next()) {
+        RaggedShape &shape = result.shape;
+        for (auto iter = shape.Iterator(); !iter.Done(); iter.Next()) {
           std::vector<int32_t> index = iter.Value();
-          int32_t t = result[index];  // don't need the value, just make sure
-                                      // it's a valid index.
-          int32_t i = index[1];
+          T value = result[index];
+          int32_t j = index[1];
           index.erase(index.begin() + 1);
           // result[i,j,k,l] = (shape[j])[i,k,l]
-          i = cpu_shapes[i][index];  // don't need the value, just need to
-                                     // make sure it's an allowable index.
+          EXPECT_EQ(value, cpu_ragged_vec[j][index]);
         }
       }
     }
   }
 }
-TEST(RaggedShapeOpsTest, TestStack) {
-  TestStack<kCpu>();
-  TestStack<kCuda>();
-}
-
-template <DeviceType d, typename T>
-void TestStackRagged() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  // test with random large size
-  for (int32_t m = 0; m < 2; ++m) {
-    int32_t num_shape = RandInt(2, 100);
-    int32_t num_axes = RandInt(2, 4);
-    int32_t dim0 = RandInt(1, 100);
-    std::vector<Ragged<T>> ragged_vec(num_shape);
-    std::vector<Ragged<T> *> ragged(num_shape);
-    for (int32_t j = 0; j != num_shape; ++j) {
-      RaggedShape shape =
-          RandomRaggedShape(false, num_axes, num_axes, 0, 1000).To(context);
-      int32_t src_dim0 = shape.Dim0();
-      std::vector<int32_t> row_splits_vec(dim0 + 1);
-      row_splits_vec[0] = 0;
-      for (int32_t n = 1; n < dim0; ++n) {
-        row_splits_vec[n] = RandInt(0, src_dim0);
-      }
-      row_splits_vec[dim0] = src_dim0;
-      std::sort(row_splits_vec.begin(), row_splits_vec.end());
-      Array1<int32_t> row_splits(context, row_splits_vec);
-      RaggedShape first = RaggedShape2(&row_splits, nullptr, -1);
-      RaggedShape new_shape = ComposeRaggedShapes(first, shape);
-      int32_t num_elems = new_shape.NumElements();
-      Array1<T> src_values = RandUniformArray1<T>(context, num_elems, 0, 10000);
-      ragged_vec[j] = Ragged<T>(new_shape, src_values);
-      ragged[j] = &ragged_vec[j];
-    }
-    std::vector<Ragged<T>> cpu_ragged_vec(num_shape);
-    for (auto j = 0; j != num_shape; ++j) {
-      cpu_ragged_vec[j] = ragged_vec[j].To(cpu);
-    }
-
-    {
-      // axis == 0
-      int32_t axis = 0;
-      Ragged<T> result = Stack(axis, num_shape, ragged.data());
-      ASSERT_EQ(result.NumAxes(),
-                num_axes + 2);  // note we append one axis in each shape in
-                                // `shapes` before `Stack`
-      ASSERT_EQ(result.Dim0(), num_shape);
-      result = result.To(cpu);
-      RaggedShape &shape = result.shape;
-      for (auto iter = shape.Iterator(); !iter.Done(); iter.Next()) {
-        std::vector<int32_t> index = iter.Value();
-        T value = result[index];
-        int32_t i = index[0];
-        index.erase(index.begin());
-        // result[i,j,k,l] = (shape[i])[j,k,l]
-        EXPECT_EQ(value, cpu_ragged_vec[i][index]);
-      }
-    }
-    {
-      // axis == 1
-      int32_t axis = 1;
-      Ragged<T> result = Stack(axis, num_shape, ragged.data());
-      ASSERT_EQ(result.NumAxes(),
-                num_axes + 2);  // note we append one axis in each shape in
-                                // `shapes` before `Stack`
-      ASSERT_EQ(result.Dim0(), dim0);
-      result = result.To(cpu);
-      RaggedShape &shape = result.shape;
-      for (auto iter = shape.Iterator(); !iter.Done(); iter.Next()) {
-        std::vector<int32_t> index = iter.Value();
-        T value = result[index];
-        int32_t j = index[1];
-        index.erase(index.begin() + 1);
-        // result[i,j,k,l] = (shape[j])[i,k,l]
-        EXPECT_EQ(value, cpu_ragged_vec[j][index]);
-      }
-    }
-  }
-}
 TEST(RaggedTest, TestStackRagged) {
-  TestStackRagged<kCpu, int32_t>();
-  TestStackRagged<kCuda, int32_t>();
-  TestStackRagged<kCpu, double>();
-  TestStackRagged<kCuda, double>();
+  TestStackRagged<int32_t>();
+  TestStackRagged<double>();
 }
-
 
 TEST(RaggedTest, TestMaxSize) {
   for (int32_t i = 0; i <= 10; i++) {
@@ -1922,7 +1795,7 @@ TEST(RaggedTest, TestMaxSize) {
       int32_t *row_splits_data = row_splits.Data();
       int32_t m = 0;
       for (int32_t i = 0; i + 1 < row_splits.Dim(); i++) {
-        int32_t size = row_splits_data[i+1] - row_splits_data[i];
+        int32_t size = row_splits_data[i + 1] - row_splits_data[i];
         if (size > m) m = size;
       }
       ASSERT_EQ(m, max_size);
@@ -1930,73 +1803,61 @@ TEST(RaggedTest, TestMaxSize) {
   }
 }
 
+TEST(RaggedShapeOpsTest, TestMakeTransposable) {
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // simple case
+      const std::vector<int32_t> row_splits1 = {0, 2, 5, 6, 8};
+      // const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2, 3, 3};
+      const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10, 12, 13};
+      // const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5, 6,
+      //                                        6, 7};
+      Array1<int32_t> row_splits1_array(context, row_splits1);
+      Array1<int32_t> row_splits2_array(context, row_splits2);
+      RaggedShape shape = RaggedShape3(&row_splits1_array, nullptr, -1,
+                                       &row_splits2_array, nullptr, -1);
 
-template <DeviceType d>
-void TestMakeTransposable() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+      std::vector<std::vector<int32_t>> expected_row_splits = {
+          {0, 3, 6, 9, 12}, {0, 2, 3, 3, 4, 6, 7, 10, 10, 10, 12, 13, 13}};
+      std::vector<std::vector<int32_t>> expected_row_ids = {
+          {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3},
+          {0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 9, 9, 10}};
 
-  {
-    // simple case
-    const std::vector<int32_t> row_splits1 = {0, 2, 5, 6, 8};
-    // const std::vector<int32_t> row_ids1 = {0, 0, 1, 1, 1, 2, 3, 3};
-    const std::vector<int32_t> row_splits2 = {0, 2, 3, 4, 6, 7, 10, 12, 13};
-    // const std::vector<int32_t> row_ids2 = {0, 0, 1, 2, 3, 3, 4, 5, 5, 5, 6,
-    //                                        6, 7};
-    Array1<int32_t> row_splits1_array(context, row_splits1);
-    Array1<int32_t> row_splits2_array(context, row_splits2);
-    RaggedShape shape = RaggedShape3(&row_splits1_array, nullptr, -1,
-                                     &row_splits2_array, nullptr, -1);
-
-    std::vector<std::vector<int32_t>> expected_row_splits = {
-        {0, 3, 6, 9, 12}, {0, 2, 3, 3, 4, 6, 7, 10, 10, 10, 12, 13, 13}};
-    std::vector<std::vector<int32_t>> expected_row_ids = {
-        {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3},
-        {0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 9, 9, 10}};
-
-    RaggedShape result = MakeTransposable(shape);
-    for (int32_t i = 1; i != 3; ++i) {
-      CheckArrayData(result.RowSplits(i), expected_row_splits[i - 1]);
-      CheckArrayData(result.RowIds(i), expected_row_ids[i - 1]);
-    }
-  }
-
-  {
-    // test with random large size
-    for (int32_t i = 0; i < 2; ++i) {
-      int32_t num_axes = RandInt(2, 4);
-      RaggedShape shape =
-          RandomRaggedShape(true, num_axes, num_axes, 0, 1000).To(context);
-      int32_t dim0 = shape.Dim0();
-      int32_t max_size = shape.MaxSize(1);
       RaggedShape result = MakeTransposable(shape);
-      shape = shape.To(cpu);
-      result = result.To(cpu);
-      EXPECT_EQ(result.Dim0(), dim0);
-      EXPECT_EQ(result.TotSize(1), dim0 * max_size);
-      // check if every sub list in axis 1 has the same size
-      int32_t *row_splits1 = result.RowSplits(1).Data();
-      for (int32_t j = 0; j != dim0 + 1; ++j) {
-        EXPECT_EQ(row_splits1[j], j * max_size);
+      for (int32_t i = 1; i != 3; ++i) {
+        CheckArrayData(result.RowSplits(i), expected_row_splits[i - 1]);
+        CheckArrayData(result.RowIds(i), expected_row_ids[i - 1]);
       }
-      if (num_axes > 2) {
-        for (auto iter = shape.Iterator(); !iter.Done(); iter.Next()) {
-          std::vector<int32_t> index = iter.Value();
-          EXPECT_EQ(shape[index], result[index]);
+    }
+
+    {
+      // test with random large size
+      for (int32_t i = 0; i < 2; ++i) {
+        int32_t num_axes = RandInt(2, 4);
+        RaggedShape shape =
+            RandomRaggedShape(true, num_axes, num_axes, 0, 1000).To(context);
+        int32_t dim0 = shape.Dim0();
+        int32_t max_size = shape.MaxSize(1);
+        RaggedShape result = MakeTransposable(shape);
+        shape = shape.To(cpu);
+        result = result.To(cpu);
+        EXPECT_EQ(result.Dim0(), dim0);
+        EXPECT_EQ(result.TotSize(1), dim0 * max_size);
+        // check if every sub list in axis 1 has the same size
+        int32_t *row_splits1 = result.RowSplits(1).Data();
+        for (int32_t j = 0; j != dim0 + 1; ++j) {
+          EXPECT_EQ(row_splits1[j], j * max_size);
+        }
+        if (num_axes > 2) {
+          for (auto iter = shape.Iterator(); !iter.Done(); iter.Next()) {
+            std::vector<int32_t> index = iter.Value();
+            EXPECT_EQ(shape[index], result[index]);
+          }
         }
       }
     }
   }
-}
-TEST(RaggedShapeOpsTest, TestMakeTransposable) {
-  TestMakeTransposable<kCpu>();
-  TestMakeTransposable<kCuda>();
 }
 
 }  // namespace k2

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -110,7 +110,7 @@ __global__ void RowSplitsToRowIdsKernel(int32_t num_rows,
        }
        x[orig_i] = x[i];
 */
-void RowSplitsToRowIds(ContextPtr &c, int32_t num_rows,
+void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
                        const int32_t *row_splits, int32_t num_elems,
                        int32_t *row_ids) {
   NVTX_RANGE(__func__);
@@ -266,7 +266,7 @@ __global__ void RowIdsToRowSplitsKernel(int32_t num_elems,
 }
 
 // see declaration in utils.h for documentation.
-void RowIdsToRowSplits(ContextPtr &c, int32_t num_elems, const int32_t *row_ids,
+void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
                        bool no_empty_rows, int32_t num_rows,
                        int32_t *row_splits) {
   NVTX_RANGE(__func__);

--- a/k2/csrc/utils.h
+++ b/k2/csrc/utils.h
@@ -198,7 +198,7 @@ namespace k2 {
   10 15 ].
  */
 template <typename SrcPtr, typename DestPtr>
-void ExclusiveSum(ContextPtr &c, int32_t n, SrcPtr src, DestPtr dest);
+void ExclusiveSum(ContextPtr c, int32_t n, SrcPtr src, DestPtr dest);
 
 /* Return the maximum value of the device array 't'.  Note: the sum will be
    initialized with T(0).
@@ -208,7 +208,7 @@ void ExclusiveSum(ContextPtr &c, int32_t n, SrcPtr src, DestPtr dest);
    additional cost.
  */
 template <typename T>
-T MaxValue(ContextPtr &c, int32_t nelems, const T *t);
+T MaxValue(ContextPtr c, int32_t nelems, const T *t);
 
 /*
   This is a rather special purpose function that is used in RaggedShape.
@@ -237,7 +237,7 @@ T MaxValue(ContextPtr &c, int32_t nelems, const T *t);
    Note: there is another function of the same name using the Array1 interface,
    declared in array_ops.h, that may be more convenient.
 */
-void RowSplitsToRowIds(ContextPtr &c, int32_t num_rows,
+void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
                        const int32_t *row_splits, int32_t num_elems,
                        int32_t *row_ids);
 
@@ -303,7 +303,7 @@ RowIdFromRowSplits(int32_t num_rows, const int32_t *row_splits, int32_t index,
    Note: there is another function of the same name using the Array1 interface,
    declared in array_ops.h, that may be more convenient.
  */
-void RowIdsToRowSplits(ContextPtr &c, int32_t num_elems, const int32_t *row_ids,
+void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
                        bool no_empty_rows, int32_t num_rows,
                        int32_t *row_splits);
 

--- a/k2/csrc/utils_inl.h
+++ b/k2/csrc/utils_inl.h
@@ -25,7 +25,7 @@
 
 namespace k2 {
 template <typename SrcPtr, typename DestPtr>
-void ExclusiveSum(ContextPtr &c, int32_t n, const SrcPtr src, DestPtr dest) {
+void ExclusiveSum(ContextPtr c, int32_t n, const SrcPtr src, DestPtr dest) {
   K2_CHECK_GE(n, 0);
   DeviceType d = c->GetDeviceType();
   using SumType = typename std::decay<decltype(dest[0])>::type;
@@ -52,7 +52,7 @@ void ExclusiveSum(ContextPtr &c, int32_t n, const SrcPtr src, DestPtr dest) {
   }
 }
 template <typename T>
-T MaxValue(ContextPtr &c, int32_t nelems, const T *t) {
+T MaxValue(ContextPtr c, int32_t nelems, const T *t) {
   DeviceType d = c->GetDeviceType();
   if (d == kCpu) {
     // note the return value is initialized with T(0)

--- a/k2/csrc/utils_test.cu
+++ b/k2/csrc/utils_test.cu
@@ -25,279 +25,241 @@
 #include "k2/csrc/utils.h"
 
 namespace k2 {
-template <typename T, DeviceType d>
+template <typename T>
 void TestExclusiveSum() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    std::vector<T> data(5);
-    std::iota(data.begin(), data.end(), 0);
-    EXPECT_THAT(data, ::testing::ElementsAre(0, 1, 2, 3, 4));
-    Array1<T> src(context, data);
-    Array1<T> dst(context, src.Dim());
-    T *dst_data = dst.Data();
-    ExclusiveSum(context, src.Dim(), src.Data(), dst.Data());
-    // copy data from CPU/GPU to CPU
-    Array1<T> cpu_array = dst.To(cpu);
-    std::vector<T> cpu_data(cpu_array.Data(),
-                            cpu_array.Data() + cpu_array.Dim());
-    EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 0, 1, 3, 6));
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      std::vector<T> data(5);
+      std::iota(data.begin(), data.end(), 0);
+      EXPECT_THAT(data, ::testing::ElementsAre(0, 1, 2, 3, 4));
+      Array1<T> src(context, data);
+      Array1<T> dst(context, src.Dim());
+      T *dst_data = dst.Data();
+      ExclusiveSum(context, src.Dim(), src.Data(), dst.Data());
+      // copy data from CPU/GPU to CPU
+      Array1<T> cpu_array = dst.To(cpu);
+      std::vector<T> cpu_data(cpu_array.Data(),
+                              cpu_array.Data() + cpu_array.Dim());
+      EXPECT_THAT(cpu_data, ::testing::ElementsAre(0, 0, 1, 3, 6));
+    }
   }
 }
 
 TEST(UtilsTest, ExclusiveSum) {
-  TestExclusiveSum<int32_t, kCpu>();
-  TestExclusiveSum<int32_t, kCuda>();
-  TestExclusiveSum<double, kCpu>();
-  TestExclusiveSum<double, kCuda>();
+  TestExclusiveSum<int32_t>();
+  TestExclusiveSum<double>();
 
   // TODO(haowen): add tests where output type differs from input type?
 }
 
-template <typename T, DeviceType d>
+template <typename T>
 void TestMaxValue() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // empty input array
+      std::vector<T> data;
+      Array1<T> src(context, data);
+      T max_value = MaxValue(context, src.Dim(), src.Data());
+      EXPECT_EQ(max_value, 0);
+    }
 
-  {
-    // empty input array
-    std::vector<T> data;
-    Array1<T> src(context, data);
-    T max_value = MaxValue(context, src.Dim(), src.Data());
-    EXPECT_EQ(max_value, 0);
-  }
+    {
+      // no empty input array
+      std::vector<T> data = {0, 1, 5, 7, 8, 1};
+      Array1<T> src(context, data);
+      T max_value = MaxValue(context, src.Dim(), src.Data());
+      EXPECT_EQ(max_value, 8);
+    }
 
-  {
-    // no empty input array
-    std::vector<T> data = {0, 1, 5, 7, 8, 1};
-    Array1<T> src(context, data);
-    T max_value = MaxValue(context, src.Dim(), src.Data());
-    EXPECT_EQ(max_value, 8);
-  }
+    {
+      // tests with larger random size
+      int32_t max_elem = 10000;
+      int32_t num_elems = RandInt(2000, max_elem);
+      std::vector<int32_t> data(num_elems);
+      std::iota(data.begin(), data.end(), 0);
+      // shuffle data
+      std::random_device rd;
+      std::mt19937 g(rd());
+      std::shuffle(data.begin(), data.end(), g);
+      // assign max_elem to a random position
+      int32_t pos = RandInt(0, num_elems - 1);
+      data[pos] = max_elem;
 
-  {
-    // tests with larger random size
-    int32_t max_elem = 10000;
-    int32_t num_elems = RandInt(2000, max_elem);
-    std::vector<int32_t> data(num_elems);
-    std::iota(data.begin(), data.end(), 0);
-    // shuffle data
-    std::random_device rd;
-    std::mt19937 g(rd());
-    std::shuffle(data.begin(), data.end(), g);
-    // assign max_elem to a random position
-    int32_t pos = RandInt(0, num_elems - 1);
-    data[pos] = max_elem;
-
-    Array1<int32_t> src(context, data);
-    int32_t max_value = MaxValue(context, src.Dim(), src.Data());
-    EXPECT_EQ(max_value, max_elem);
+      Array1<int32_t> src(context, data);
+      int32_t max_value = MaxValue(context, src.Dim(), src.Data());
+      EXPECT_EQ(max_value, max_elem);
+    }
   }
 }
 
 TEST(UtilsTest, MaxValue) {
-  TestMaxValue<int32_t, kCpu>();
-  TestMaxValue<int32_t, kCuda>();
-  TestMaxValue<double, kCpu>();
-  TestMaxValue<double, kCuda>();
-}
-
-template <DeviceType d>
-void TestRowSplitsToRowIds() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
-
-  {
-    // test empty case
-    const std::vector<int32_t> row_splits_vec = {0};
-    const std::vector<int32_t> row_ids_vec;
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    int32_t num_rows = row_splits.Dim() - 1;
-    int32_t num_elements = row_splits[num_rows];
-    Array1<int32_t> row_ids(context, num_elements);
-    int32_t *row_ids_data = row_ids.Data();
-    EXPECT_EQ(row_ids.Dim(), num_elements);
-    // just run to check if there is any error
-    RowSplitsToRowIds(context, num_rows, row_splits.Data(), num_elements,
-                      row_ids_data);
-  }
-
-  {
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_splits(context, row_splits_vec);
-    int32_t num_rows = row_splits.Dim() - 1;
-    int32_t num_elements = row_splits[num_rows];
-    Array1<int32_t> row_ids(context, num_elements);
-    int32_t *row_ids_data = row_ids.Data();
-    EXPECT_EQ(row_ids.Dim(), num_elements);
-    RowSplitsToRowIds(context, num_rows, row_splits.Data(), num_elements,
-                      row_ids_data);
-    // copy data from CPU/GPU to CPU
-    Array1<int32_t> cpu_array = row_ids.To(cpu);
-    std::vector<int32_t> cpu_data(cpu_array.Data(),
-                                  cpu_array.Data() + cpu_array.Dim());
-    EXPECT_EQ(cpu_data, row_ids_vec);
-  }
-
-  {
-    // test with random large size
-    const int32_t min_num_elements = 2000;
-    RaggedShape shape = RandomRaggedShape(true, 2, 2, min_num_elements, 10000);
-    ASSERT_EQ(shape.NumAxes(), 2);
-    const auto &axes = shape.Axes();
-    ASSERT_EQ(axes.size(), 1);
-    // note `src_row_splits` is on CPU as it is created with RandomRaggedShape
-    const Array1<int32_t> &src_row_splits = axes[0].row_splits;
-    Array1<int32_t> row_splits = src_row_splits.To(context);
-    // don't call `shape.RowIds(axis)` here, it will make the test meaningless
-    // as `shape.RowId(axis)` calls `RowSplitsToRowIds()` internally.
-    // note `row_ids` is on CPU as it is created with RandomRaggedShape
-    const Array1<int32_t> &expected_row_ids = axes[0].row_ids;
-    int32_t num_rows = row_splits.Dim() - 1;
-    int32_t num_elements = row_splits[num_rows];
-    ASSERT_GE(num_elements, min_num_elements);
-    ASSERT_EQ(expected_row_ids.Dim(), num_elements);
-    Array1<int32_t> row_ids(context, num_elements);
-    int32_t *row_ids_data = row_ids.Data();
-    EXPECT_EQ(row_ids.Dim(), num_elements);
-    RowSplitsToRowIds(context, num_rows, row_splits.Data(), num_elements,
-                      row_ids_data);
-    // copy data from CPU/GPU to CPU
-    Array1<int32_t> cpu_array = row_ids.To(cpu);
-    std::vector<int32_t> cpu_data(cpu_array.Data(),
-                                  cpu_array.Data() + cpu_array.Dim());
-    std::vector<int32_t> expected_row_ids_data(
-        expected_row_ids.Data(),
-        expected_row_ids.Data() + expected_row_ids.Dim());
-    EXPECT_EQ(cpu_data, expected_row_ids_data);
-  }
+  TestMaxValue<int32_t>();
+  TestMaxValue<double>();
 }
 
 TEST(UtilsTest, RowSplitsToRowIds) {
-  TestRowSplitsToRowIds<kCpu>();
-  TestRowSplitsToRowIds<kCuda>();
-}
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // test empty case
+      const std::vector<int32_t> row_splits_vec = {0};
+      const std::vector<int32_t> row_ids_vec;
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      int32_t num_rows = row_splits.Dim() - 1;
+      int32_t num_elements = row_splits[num_rows];
+      Array1<int32_t> row_ids(context, num_elements);
+      int32_t *row_ids_data = row_ids.Data();
+      EXPECT_EQ(row_ids.Dim(), num_elements);
+      // just run to check if there is any error
+      RowSplitsToRowIds(context, num_rows, row_splits.Data(), num_elements,
+                        row_ids_data);
+    }
 
-template <DeviceType d>
-void TestRowIdsToRowSplits() {
-  ContextPtr cpu = GetCpuContext();  // will use to copy data
-  ContextPtr context = nullptr;
-  if (d == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(d, kCuda);
-    context = GetCudaContext();
-  }
+    {
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_splits(context, row_splits_vec);
+      int32_t num_rows = row_splits.Dim() - 1;
+      int32_t num_elements = row_splits[num_rows];
+      Array1<int32_t> row_ids(context, num_elements);
+      int32_t *row_ids_data = row_ids.Data();
+      EXPECT_EQ(row_ids.Dim(), num_elements);
+      RowSplitsToRowIds(context, num_rows, row_splits.Data(), num_elements,
+                        row_ids_data);
+      // copy data from CPU/GPU to CPU
+      Array1<int32_t> cpu_array = row_ids.To(cpu);
+      std::vector<int32_t> cpu_data(cpu_array.Data(),
+                                    cpu_array.Data() + cpu_array.Dim());
+      EXPECT_EQ(cpu_data, row_ids_vec);
+    }
 
-  {
-    // test empty case
-    const std::vector<int32_t> row_ids_vec;
-    const std::vector<int32_t> row_splits_vec;
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    int32_t num_rows = 0;
-    int32_t num_elements = row_ids.Dim();
-    Array1<int32_t> row_splits(context, num_rows + 1);
-    int32_t *row_splits_data = row_splits.Data();
-    RowIdsToRowSplits(context, num_elements, row_ids.Data(), true, num_rows,
-                      row_splits_data);
-    EXPECT_EQ(row_splits[0], 0);
-  }
-
-  {
-    // no empty rows
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 1, 1, 2};
-    const std::vector<int32_t> row_splits_vec = {0, 2, 5, 6};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    int32_t num_elements = row_ids.Dim();
-    int32_t num_rows = row_ids[num_elements - 1] + 1;
-    Array1<int32_t> row_splits(context, num_rows + 1);
-    EXPECT_EQ(row_splits.Dim(), num_rows + 1);
-    int32_t *row_splits_data = row_splits.Data();
-    RowIdsToRowSplits(context, num_elements, row_ids.Data(), true, num_rows,
-                      row_splits_data);
-    // copy data from CPU/GPU to CPU
-    Array1<int32_t> cpu_array = row_splits.To(cpu);
-    std::vector<int32_t> cpu_data(cpu_array.Data(),
-                                  cpu_array.Data() + cpu_array.Dim());
-    EXPECT_EQ(cpu_data, row_splits_vec);
-  }
-
-  {
-    // has empty rows
-    const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
-                                                 12, 13, 15, 15, 16};
-    const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
-                                              4, 5, 5, 5, 6, 7, 7, 9};
-    Array1<int32_t> row_ids(context, row_ids_vec);
-    int32_t num_elements = row_ids.Dim();
-    int32_t num_rows = row_ids[num_elements - 1] + 1;
-    Array1<int32_t> row_splits(context, num_rows + 1);
-    EXPECT_EQ(row_splits.Dim(), num_rows + 1);
-    int32_t *row_splits_data = row_splits.Data();
-    RowIdsToRowSplits(context, num_elements, row_ids.Data(), false, num_rows,
-                      row_splits_data);
-    // copy data from CPU/GPU to CPU
-    Array1<int32_t> cpu_array = row_splits.To(cpu);
-    std::vector<int32_t> cpu_data(cpu_array.Data(),
-                                  cpu_array.Data() + cpu_array.Dim());
-    EXPECT_EQ(cpu_data, row_splits_vec);
-  }
-
-  {
-    // test with random large size
-    const int32_t min_num_elements = 2000;
-    RaggedShape shape = RandomRaggedShape(true, 2, 2, min_num_elements, 10000);
-    ASSERT_EQ(shape.NumAxes(), 2);
-    const auto &axes = shape.Axes();
-    ASSERT_EQ(axes.size(), 1);
-    // note `src_row_ids` is on CPU as it is created with RandomRaggedShape
-    const Array1<int32_t> &src_row_ids = axes[0].row_ids;
-    Array1<int32_t> row_ids = src_row_ids.To(context);
-    // note `row_splits` is on CPU as it is created with RandomRaggedShape
-    const Array1<int32_t> &expected_row_splits = axes[0].row_splits;
-    int32_t num_elements = row_ids.Dim();
-    ASSERT_GE(num_elements, min_num_elements);
-    int32_t num_rows = expected_row_splits.Dim() - 1;
-    Array1<int32_t> row_splits(context, num_rows + 1);
-    EXPECT_EQ(row_splits.Dim(), num_rows + 1);
-    int32_t *row_splits_data = row_splits.Data();
-    RowIdsToRowSplits(context, num_elements, row_ids.Data(), false, num_rows,
-                      row_splits_data);
-    // copy data from CPU/GPU to CPU
-    Array1<int32_t> cpu_array = row_splits.To(cpu);
-    std::vector<int32_t> cpu_data(cpu_array.Data(),
-                                  cpu_array.Data() + cpu_array.Dim());
-    std::vector<int32_t> expected_row_splits_data(
-        expected_row_splits.Data(),
-        expected_row_splits.Data() + expected_row_splits.Dim());
-    EXPECT_EQ(cpu_data, expected_row_splits_data);
+    {
+      // test with random large size
+      const int32_t min_num_elements = 2000;
+      RaggedShape shape =
+          RandomRaggedShape(true, 2, 2, min_num_elements, 10000);
+      ASSERT_EQ(shape.NumAxes(), 2);
+      const auto &axes = shape.Axes();
+      ASSERT_EQ(axes.size(), 1);
+      // note `src_row_splits` is on CPU as it is created with RandomRaggedShape
+      const Array1<int32_t> &src_row_splits = axes[0].row_splits;
+      Array1<int32_t> row_splits = src_row_splits.To(context);
+      // don't call `shape.RowIds(axis)` here, it will make the test meaningless
+      // as `shape.RowId(axis)` calls `RowSplitsToRowIds()` internally.
+      // note `row_ids` is on CPU as it is created with RandomRaggedShape
+      const Array1<int32_t> &expected_row_ids = axes[0].row_ids;
+      int32_t num_rows = row_splits.Dim() - 1;
+      int32_t num_elements = row_splits[num_rows];
+      ASSERT_GE(num_elements, min_num_elements);
+      ASSERT_EQ(expected_row_ids.Dim(), num_elements);
+      Array1<int32_t> row_ids(context, num_elements);
+      int32_t *row_ids_data = row_ids.Data();
+      EXPECT_EQ(row_ids.Dim(), num_elements);
+      RowSplitsToRowIds(context, num_rows, row_splits.Data(), num_elements,
+                        row_ids_data);
+      // copy data from CPU/GPU to CPU
+      Array1<int32_t> cpu_array = row_ids.To(cpu);
+      std::vector<int32_t> cpu_data(cpu_array.Data(),
+                                    cpu_array.Data() + cpu_array.Dim());
+      std::vector<int32_t> expected_row_ids_data(
+          expected_row_ids.Data(),
+          expected_row_ids.Data() + expected_row_ids.Dim());
+      EXPECT_EQ(cpu_data, expected_row_ids_data);
+    }
   }
 }
 
 TEST(UtilsTest, RowIdsToRowSplits) {
-  TestRowIdsToRowSplits<kCpu>();
-  TestRowIdsToRowSplits<kCuda>();
+  ContextPtr cpu = GetCpuContext();  // will be used to copy data
+  for (auto &context : {GetCpuContext(), GetCudaContext()}) {
+    {
+      // test empty case
+      const std::vector<int32_t> row_ids_vec;
+      const std::vector<int32_t> row_splits_vec;
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      int32_t num_rows = 0;
+      int32_t num_elements = row_ids.Dim();
+      Array1<int32_t> row_splits(context, num_rows + 1);
+      int32_t *row_splits_data = row_splits.Data();
+      RowIdsToRowSplits(context, num_elements, row_ids.Data(), true, num_rows,
+                        row_splits_data);
+      EXPECT_EQ(row_splits[0], 0);
+    }
+
+    {
+      // no empty rows
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 1, 1, 2};
+      const std::vector<int32_t> row_splits_vec = {0, 2, 5, 6};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      int32_t num_elements = row_ids.Dim();
+      int32_t num_rows = row_ids[num_elements - 1] + 1;
+      Array1<int32_t> row_splits(context, num_rows + 1);
+      EXPECT_EQ(row_splits.Dim(), num_rows + 1);
+      int32_t *row_splits_data = row_splits.Data();
+      RowIdsToRowSplits(context, num_elements, row_ids.Data(), true, num_rows,
+                        row_splits_data);
+      // copy data from CPU/GPU to CPU
+      Array1<int32_t> cpu_array = row_splits.To(cpu);
+      std::vector<int32_t> cpu_data(cpu_array.Data(),
+                                    cpu_array.Data() + cpu_array.Dim());
+      EXPECT_EQ(cpu_data, row_splits_vec);
+    }
+
+    {
+      // has empty rows
+      const std::vector<int32_t> row_splits_vec = {0,  2,  3,  5,  8, 9,
+                                                   12, 13, 15, 15, 16};
+      const std::vector<int32_t> row_ids_vec = {0, 0, 1, 2, 2, 3, 3, 3,
+                                                4, 5, 5, 5, 6, 7, 7, 9};
+      Array1<int32_t> row_ids(context, row_ids_vec);
+      int32_t num_elements = row_ids.Dim();
+      int32_t num_rows = row_ids[num_elements - 1] + 1;
+      Array1<int32_t> row_splits(context, num_rows + 1);
+      EXPECT_EQ(row_splits.Dim(), num_rows + 1);
+      int32_t *row_splits_data = row_splits.Data();
+      RowIdsToRowSplits(context, num_elements, row_ids.Data(), false, num_rows,
+                        row_splits_data);
+      // copy data from CPU/GPU to CPU
+      Array1<int32_t> cpu_array = row_splits.To(cpu);
+      std::vector<int32_t> cpu_data(cpu_array.Data(),
+                                    cpu_array.Data() + cpu_array.Dim());
+      EXPECT_EQ(cpu_data, row_splits_vec);
+    }
+
+    {
+      // test with random large size
+      const int32_t min_num_elements = 2000;
+      RaggedShape shape =
+          RandomRaggedShape(true, 2, 2, min_num_elements, 10000);
+      ASSERT_EQ(shape.NumAxes(), 2);
+      const auto &axes = shape.Axes();
+      ASSERT_EQ(axes.size(), 1);
+      // note `src_row_ids` is on CPU as it is created with RandomRaggedShape
+      const Array1<int32_t> &src_row_ids = axes[0].row_ids;
+      Array1<int32_t> row_ids = src_row_ids.To(context);
+      // note `row_splits` is on CPU as it is created with RandomRaggedShape
+      const Array1<int32_t> &expected_row_splits = axes[0].row_splits;
+      int32_t num_elements = row_ids.Dim();
+      ASSERT_GE(num_elements, min_num_elements);
+      int32_t num_rows = expected_row_splits.Dim() - 1;
+      Array1<int32_t> row_splits(context, num_rows + 1);
+      EXPECT_EQ(row_splits.Dim(), num_rows + 1);
+      int32_t *row_splits_data = row_splits.Data();
+      RowIdsToRowSplits(context, num_elements, row_ids.Data(), false, num_rows,
+                        row_splits_data);
+      // copy data from CPU/GPU to CPU
+      Array1<int32_t> cpu_array = row_splits.To(cpu);
+      std::vector<int32_t> cpu_data(cpu_array.Data(),
+                                    cpu_array.Data() + cpu_array.Dim());
+      std::vector<int32_t> expected_row_splits_data(
+          expected_row_splits.Data(),
+          expected_row_splits.Data() + expected_row_splits.Dim());
+      EXPECT_EQ(cpu_data, expected_row_splits_data);
+    }
+  }
 }
 }  // namespace k2


### PR DESCRIPTION
And changed some functions' context parameter from `ContextPtr& c` to `ContextPtr c` to accept lvalue (It also could be fine if we change them to `const ContextPtr& c`, but as `ContextPtr` is a shared_ptr, I think it is very cheap to pass by value).