### PR TITLE
Fail earlier if no compiler supporting c++14 is available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,15 @@ include(CheckIncludeFileCXX)
 check_include_file_cxx(cxxabi.h K2_HAVE_CXXABI_H)
 check_include_file_cxx(execinfo.h K2_HAVE_EXECINFO_H)
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++14" K2_COMPILER_SUPPORTS_CXX14)
+if(NOT K2_COMPILER_SUPPORTS_CXX14)
+  message(FATAL_ERROR "
+    k2 requires a compiler supporting at least C++14.
+    If you are using GCC, please upgrade it to at least version 5.0.
+    If you are using Clang, please upgrade it to at least version 3.4.")
+endif()
+
 # ========= Settings for CUB begin =========
 # the following settings are modified from cub/CMakeLists.txt
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ version to be used.")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,6 +55,7 @@ after creation.
 
 Before compiling k2, some preparation work has to be done:
 
+- Have a compiler supporting at least c++14, e.g., GCC >= 5.0, Clang >= 3.4.
 - Install CMake. CMake 3.11.0 and 3.18.0 are known to work.
 - Install Python3. Python 3.6, 3.7 and 3.8 are known to work.
 - Install PyTorch. PyTorch 1.6 and 1.7 are known to work.


### PR DESCRIPTION
```bash
cmake -DCMAKE_BUILD_TYPE=Release ..
```
will exit with error if it detects that the compiler does not support C++14.