### PR TITLE
Enable NVTX_RANGE for more functions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           pwd
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DK2_ENABLE_NVTX=OFF ..
           cat k2/csrc/version.h
 
       - name: Build _k2
@@ -95,10 +95,7 @@ jobs:
         run: |
           echo "number of cores: $(nproc)"
           cd build
-          make VERBOSE=1
-          ls -lh lib/*
-          rm lib/*
-          make VERBOSE=1 _k2
+          make VERBOSE=1 -j _k2
           ls -lh lib/*
 
       - name: Build pip packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           pwd
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DK2_ENABLE_NVTX=OFF ..
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
           cat k2/csrc/version.h
 
       - name: Build _k2
@@ -95,7 +95,9 @@ jobs:
         run: |
           echo "number of cores: $(nproc)"
           cd build
-          make VERBOSE=1 -j _k2
+          # we cannot use -j here because of limited RAM
+          # of the VM provided by GitHub actions
+          make VERBOSE=1 _k2
           ls -lh lib/*
 
       - name: Build pip packages

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,5 +99,7 @@ jobs:
         run: |
           echo "number of cores: $(nproc)"
           cd build
-          make -j
+          # we cannot use -j here because of limited RAM
+          # of the VM provided by GitHub actions
+          make
           ctest --output-on-failure

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,8 +99,5 @@ jobs:
         run: |
           echo "number of cores: $(nproc)"
           cd build
-          make
-          ./bin/cu_fsa_algo_test
-          ./bin/cu_fsa_utils_test
-          ./bin/cu_ragged_test
+          make -j
           ctest --output-on-failure

--- a/k2/csrc/array_inl.h
+++ b/k2/csrc/array_inl.h
@@ -35,6 +35,7 @@ namespace k2 {
 
 template <typename T>
 Array1<T> Array1<T>::Clone() const {
+  NVTX_RANGE(__func__);
   Array1<T> ans(Context(), Dim());
   ans.CopyFrom(*this);
   return ans;
@@ -53,8 +54,7 @@ void Array1<T>::CopyFrom(const Array1<T> &src) {
 }
 template <typename T>
 std::ostream &operator<<(std::ostream &stream, const Array1<T> &array) {
-  if (array.GetRegion() == nullptr)
-    return stream << "<invalid Array1>";
+  if (array.GetRegion() == nullptr) return stream << "<invalid Array1>";
   stream << "[ ";
   Array1<T> to_print = array.To(GetCpuContext());
   const T *to_print_data = to_print.Data();
@@ -66,8 +66,7 @@ std::ostream &operator<<(std::ostream &stream, const Array1<T> &array) {
 
 template <typename T>
 std::ostream &operator<<(std::ostream &stream, const Array2<T> &array) {
-  if (array.GetRegion() == nullptr)
-    return stream << "<invalid Array2>";
+  if (array.GetRegion() == nullptr) return stream << "<invalid Array2>";
   stream << "\n[";
   Array2<T> array_cpu = array.To(GetCpuContext());
   int32_t num_rows = array_cpu.Dim0();

--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -61,6 +61,7 @@ void Transpose(ContextPtr &c, const Array2<T> &src, Array2<T> *dest);
  */
 template <typename S, typename T>
 void ExclusiveSum(const Array1<S> &src, Array1<T> *dest) {
+  NVTX_RANGE(__func__);
   K2_CHECK(IsCompatible(src, *dest));
   int32_t src_dim = src.Dim();
   int32_t dest_dim = dest->Dim();
@@ -79,6 +80,7 @@ void ExclusiveSum(const Array1<S> &src, Array1<T> *dest) {
  */
 template <typename T>
 Array1<T> ExclusiveSum(const Array1<T> &src) {
+  NVTX_RANGE(__func__);
   Array1<T> ans(src.Context(), src.Dim());
   ExclusiveSum(src, &ans);
   return ans;

--- a/k2/csrc/context.h
+++ b/k2/csrc/context.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "k2/csrc/log.h"
+#include "k2/csrc/nvtx.h"
 
 namespace k2 {
 
@@ -168,6 +169,7 @@ inline cudaMemcpyKind GetMemoryCopyKind(const Context &src,
 // for `context`.
 inline void MemoryCopy(void *dst, const void *src, std::size_t count,
                        cudaMemcpyKind kind, Context *context) {
+  NVTX_RANGE(__func__);
   cudaError_t ret;
   if (kind == cudaMemcpyHostToHost) {
     memcpy(dst, src, count);
@@ -290,6 +292,7 @@ struct Region : public std::enable_shared_from_this<Region> {
                          larger of double the current size, or
                          the next power of 2 greater than `new_bytes_used`). */
   void Extend(size_t new_bytes_used) {
+    NVTX_RANGE(__func__);
     if (new_bytes_used <= bytes_used) return;
     if (num_bytes < new_bytes_used) {  // reallocate and copy
       size_t new_size = std::max<size_t>(num_bytes * 2, new_bytes_used);

--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -256,6 +256,7 @@ void RemoveEpsilon(FsaOrVec &src, FsaOrVec *dest,
 
 void Determinize(FsaOrVec &src, FsaOrVec *dest,
                  Ragged<int32_t> *arc_derivs /*=nullptr*/) {
+  NVTX_RANGE(__func__);
   int32_t num_axes = src.NumAxes();
   if (num_axes < 2 || num_axes > 3) {
     K2_LOG(FATAL) << "Input has bad num-axes " << num_axes;
@@ -748,6 +749,7 @@ Fsa Union(FsaVec &fsas, Array1<int32_t> *arc_map /*= nullptr*/) {
 }
 
 Fsa Closure(Fsa &fsa, Array1<int32_t> *arc_map /* = nullptr*/) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(fsa.NumAxes(), 2) << "We support only a single FSA.";
   ContextPtr &c = fsa.Context();
 

--- a/k2/csrc/host_shim.cu
+++ b/k2/csrc/host_shim.cu
@@ -20,7 +20,7 @@
 namespace k2 {
 
 k2host::Fsa FsaToHostFsa(Fsa &fsa) {
-    NVTX_RANGE(__func__);
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(fsa.NumAxes(), 2);
   K2_CHECK_EQ(fsa.Context()->GetDeviceType(), kCpu);
   // reinterpret_cast works because the arcs have the same members
@@ -142,7 +142,6 @@ FsaVec FsaVecCreator::GetFsaVec() {
 */
 static Array1<bool> CheckProperties(FsaOrVec &fsas,
                                     bool (*f)(const k2host::Fsa &)) {
-  NVTX_RANGE(__func__);
   NVTX_RANGE("CheckProperties");
   ContextPtr &c = fsas.Context();
   K2_CHECK_EQ(c->GetDeviceType(), kCpu);

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -377,6 +377,7 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
                                 const Array1<int32_t> &new2old,
                                 Array2<int32_t> *old_offsets,
                                 Array2<int32_t> *new_offsets) {
+  NVTX_RANGE(__func__);
   K2_CHECK(src.NumAxes() > 1);
   ContextPtr &c = src.Context();
   int32_t num_axes = src.NumAxes(), ans_dim0 = new2old.Dim();
@@ -407,6 +408,7 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
 
 RaggedShape Index(RaggedShape &src, const Array1<int32_t> &new2old,
                   Array1<int32_t> *elem_indexes /*=nullptr*/) {
+  NVTX_RANGE(__func__);
   ContextPtr c = src.Context();
   bool is_cpu = (c->GetDeviceType() == kCpu);
   K2_CHECK(IsCompatible(src, new2old));
@@ -584,6 +586,7 @@ Array2<int32_t> GetOffsets(int32_t num_srcs, RaggedShape **src) {
 
 void GetRowInfo(RaggedShape &src, Array1<int32_t *> *row_splits,
                 Array1<int32_t *> *row_ids) {
+  NVTX_RANGE(__func__);
   int32_t axes = src.NumAxes();
   K2_CHECK_GE(axes, 2);
   src.Populate();
@@ -601,6 +604,7 @@ void GetRowInfo(RaggedShape &src, Array1<int32_t *> *row_splits,
 void GetRowInfoMulti(int32_t num_srcs, RaggedShape **src,
                      Array2<int32_t *> *row_splits,
                      Array2<int32_t *> *row_ids) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GT(num_srcs, 0);
   int32_t num_axes_in = src[0]->NumAxes();
   K2_CHECK_GE(num_axes_in, 2);
@@ -752,6 +756,7 @@ RaggedShape Append(int32_t axis, int32_t num_srcs, RaggedShape **src) {
 }
 
 RaggedShape RemoveAxis(RaggedShape &src, int32_t axis) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GT(src.NumAxes(), 2);
   K2_CHECK(axis >= 0 && axis < src.NumAxes());
 
@@ -779,6 +784,7 @@ RaggedShape RemoveAxis(RaggedShape &src, int32_t axis) {
 }
 
 RaggedShape MakeTransposable(RaggedShape &src) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GE(src.NumAxes(), 2);
   int32_t src_dim0 = src.Dim0(), src_tot_size1 = src.TotSize(1);
   if (src_dim0 <= 1) return src;
@@ -866,6 +872,7 @@ RaggedShape MakeTransposable(RaggedShape &src) {
 
 // transpose axes 0 and 1.
 RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GT(src.NumAxes(), 2);
   ContextPtr c = src.Context();
   int32_t src_dim0 = src.Dim0(), src_tot_size1 = src.TotSize(1);
@@ -945,6 +952,7 @@ RaggedShape Stack(int32_t axis, int32_t num_srcs, RaggedShape **src) {
 }
 
 RaggedShape TrivialShape(ContextPtr &c, int32_t num_elems) {
+  NVTX_RANGE(__func__);
   // row_splits= [
   Array1<int32_t> row_splits = Range<int32_t>(c, 2, 0, num_elems);
   Array1<int32_t> row_ids(c, num_elems, 0);
@@ -952,6 +960,7 @@ RaggedShape TrivialShape(ContextPtr &c, int32_t num_elems) {
 }
 
 RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1) {
+  NVTX_RANGE(__func__);
   Array1<int32_t> row_splits = Range<int32_t>(c, dim0 + 1, 0, dim1);
   int32_t *row_splits_data = row_splits.Data();
   Array1<int32_t> row_ids(c, dim0 * dim1);
@@ -965,6 +974,7 @@ RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1) {
 
 Ragged<int32_t> GetCountsPartitioned(Ragged<int32_t> &src,
                                      RaggedShape &ans_ragged_shape) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(src.NumAxes(), 2);
   K2_CHECK_EQ(ans_ragged_shape.NumAxes(), 2);
   K2_CHECK(IsCompatible(src, ans_ragged_shape));
@@ -978,6 +988,7 @@ Ragged<int32_t> GetCountsPartitioned(Ragged<int32_t> &src,
 
 static Array1<int32_t> GetTransposeReorderingCpu(Ragged<int32_t> &src,
                                                  int32_t num_cols) {
+  NVTX_RANGE(__func__);
   std::vector<std::vector<int32_t>> column_indexes(num_cols);  // [column][row]
   const int32_t *values_data = src.values.Data();
   int32_t n = src.values.Dim();
@@ -998,6 +1009,7 @@ static Array1<int32_t> GetTransposeReorderingCpu(Ragged<int32_t> &src,
 
 static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
                                                            int32_t num_cols) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(src.NumAxes(), 3);
   ContextPtr &context = src.Context();
   K2_CHECK_EQ(context->GetDeviceType(), kCuda);
@@ -1043,6 +1055,7 @@ static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
 }
 
 Array1<int32_t> GetTransposeReordering(Ragged<int32_t> &src, int32_t num_cols) {
+  NVTX_RANGE(__func__);
   ContextPtr &context = src.Context();
   if (src.NumAxes() < 2) {
     // src is empty
@@ -1092,6 +1105,7 @@ Array1<int32_t> GetTransposeReordering(Ragged<int32_t> &src, int32_t num_cols) {
 }
 
 RaggedShape ChangeSublistSize(RaggedShape &src, int32_t size_delta) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GE(src.NumAxes(), 2);
   // the result will have the same num-axes as `src` (the NumAxes() of the
   // object is not the same as the number of RaggedShapeDim axes).
@@ -1162,6 +1176,7 @@ RaggedShape ChangeSublistSize(RaggedShape &src, int32_t size_delta) {
 }
 
 RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &renumbering) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(renumbering.NumOldElems(), src.NumElements());
 
   // Make sure final row-ids are populated.
@@ -1175,6 +1190,7 @@ RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &renumbering) {
 
 RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &r_before_last,
                                  Renumbering &r_last) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(r_before_last.NumOldElems(), src.TotSize(src.NumAxes() - 2));
   K2_CHECK_EQ(r_last.NumOldElems(), src.NumElements());
 
@@ -1260,6 +1276,7 @@ RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &r_before_last,
 }
 
 RaggedShape EmptyRaggedShape(ContextPtr &c, int32_t num_axes) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GE(num_axes, 2);
   std::vector<RaggedShapeDim> axes(num_axes - 1);
   axes[0].row_splits = Array1<int32_t>(c, 1, 0);

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -300,6 +300,7 @@ RaggedShape Transpose(RaggedShape &src,
 template <typename T>
 Ragged<T> Transpose(Ragged<T> &src,
                     Array1<int32_t> *value_indexes_out = nullptr) {
+  NVTX_RANGE(__func__);
   Array1<int32_t> value_indexes;
   RaggedShape ans_shape = Transpose(src.shape, &value_indexes);
   if (value_indexes_out) *value_indexes_out = value_indexes;

--- a/k2/csrc/test_utils.cu
+++ b/k2/csrc/test_utils.cu
@@ -22,6 +22,7 @@
 namespace k2 {
 
 void ToNotTopSorted(Fsa *fsa) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(fsa->Context()->GetDeviceType(), kCpu);
 
   int32_t num_states = fsa->TotSize(0);
@@ -53,6 +54,7 @@ void ToNotTopSorted(Fsa *fsa) {
 }
 
 Fsa GetRandFsa() {
+  NVTX_RANGE(__func__);
   k2host::RandFsaOptions opts;
   opts.num_syms = 5 + RandInt(0, 100);
   opts.num_states = 10 + RandInt(0, 2000);

--- a/k2/csrc/top_sort.cu
+++ b/k2/csrc/top_sort.cu
@@ -24,6 +24,7 @@ namespace k2 {
 // See declaration in fsa_util.h
 FsaVec RenumberFsaVec(FsaVec &fsas, const Array1<int32_t> &order,
                       Array1<int32_t> *arc_map) {
+  NVTX_RANGE(__func__);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   ContextPtr &c = fsas.Context();
   K2_CHECK_LE(order.Dim(), fsas.TotSize(1));
@@ -137,6 +138,7 @@ class TopSorter {
     state, so we remove them.
    */
   std::unique_ptr<Ragged<int32_t>> GetInitialBatch() {
+    NVTX_RANGE(__func__);
     // Initialize it with a list of all states that currently have zero
     // in-degree.
     int32_t num_states = state_in_degree_.Dim();
@@ -174,6 +176,7 @@ class TopSorter {
          @return   Returns the states which, after processing.
    */
   std::unique_ptr<Ragged<int32_t>> GetNextBatch(Ragged<int32_t> &cur_states) {
+    NVTX_RANGE(__func__);
     // Process arcs leaving all states in `cur`
 
     // First figure out how many arcs leave each state.
@@ -278,6 +281,7 @@ class TopSorter {
     reachable from the start state).
    */
   std::unique_ptr<Ragged<int32_t>> GetFinalBatch() {
+    NVTX_RANGE(__func__);
     int32_t num_fsas = NumFsas();
     const int32_t *fsas_row_splits1_data = fsas_.RowSplits(1).Data();
     Array1<int32_t> has_final_state(c_, num_fsas + 1);
@@ -310,6 +314,7 @@ class TopSorter {
   }
 
   void InitDestStatesAndInDegree() {
+    NVTX_RANGE(__func__);
     int32_t num_fsas = fsas_.shape.TotSize(0),
             num_states = fsas_.shape.TotSize(1);
 
@@ -359,6 +364,7 @@ class TopSorter {
                  states.)
    */
   FsaVec TopSort(Array1<int32_t> *arc_map) {
+    NVTX_RANGE(__func__);
     InitDestStatesAndInDegree();
 
     std::vector<std::unique_ptr<Ragged<int32_t>>> iters;
@@ -424,6 +430,7 @@ class TopSorter {
 };
 
 void TopSort(FsaVec &src, FsaVec *dest, Array1<int32_t> *arc_map) {
+  NVTX_RANGE(__func__);
   K2_CHECK_GE(src.NumAxes(), 2);
   K2_CHECK_LE(src.NumAxes(), 3);
   if (src.NumAxes() == 2) {


### PR DESCRIPTION
@danpovey @qindazhu 
Currently, we are using `__func__` for `NVTX_RANGE`. Should we replace it with `__PRETTY_FUNCTION__`?

`__PRETTY_FUNCTION__`, as can be seen from its name, is more readable than `__func__`, though it is an extension
of GCC and is supported by GCC and Clang, not supported by MSVC.

We can define a macro `K2_PRETTY_FUNCTION`, which is equivalent to `__PRETTY_FUNCTION__` when
the compiler is GCC or Clang; otherwise, it is defined as `__func__`.

---

The following code
```cpp
#include <iostream>

template<typename T, int N>
int Foo(int i){
    std::cout << __PRETTY_FUNCTION__ << "\n";
    std::cout << __func__ << "\n";
    return 0;
}
int main()
{
    Foo<float, 10>(2);
    Foo<int, 20>(5);
    return 0;
}
```

prints
```
int Foo(int) [T = float, N = 10]
Foo
int Foo(int) [T = int, N = 20]
Foo
```