### PR TITLE
Replace __func__ with K2_FUNC.

### DIFF
--- a/k2/csrc/algorithms.cu
+++ b/k2/csrc/algorithms.cu
@@ -15,10 +15,12 @@
 #include "k2/csrc/algorithms.h"
 #include "k2/csrc/array.h"
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/macros.h"
+#include "k2/csrc/nvtx.h"
 
 namespace k2 {
 void Renumbering::ComputeOld2New() {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   old2new_ = Array1<int32_t>(keep_.Context(), keep_.Dim() + 1);
   ExclusiveSum(keep_, &old2new_);
   num_new_elems_ = old2new_.Back();
@@ -32,7 +34,7 @@ namespace {
 // CUDA limitations about lambdas in classes with private members.
 inline void ComputeNew2OldHelper(ContextPtr &c, const int32_t *old2new_data,
                                  int32_t *new2old_data, int32_t old_dim) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   // Note: the following accesses data one past the end of (current)
   // old2new_, but it does actually exist.
   if (c->GetDeviceType() == kCpu) {
@@ -53,7 +55,7 @@ inline void ComputeNew2OldHelper(ContextPtr &c, const int32_t *old2new_data,
 }  // namespace
 
 void Renumbering::ComputeNew2Old() {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (!old2new_.IsValid()) ComputeOld2New();
   new2old_ = Array1<int32_t>(keep_.Context(), num_new_elems_ + 1);
   const int32_t *old2new_data = old2new_.Data();

--- a/k2/csrc/algorithms.h
+++ b/k2/csrc/algorithms.h
@@ -14,6 +14,7 @@
 
 #include "k2/csrc/array.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/macros.h"
 
 //  this really contains various utilities that are useful for k2 algorithms.
 namespace k2 {
@@ -24,7 +25,7 @@ class Renumbering {
   Renumbering(ContextPtr c, int32_t num_old_elems) { Init(c, num_old_elems); }
 
   void Init(ContextPtr c, int32_t num_old_elems) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     // make the underlying region allocate an extra element as we'll do
     // exclusive sum in New2Old() and Old2New()
     Array1<char> temp = Array1<char>(c, num_old_elems + 1);
@@ -34,7 +35,7 @@ class Renumbering {
   int32_t NumOldElems() const { return keep_.Dim(); }
 
   int32_t NumNewElems() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (!old2new_.IsValid()) ComputeOld2New();
     return num_new_elems_;
   }
@@ -57,7 +58,7 @@ class Renumbering {
                   dimension).
   */
   Array1<int32_t> &New2Old() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (!new2old_.IsValid()) ComputeNew2Old();
     return new2old_;
   }
@@ -73,7 +74,7 @@ class Renumbering {
                   Will be allocated with the same context as keep_.
   */
   Array1<int32_t> &Old2New() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (!old2new_.IsValid()) ComputeOld2New();
     return old2new_;
   }
@@ -83,9 +84,9 @@ class Renumbering {
   // ComputeNew2Old() also computes old2new_ if needed.
   void ComputeNew2Old();
 
-  Array1<char> keep_;    // array of elements to keep; dimension is the
-                         // `num_old_elems` provided in the constructor but it
-                         // was allocated with one extra element.
+  Array1<char> keep_;  // array of elements to keep; dimension is the
+                       // `num_old_elems` provided in the constructor but it
+                       // was allocated with one extra element.
   Array1<int32_t> old2new_;
   int32_t num_new_elems_;  // equals last element of old2new_; set when
                            // old2new_ is created.

--- a/k2/csrc/array.h
+++ b/k2/csrc/array.h
@@ -23,6 +23,7 @@
 #include "k2/csrc/dtype.h"
 #include "k2/csrc/eval.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/nvtx.h"
 #include "k2/csrc/tensor.h"
 
@@ -101,7 +102,7 @@ class Array1 {
      @param [in] size   Number of elements to include, 0 <= size <= Dim()-start
   */
   Array1<T> Range(int32_t start, int32_t size) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GE(start, 0);
     K2_CHECK_LE(start, Dim());
     K2_CHECK_GE(size, 0);
@@ -118,7 +119,7 @@ class Array1 {
                         start <= end <= Dim().
   */
   Array1<T> Arange(int32_t start, int32_t end) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GE(start, 0);
     K2_CHECK_LE(start, dim_);
     K2_CHECK_GE(end, start);
@@ -140,7 +141,7 @@ class Array1 {
   // TODO(haowen): does not support inc < 0 with below implementations, we may
   // not need a negative version, will revisit it later
   Tensor Range(int32_t start, int32_t size, int32_t inc) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GE(start, 0);
     K2_CHECK_GE(size, 0);
     K2_CHECK_GT(inc, 0);
@@ -156,7 +157,7 @@ class Array1 {
   // when changing the tensor's data, it will also change data in the parent
   // array as they share the memory.
   Tensor ToTensor() const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Dtype type = DtypeOf<ValueType>::dtype;
     std::vector<int32_t> dims = {Dim()};
     Shape shape(dims);  // strides == 1
@@ -179,7 +180,7 @@ class Array1 {
      context).
   */
   Array1 To(ContextPtr ctx) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (ctx->IsCompatible(*Context())) return *this;
     Array1 ans(ctx, Dim());
     ans.CopyFrom(*this);
@@ -194,7 +195,7 @@ class Array1 {
   template <typename S>
   Array1<typename std::enable_if<!std::is_same<S, T>::value, S>::type> AsType()
       const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     // S != T
     Array1<S> ans(Context(), Dim());
     S *ans_data = ans.Data();
@@ -225,7 +226,7 @@ class Array1 {
     Region and not to the data directly.
   */
   void Resize(int32_t new_size) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (new_size < dim_) {
       K2_CHECK_GE(new_size, 0);
     } else {
@@ -262,7 +263,7 @@ class Array1 {
      this is a CPU array, it would have much less overhead to index the Data()
      pointer. */
   T operator[](int32_t i) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GE(i, 0);
     K2_CHECK_LT(i, Dim());
     const T *data = Data() + i;
@@ -289,7 +290,7 @@ class Array1 {
 
   /* Setting all elements to a scalar */
   void operator=(const T t) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     T *data = Data();
     if (Context()->GetDeviceType() == kCpu) {
       for (int i = 0; i < dim_; i++) data[i] = t;
@@ -310,7 +311,7 @@ class Array1 {
      but also supports -1 as an index.
    */
   Array1 operator[](const Array1<int32_t> &indexes) const {
-    NVTX_RANGE("Array1::operator[](Array1)");
+    NVTX_RANGE(K2_FUNC);
     const ContextPtr &c = Context();
     K2_CHECK(c->IsCompatible(*indexes.Context()));
     int32_t ans_dim = indexes.Dim();
@@ -332,7 +333,7 @@ class Array1 {
 
   // constructor from CPU array (transfers to GPU if necessary)
   Array1(ContextPtr ctx, const std::vector<T> &src) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Init(ctx, src.size());
     T *data = Data();
     auto kind = GetMemoryCopyKind(*GetCpuContext(), *Context());
@@ -356,7 +357,7 @@ class Array1 {
     to the same data as the (possibly-copied) tensor.
    */
   explicit Array1(const Tensor &tensor) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Dtype type = DtypeOf<ValueType>::dtype;
     K2_CHECK_EQ(type, tensor.GetDtype());
     if (tensor.IsContiguous()) {
@@ -452,7 +453,7 @@ class Array2 {
   /*  returns a flat version of this, appending the rows; will copy the data if
       it was not contiguous. */
   Array1<T> Flatten() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (dim1_ == elem_stride0_) {
       return Array1<T>(dim0_ * dim1_, region_, byte_offset_);
     } else {
@@ -484,7 +485,7 @@ class Array2 {
                         increases.  Require inc > 0.
   */
   Array2<T> RowArange(int32_t start, int32_t end, int32_t inc = 1) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GT(inc, 0);
     K2_CHECK_GE(start, 0);
     K2_CHECK_GE(end, start);
@@ -505,7 +506,7 @@ class Array2 {
      @param [in] end    One-past-the-last column that *should not* be included.
   */
   Array2<T> ColArange(int32_t start, int32_t end) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GE(start, 0);
     K2_CHECK_GE(end, start);
     K2_CHECK_LE(end, dim1_);
@@ -515,7 +516,7 @@ class Array2 {
 
   // return a row (indexing on the 0th axis)
   Array1<T> operator[](int32_t i) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_GE(i, 0);
     K2_CHECK_LT(i, dim0_);
     int32_t byte_offset = byte_offset_ + i * elem_stride0_ * ElementSize();
@@ -575,7 +576,7 @@ class Array2 {
 
   // Setting all elements to a scalar
   void operator=(const T t) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     T *data = Data();
     int32_t elem_stride0 = elem_stride0_;
     auto lambda_set_elems = [=] __host__ __device__(int32_t i,
@@ -594,7 +595,7 @@ class Array2 {
     is not compatible with the current context.
   */
   Array2<T> To(ContextPtr ctx) const {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (ctx->IsCompatible(*Context())) return *this;
 
     Array2<T> ans(ctx, dim0_, dim1_);
@@ -616,7 +617,7 @@ class Array2 {
   // when changing the tensor's data, it will also change data in the parent
   // array as they share the memory.
   Tensor ToTensor() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Dtype type = DtypeOf<ValueType>::dtype;
     std::vector<int32_t> dims = {dim0_, dim1_};
     std::vector<int32_t> strides = {elem_stride0_, 1};
@@ -627,7 +628,7 @@ class Array2 {
   // Return one column of this Array2, as a Tensor.  (Will point to the
   // same data).
   Tensor Col(int32_t i) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     K2_CHECK_LT(static_cast<uint32_t>(i), static_cast<uint32_t>(dim1_));
     Dtype type = DtypeOf<ValueType>::dtype;
     std::vector<int32_t> dims = {dim0_};
@@ -662,7 +663,7 @@ class Array2 {
 
   */
   explicit Array2(Tensor &t, bool copy_for_strides = true) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     auto type = t.GetDtype();
     K2_CHECK_EQ(type, DtypeOf<T>::dtype);
     const auto &shape = t.GetShape();
@@ -705,7 +706,7 @@ class Array2 {
   // extended __host__ __device__ lambda
   // must have public access.
   void CopyDataFromTensor(const Tensor &t) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     T *this_data = Data();
     const T *t_data = t.Data<T>();
     int32_t elem_stride0 = elem_stride0_;

--- a/k2/csrc/array_inl.h
+++ b/k2/csrc/array_inl.h
@@ -29,13 +29,14 @@
 #include <vector>
 
 #include "cub/cub.cuh"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/utils.h"
 
 namespace k2 {
 
 template <typename T>
 Array1<T> Array1<T>::Clone() const {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   Array1<T> ans(Context(), Dim());
   ans.CopyFrom(*this);
   return ans;
@@ -43,7 +44,7 @@ Array1<T> Array1<T>::Clone() const {
 
 template <typename T>
 void Array1<T>::CopyFrom(const Array1<T> &src) {
-  NVTX_RANGE("Array1::CopyFrom");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(dim_, src.dim_);
   if (dim_ == 0) return;
   auto kind = GetMemoryCopyKind(*src.Context(), *Context());

--- a/k2/csrc/array_ops.cu
+++ b/k2/csrc/array_ops.cu
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/macros.h"
 
 namespace k2 {
 
@@ -22,7 +23,7 @@ namespace k2 {
 // subtracting one from the dims of all but the last array.
 Array1<int32_t> SpliceRowSplits(int32_t num_arrays,
                                 const Array1<int32_t> **src) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(num_arrays, 0);
   ContextPtr &c = src[0]->Context();
 
@@ -154,7 +155,7 @@ Array1<int32_t> SpliceRowSplits(int32_t num_arrays,
 
 bool ValidateRowIds(const Array1<int32_t> &row_ids,
                     Array1<int32_t> *temp /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &ctx = row_ids.Context();
   const int32_t *data = row_ids.Data();
   int32_t dim = row_ids.Dim();
@@ -184,7 +185,7 @@ bool ValidateRowIds(const Array1<int32_t> &row_ids,
 
 bool ValidateRowSplits(const Array1<int32_t> &row_splits,
                        Array1<int32_t> *temp /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &ctx = row_splits.Context();
   const int32_t *data = row_splits.Data();
   int32_t dim = row_splits.Dim();
@@ -214,7 +215,7 @@ bool ValidateRowSplits(const Array1<int32_t> &row_splits,
 bool ValidateRowSplitsAndIds(const Array1<int32_t> &row_splits,
                              const Array1<int32_t> &row_ids,
                              Array1<int32_t> *temp /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   // Check if their context are compatible or not while getting
   ContextPtr ctx = GetContext(row_splits, row_ids);
   int32_t num_rows = row_splits.Dim() - 1, num_elems = row_ids.Dim();
@@ -258,7 +259,7 @@ bool ValidateRowSplitsAndIds(const Array1<int32_t> &row_splits,
 
 void RowSplitsToRowIds(const Array1<int32_t> &row_splits,
                        Array1<int32_t> *row_ids) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = GetContext(row_splits, *row_ids);
   int32_t num_elems = row_ids->Dim(), num_rows = row_splits.Dim() - 1;
   K2_CHECK_GE(num_rows, 0);
@@ -270,7 +271,7 @@ void RowSplitsToRowIds(const Array1<int32_t> &row_splits,
 
 void RowIdsToRowSplits(const Array1<int32_t> &row_ids,
                        Array1<int32_t> *row_splits) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = GetContext(*row_splits, row_ids);
   int32_t num_elems = row_ids.Dim(), num_rows = row_splits->Dim() - 1;
   K2_CHECK_GE(num_rows, 0);
@@ -282,7 +283,7 @@ void RowIdsToRowSplits(const Array1<int32_t> &row_ids,
 }
 
 Array1<int32_t> GetCounts(const Array1<int32_t> &src, int32_t n) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(n, 0);
   ContextPtr &c = src.Context();
   int32_t dim = src.Dim();

--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -19,6 +19,7 @@
 #include "k2/csrc/array.h"
 #include "k2/csrc/context.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/ragged.h"
 #include "k2/csrc/utils.h"
 
@@ -61,7 +62,7 @@ void Transpose(ContextPtr &c, const Array2<T> &src, Array2<T> *dest);
  */
 template <typename S, typename T>
 void ExclusiveSum(const Array1<S> &src, Array1<T> *dest) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(src, *dest));
   int32_t src_dim = src.Dim();
   int32_t dest_dim = dest->Dim();
@@ -80,7 +81,7 @@ void ExclusiveSum(const Array1<S> &src, Array1<T> *dest) {
  */
 template <typename T>
 Array1<T> ExclusiveSum(const Array1<T> &src) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   Array1<T> ans(src.Context(), src.Dim());
   ExclusiveSum(src, &ans);
   return ans;

--- a/k2/csrc/array_ops_inl.h
+++ b/k2/csrc/array_ops_inl.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "cub/cub.cuh"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/utils.h"
 
 namespace k2 {
@@ -129,7 +130,7 @@ __global__ void TransposeKernel(int32_t rows, int32_t cols,
 // to compute exclusive sum for each row
 template <typename T>
 void ExclusiveSumPerRow(const Array2<T> &src, Array2<T> *dest) {
-  NVTX_RANGE("ExclusiveSumPerRow");
+  NVTX_RANGE(K2_FUNC);
   int32_t rows = dest->Dim0();
   // note there may be dest->Dim1() == src.Dim1() + 1
   int32_t cols = dest->Dim1();
@@ -188,7 +189,7 @@ struct iterator_traits<k2::internal::ReversedPtr<T>> {
 namespace k2 {
 template <typename T>
 void Transpose(ContextPtr &c, const Array2<T> &src, Array2<T> *dest) {
-  NVTX_RANGE("Transpose");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(c->IsCompatible(*src.Context()));
   K2_CHECK(c->IsCompatible(*dest->Context()));
   int32_t rows = src.Dim0();
@@ -224,7 +225,7 @@ void Transpose(ContextPtr &c, const Array2<T> &src, Array2<T> *dest) {
 
 template <typename T>
 void ExclusiveSumDeref(Array1<const T *> &src, Array1<T> *dest) {
-  NVTX_RANGE("ExclusiveSumDeref");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(src, *dest));
   int32_t src_dim = src.Dim();
   int32_t dest_dim = dest->Dim();
@@ -240,7 +241,7 @@ void ExclusiveSumDeref(Array1<const T *> &src, Array1<T> *dest) {
 
 template <typename T>
 void ExclusiveSum(const Array2<T> &src, Array2<T> *dest, int32_t axis) {
-  NVTX_RANGE("ExclusiveSum");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(axis == 0 || axis == 1);
   K2_CHECK(IsCompatible(src, *dest));
   int32_t src_major_dim = src.Dim0();  // the axis will be summed
@@ -286,7 +287,7 @@ void ExclusiveSum(const Array2<T> &src, Array2<T> *dest, int32_t axis) {
 // Splice() in array_ops.cu, since it was modified from this code.
 template <typename T>
 Array1<T> Append(int32_t num_arrays, const Array1<T> **src) {
-  NVTX_RANGE("Append1");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(num_arrays, 0);
   ContextPtr &c = src[0]->Context();
 
@@ -389,7 +390,7 @@ Array1<T> Append(int32_t num_arrays, const Array1<T> **src) {
 
 template <typename T>
 Array1<T> Append(int32_t src_size, const Array1<T> *src) {
-  NVTX_RANGE("Append2");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(src_size, 0);
   std::vector<const Array1<T> *> srcs(src_size);
   for (int32_t i = 0; i != src_size; ++i) srcs[i] = src + i;
@@ -399,7 +400,7 @@ Array1<T> Append(int32_t src_size, const Array1<T> *src) {
 
 template <typename T, typename Op>
 void ApplyOpOnArray1(Array1<T> &src, T default_value, Array1<T> *dest) {
-  NVTX_RANGE("ApplyOpOnArray1");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(src, *dest));
   K2_CHECK_EQ(dest->Dim(), 1);
 
@@ -435,7 +436,7 @@ void ApplyOpOnArray1(Array1<T> &src, T default_value, Array1<T> *dest) {
 template <typename T>
 Array1<T> RandUniformArray1(ContextPtr c, int32_t dim, T min_value,
                             T max_value) {
-  NVTX_RANGE("RandUniformArray1");
+  NVTX_RANGE(K2_FUNC);
   static_assert(std::is_floating_point<T>::value || std::is_integral<T>::value,
                 "Only support floating-point and integral type");
   Array1<T> temp(GetCpuContext(), dim);
@@ -455,7 +456,7 @@ Array1<T> RandUniformArray1(ContextPtr c, int32_t dim, T min_value,
 template <typename T>
 Array2<T> RandUniformArray2(ContextPtr c, int32_t dim0, int32_t dim1,
                             T min_value, T max_value) {
-  NVTX_RANGE("RandUniformArray2");
+  NVTX_RANGE(K2_FUNC);
   int32_t dim1_extra = RandInt(0, 2),  // make it randomly not contiguous.
       new_dim1 = dim1 + dim1_extra;
   Array1<T> array1temp =
@@ -468,7 +469,7 @@ Array2<T> RandUniformArray2(ContextPtr c, int32_t dim0, int32_t dim1,
 
 template <typename T>
 Array1<T> Range(ContextPtr c, int32_t dim, T first_value, T inc /*=1*/) {
-  NVTX_RANGE("Range");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(dim, 0);
   Array1<T> ans = Array1<T>(c, dim);
   T *ans_data = ans.Data();
@@ -485,7 +486,7 @@ Array1<T> Range(ContextPtr c, int32_t dim, T first_value, T inc /*=1*/) {
 
 template <typename T>
 Array2<T> ToContiguous(const Array2<T> &src) {
-  NVTX_RANGE("ToContiguous");
+  NVTX_RANGE(K2_FUNC);
   int32_t dim0 = src.Dim0();
   int32_t dim1 = src.Dim1();
   int32_t elem_stride0 = src.ElemStride0();
@@ -503,7 +504,7 @@ Array2<T> ToContiguous(const Array2<T> &src) {
 
 template <typename T>
 bool Equal(const Array1<T> &a, const Array1<T> &b) {
-  NVTX_RANGE("Equal(Array1)");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(a.Dim(), b.Dim());
   ContextPtr c = GetContext(a, b);
   const T *a_data = a.Data(), *b_data = b.Data();
@@ -524,7 +525,7 @@ bool Equal(const Array1<T> &a, const Array1<T> &b) {
 
 template <typename T>
 bool Equal(const Array2<T> &a, const Array2<T> &b) {
-  NVTX_RANGE("Equal(Array2)");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(a.Dim0(), b.Dim0());
   K2_CHECK_EQ(a.Dim1(), b.Dim1());
   ContextPtr c = GetContext(a, b);
@@ -560,7 +561,7 @@ bool Equal(const Array2<T> &a, const Array2<T> &b) {
 
 template <typename T>
 bool IsMonotonic(const Array1<T> &a) {
-  NVTX_RANGE("IsMonotonic");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = a.Context();
   int32_t dim = a.Dim();
   const T *data = a.Data();
@@ -581,7 +582,7 @@ bool IsMonotonic(const Array1<T> &a) {
 
 template <typename S, typename T>
 void MonotonicLowerBound(const Array1<S> &src, Array1<T> *dest) {
-  NVTX_RANGE("MonotonicLowerBound");
+  NVTX_RANGE(K2_FUNC);
   K2_STATIC_ASSERT((std::is_convertible<S, T>::value));
   K2_CHECK(IsCompatible(src, *dest));
   int32_t dim = src.Dim();
@@ -620,7 +621,7 @@ void MonotonicLowerBound(const Array1<S> &src, Array1<T> *dest) {
 
 template <typename T>
 Array1<T> Plus(const Array1<T> &src, T t) {
-  NVTX_RANGE("Plus");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = src.Context();
   int32_t dim = src.Dim();
   Array1<T> ans(c, dim);
@@ -640,7 +641,7 @@ Array1<T> Plus(const Array1<T> &src, T t) {
 template <typename T>
 Array1<T> Index(const Array1<T> &src, const Array1<int32_t> &indexes,
                 bool allow_minus_one) {
-  NVTX_RANGE("Index(Array1)");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = src.Context();
   K2_CHECK(c->IsCompatible(*indexes.Context()));
   int32_t ans_dim = indexes.Dim();
@@ -683,7 +684,7 @@ Array1<T> Index(const Array1<T> &src, const Array1<int32_t> &indexes,
 template <typename T>
 Array2<T> IndexRows(const Array2<T> &src, const Array1<int32_t> &indexes,
                     bool allow_minus_one) {
-  NVTX_RANGE("Index(Array2)");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = src.Context();
   K2_CHECK(c->IsCompatible(*indexes.Context()));
   int32_t ans_dim0 = indexes.Dim(), dim1 = src.Dim1();

--- a/k2/csrc/context.h
+++ b/k2/csrc/context.h
@@ -169,7 +169,7 @@ inline cudaMemcpyKind GetMemoryCopyKind(const Context &src,
 // for `context`.
 inline void MemoryCopy(void *dst, const void *src, std::size_t count,
                        cudaMemcpyKind kind, Context *context) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   cudaError_t ret;
   if (kind == cudaMemcpyHostToHost) {
     memcpy(dst, src, count);
@@ -292,7 +292,7 @@ struct Region : public std::enable_shared_from_this<Region> {
                          larger of double the current size, or
                          the next power of 2 greater than `new_bytes_used`). */
   void Extend(size_t new_bytes_used) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     if (new_bytes_used <= bytes_used) return;
     if (num_bytes < new_bytes_used) {  // reallocate and copy
       size_t new_size = std::max<size_t>(num_bytes * 2, new_bytes_used);

--- a/k2/csrc/fsa.cu
+++ b/k2/csrc/fsa.cu
@@ -11,6 +11,7 @@
 
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/fsa.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/tensor_ops.h"
 
 namespace k2 {
@@ -30,7 +31,7 @@ std::istream &operator>>(std::istream &is, Arc &arc) {
 }
 
 std::string FsaPropertiesAsString(int32_t properties) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   static constexpr char kSep = '|';
   std::ostringstream os;
 
@@ -53,7 +54,7 @@ std::string FsaPropertiesAsString(int32_t properties) {
 
 void GetFsaVecBasicProperties(FsaVec &fsa_vec, Array1<int32_t> *properties_out,
                               int32_t *tot_properties_out) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (fsa_vec.NumAxes() != 3) {
     K2_LOG(FATAL) << "Input has wrong num-axes " << fsa_vec.NumAxes()
                   << " vs. 3.";
@@ -135,7 +136,6 @@ void GetFsaVecBasicProperties(FsaVec &fsa_vec, Array1<int32_t> *properties_out,
       reachable_data[num_states + idx0x_next - 1] = static_cast<char>(1);
     }
 
-
     if (arc.dest_state != arc.src_state)
       // Note: below, we're effectively accessing co_reachable_data.
       reachable_data[num_states + idx01] = 1;
@@ -214,7 +214,7 @@ void GetFsaVecBasicProperties(FsaVec &fsa_vec, Array1<int32_t> *properties_out,
 }
 
 FsaVec FsaToFsaVec(const Fsa &fsa) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (fsa.NumAxes() != 2) return fsa;
   ContextPtr &c = fsa.values.Context();
   RaggedShape first_axis = TrivialShape(c, fsa.shape.Dim0());
@@ -223,7 +223,7 @@ FsaVec FsaToFsaVec(const Fsa &fsa) {
 }
 
 int32_t GetFsaBasicProperties(const Fsa &fsa) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (fsa.NumAxes() != 2) return 0;
   FsaVec vec = FsaToFsaVec(fsa);
   Array1<int32_t> properties;
@@ -233,7 +233,7 @@ int32_t GetFsaBasicProperties(const Fsa &fsa) {
 }
 
 Fsa FsaFromArray1(Array1<Arc> &array, bool *error) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   const Arc *arcs_data = array.Data();
   ContextPtr &c = array.Context();
   int32_t num_arcs = array.Dim();
@@ -323,7 +323,7 @@ Fsa FsaFromArray1(Array1<Arc> &array, bool *error) {
 }
 
 Tensor FsaToTensor(const Fsa &fsa) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsa.NumAxes(), 2);
   Array2<int32_t> arcs_as_ints(fsa.values.Dim(), 4, 4, fsa.values.ByteOffset(),
                                fsa.values.GetRegion());
@@ -331,7 +331,7 @@ Tensor FsaToTensor(const Fsa &fsa) {
 }
 
 Fsa FsaFromTensor(Tensor &t, bool *error) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (!t.IsContiguous()) t = ToContiguous(t);
 
   *error = false;
@@ -356,7 +356,7 @@ Fsa FsaFromTensor(Tensor &t, bool *error) {
 }
 
 FsaVec FsaVecFromTensor(Tensor &t, bool *error) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (!t.IsContiguous()) t = ToContiguous(t);
 
   *error = false;
@@ -455,7 +455,7 @@ FsaVec FsaVecFromTensor(Tensor &t, bool *error) {
 }
 
 Tensor FsaVecToTensor(const FsaVec &fsa_vec) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (fsa_vec.NumAxes() != 3) {
     K2_LOG(FATAL) << "Expected num-axes == 3. Given: " << fsa_vec.NumAxes();
   }

--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -26,6 +26,7 @@
 #include "k2/csrc/host/rmepsilon.h"
 #include "k2/csrc/host/topsort.h"
 #include "k2/csrc/host_shim.h"
+#include "k2/csrc/macros.h"
 
 // this contains a subset of the algorithms in fsa_algo.h; currently it just
 // contains one that are wrappings of the corresponding algorithms in
@@ -34,7 +35,7 @@ namespace k2 {
 
 bool RecursionWrapper(bool (*f)(Fsa &, Fsa *, Array1<int32_t> *), Fsa &src,
                       Fsa *dest, Array1<int32_t> *arc_map) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   // src is actually an FsaVec.  Just recurse for now.
   int32_t num_fsas = src.shape.Dim0();
   std::vector<Fsa> srcs(num_fsas), dests(num_fsas);
@@ -58,7 +59,7 @@ bool RecursionWrapper(bool (*f)(Fsa &, Fsa *, Array1<int32_t> *), Fsa &src,
 }
 
 bool Connect(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t num_axes = src.NumAxes();
   if (num_axes < 2 || num_axes > 3) {
     K2_LOG(FATAL) << "Input has bad num-axes " << num_axes;
@@ -83,7 +84,7 @@ bool Connect(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*=nullptr*/) {
 }
 
 bool HostTopSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t num_axes = src.NumAxes();
   if (num_axes < 2 || num_axes > 3) {
     K2_LOG(FATAL) << "Input has bad num-axes " << num_axes;
@@ -110,7 +111,7 @@ bool HostTopSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*=nullptr*/) {
 bool Intersect(FsaOrVec &a_fsas, FsaOrVec &b_fsas,
                bool treat_epsilons_specially, FsaVec *out,
                Array1<int32_t> *arc_map_a, Array1<int32_t> *arc_map_b) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(a_fsas.NumAxes() >= 2 && a_fsas.NumAxes() <= 3);
   K2_CHECK(b_fsas.NumAxes() >= 2 && b_fsas.NumAxes() <= 3);
   ContextPtr c = a_fsas.Context();
@@ -198,7 +199,7 @@ bool Intersect(FsaOrVec &a_fsas, FsaOrVec &b_fsas,
 void RecursionWrapper(void (*f)(FsaOrVec &, FsaOrVec *, Ragged<int32_t> *),
                       FsaOrVec &src, FsaOrVec *dest,
                       Ragged<int32_t> *arc_deriv) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   // src is actually an FsaVec.  Just recurse for now.
   K2_CHECK_EQ(src.NumAxes(), 3);
   int32_t num_fsas = src.shape.Dim0();
@@ -221,7 +222,7 @@ void RecursionWrapper(void (*f)(FsaOrVec &, FsaOrVec *, Ragged<int32_t> *),
 
 void RemoveEpsilon(FsaOrVec &src, FsaOrVec *dest,
                    Ragged<int32_t> *arc_derivs /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t num_axes = src.NumAxes();
   if (num_axes < 2 || num_axes > 3) {
     K2_LOG(FATAL) << "Input has bad num-axes " << num_axes;
@@ -256,7 +257,7 @@ void RemoveEpsilon(FsaOrVec &src, FsaOrVec *dest,
 
 void Determinize(FsaOrVec &src, FsaOrVec *dest,
                  Ragged<int32_t> *arc_derivs /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t num_axes = src.NumAxes();
   if (num_axes < 2 || num_axes > 3) {
     K2_LOG(FATAL) << "Input has bad num-axes " << num_axes;
@@ -290,7 +291,7 @@ void Determinize(FsaOrVec &src, FsaOrVec *dest,
 }
 
 Fsa LinearFsa(const Array1<int32_t> &symbols) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = symbols.Context();
   int32_t n = symbols.Dim(), num_states = n + 2, num_arcs = n + 1;
   Array1<int32_t> row_splits1 = Range(c, num_states + 1, 0),
@@ -314,7 +315,7 @@ Fsa LinearFsa(const Array1<int32_t> &symbols) {
 }
 
 FsaVec LinearFsas(Ragged<int32_t> &symbols) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(symbols.NumAxes(), 2);
   ContextPtr &c = symbols.Context();
 
@@ -394,13 +395,13 @@ struct ArcComparer {
 }  // namespace
 
 void ArcSort(Fsa *fsa) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (fsa->NumAxes() < 2) return;  // it is empty
   SortSublists<Arc, ArcComparer>(fsa);
 }
 
 void ArcSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*= nullptr*/) {
-  NVTX_RANGE("ArcSort");
+  NVTX_RANGE(K2_FUNC);
   if (!src.values.IsValid()) return;
 
   if (arc_map != nullptr)
@@ -422,7 +423,7 @@ void ArcSort(Fsa &src, Fsa *dest, Array1<int32_t> *arc_map /*= nullptr*/) {
 // of this path. But we can consider it for the future.
 Ragged<int32_t> ShortestPath(FsaVec &fsas,
                              const Array1<int32_t> &entering_arcs) {
-  NVTX_RANGE("ShortestPath->Ragged");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   const int32_t *entering_arcs_data = entering_arcs.Data();
   const Arc *arcs_data = fsas.values.Data();
@@ -500,7 +501,7 @@ Ragged<int32_t> ShortestPath(FsaVec &fsas,
 
 void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
                          Array1<int32_t> *arc_map /*= nullptr*/) {
-  NVTX_RANGE("AddEpsilonSelfLoops");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = src.Context();
   const int32_t *old_row_splits1_data = src.RowSplits(1).Data(),
                 *old_row_ids1_data = src.RowIds(1).Data();
@@ -658,7 +659,7 @@ void AddEpsilonSelfLoops(FsaOrVec &src, FsaOrVec *dest,
 }
 
 Fsa Union(FsaVec &fsas, Array1<int32_t> *arc_map /*= nullptr*/) {
-  NVTX_RANGE("Union");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
 
   ContextPtr &context = fsas.Context();
@@ -749,7 +750,7 @@ Fsa Union(FsaVec &fsas, Array1<int32_t> *arc_map /*= nullptr*/) {
 }
 
 Fsa Closure(Fsa &fsa, Array1<int32_t> *arc_map /* = nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsa.NumAxes(), 2) << "We support only a single FSA.";
   ContextPtr &c = fsa.Context();
 

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -32,7 +32,7 @@ static constexpr const char *kDelim = " \t";
 
 // Convert a string to an integer. Abort the program on failure.
 static int32_t StringToInt(const std::string &s) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(!s.empty());
 
   bool ok = false;
@@ -54,7 +54,7 @@ static int32_t StringToInt(const std::string &s) {
 //               decimals. We have to test if the C code will behave the same
 //               w.r.t. locale as Python does.
 static float StringToFloat(const std::string &s) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(!s.empty());
   char *p = nullptr;
   float f = std::strtof(s.c_str(), &p);
@@ -64,7 +64,7 @@ static float StringToFloat(const std::string &s) {
 
 // Trim leading and trailing spaces of a string.
 static void TrimString(std::string *s) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_NE(s, nullptr);
   auto not_space = [](int32_t c) -> bool { return std::isspace(c) == 0; };
 
@@ -89,7 +89,7 @@ static void TrimString(std::string *s) {
 */
 static void SplitStringToVector(const std::string &in, const char *delim,
                                 std::vector<std::string> *out) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_NE(delim, nullptr);
   K2_CHECK_NE(out, nullptr);
   out->clear();
@@ -128,7 +128,7 @@ static void SplitStringToVector(const std::string &in, const char *delim,
    @return It returns an Fsa on CPU.
 */
 static Fsa K2AcceptorFromStream(std::istringstream &is) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   std::vector<Arc> arcs;
   std::vector<std::string> splits;
   std::string line;
@@ -190,7 +190,7 @@ static Fsa K2AcceptorFromStream(std::istringstream &is) {
 */
 static Fsa K2TransducerFromStream(std::istringstream &is,
                                   Array1<int32_t> *aux_labels) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(aux_labels != nullptr);
 
   std::vector<int32_t> aux_labels_internal;
@@ -263,7 +263,7 @@ static Fsa K2TransducerFromStream(std::istringstream &is,
    @return It returns an Fsa on CPU.
 */
 static Fsa OpenFstAcceptorFromStream(std::istringstream &is) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   std::vector<Arc> arcs;
   std::vector<std::vector<Arc>> state_to_arcs;  // indexed by states
   std::vector<std::string> splits;
@@ -380,7 +380,7 @@ static Fsa OpenFstAcceptorFromStream(std::istringstream &is) {
 */
 static Fsa OpenFstTransducerFromStream(std::istringstream &is,
                                        Array1<int32_t> *aux_labels) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(aux_labels != nullptr);
 
   std::vector<std::vector<int32_t>> state_to_aux_labels;  // indexed by states
@@ -504,7 +504,7 @@ static Fsa OpenFstTransducerFromStream(std::istringstream &is,
 
 Fsa FsaFromString(const std::string &s, bool openfst /*= false*/,
                   Array1<int32_t> *aux_labels /*= nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   std::istringstream is(s);
   K2_CHECK(is);
 
@@ -522,7 +522,7 @@ Fsa FsaFromString(const std::string &s, bool openfst /*= false*/,
 
 std::string FsaToString(const Fsa &fsa, bool openfst /*= false*/,
                         const Array1<int32_t> *aux_labels /*= nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsa.NumAxes(), 2);
 
   if (fsa.Context()->GetDeviceType() != kCpu) {
@@ -561,7 +561,7 @@ std::string FsaToString(const Fsa &fsa, bool openfst /*= false*/,
 }
 
 Array1<int32_t> GetDestStates(FsaVec &fsas, bool as_idx01) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   ContextPtr &c = fsas.Context();
   int32_t num_arcs = fsas.NumElements();
@@ -590,7 +590,7 @@ Array1<int32_t> GetDestStates(FsaVec &fsas, bool as_idx01) {
 }
 
 Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   ContextPtr &c = fsas.Context();
   Array1<int32_t> arc_dest_states = GetDestStates(fsas, true);
@@ -806,7 +806,7 @@ Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
 
 Ragged<int32_t> GetIncomingArcs(FsaVec &fsas,
                                 const Array1<int32_t> &dest_states) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   K2_CHECK(IsCompatible(fsas, dest_states));
   ContextPtr &c = fsas.Context();
@@ -835,7 +835,7 @@ Ragged<int32_t> GetIncomingArcs(FsaVec &fsas,
 
 Ragged<int32_t> GetLeavingArcIndexBatches(FsaVec &fsas,
                                           Ragged<int32_t> &state_batches) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(fsas, state_batches));
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   K2_CHECK_EQ(state_batches.NumAxes(), 3);
@@ -885,7 +885,7 @@ Ragged<int32_t> GetLeavingArcIndexBatches(FsaVec &fsas,
 Ragged<int32_t> GetEnteringArcIndexBatches(FsaVec &fsas,
                                            Ragged<int32_t> &incoming_arcs,
                                            Ragged<int32_t> &state_batches) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(fsas, state_batches));
   K2_CHECK(IsCompatible(fsas, incoming_arcs));
   K2_CHECK_EQ(fsas.NumAxes(), 3);
@@ -942,7 +942,7 @@ Ragged<int32_t> GetEnteringArcIndexBatches(FsaVec &fsas,
 }
 
 FsaVec ConvertDenseToFsaVec(DenseFsaVec &src) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = src.shape.Context();
   // caution: 'num_symbols' is the number of symbols excluding the final-symbol
   // -1.
@@ -1030,7 +1030,7 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
                                    Ragged<int32_t> &entering_arc_batches,
                                    bool log_semiring,
                                    Array1<int32_t> *entering_arcs) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_STATIC_ASSERT((std::is_same<float, FloatType>::value ||
                     std::is_same<double, FloatType>::value));
   K2_CHECK(IsCompatible(fsas, state_batches));
@@ -1244,7 +1244,7 @@ Array1<FloatType> GetBackwardScores(
     Ragged<int32_t> &leaving_arc_batches,
     const Array1<FloatType> *tot_scores /*= nullptr*/,
     bool log_semiring /*= true*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(fsas, state_batches));
   K2_CHECK(IsCompatible(fsas, leaving_arc_batches));
   K2_CHECK_EQ(fsas.NumAxes(), 3);
@@ -1443,7 +1443,7 @@ Array1<FloatType> GetBackwardScores(
 template <typename FloatType>
 Array1<FloatType> GetTotScores(FsaVec &fsas,
                                const Array1<FloatType> &forward_scores) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(fsas, forward_scores));
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   ContextPtr &c = fsas.Context();
@@ -1473,7 +1473,7 @@ template <typename FloatType>
 Array1<FloatType> GetArcScores(FsaVec &fsas,
                                const Array1<FloatType> &forward_scores,
                                const Array1<FloatType> &backward_scores) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(IsCompatible(fsas, forward_scores));
   K2_CHECK(IsCompatible(fsas, backward_scores));
   K2_CHECK_EQ(fsas.NumAxes(), 3);
@@ -1548,7 +1548,7 @@ template Array1<double> GetTotScores(FsaVec &fsas,
 
 Fsa RandomFsa(bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
               int32_t min_num_arcs /*=0*/, int32_t max_num_arcs /*=1000*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = GetCpuContext();
   K2_CHECK_GE(min_num_arcs, 0);
   K2_CHECK_GE(max_num_arcs, min_num_arcs);
@@ -1599,7 +1599,7 @@ FsaVec RandomFsaVec(int32_t min_num_fsas /*=1*/, int32_t max_num_fsas /*=1000*/,
                     bool acyclic /*=true*/, int32_t max_symbol /*=50*/,
                     int32_t min_num_arcs /*=0*/,
                     int32_t max_num_arcs /*=1000*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(min_num_fsas, 0);
   K2_CHECK_GE(max_num_fsas, min_num_fsas);
   int32_t num_fsas = RandInt(min_num_fsas, max_num_fsas);
@@ -1614,7 +1614,7 @@ DenseFsaVec RandomDenseFsaVec(int32_t min_num_fsas, int32_t max_num_fsas,
                               int32_t min_frames, int32_t max_frames,
                               int32_t min_symbols, int32_t max_symbols,
                               float scores_scale) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = GetCpuContext();
   int32_t num_fsas = RandInt(min_num_fsas, max_num_fsas);
 
@@ -1657,7 +1657,7 @@ DenseFsaVec RandomDenseFsaVec(int32_t min_num_fsas, int32_t max_num_fsas,
 }
 
 Ragged<int32_t> GetStartStates(FsaVec &src) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = src.Context();
   K2_CHECK(src.NumAxes() == 3);
   int32_t num_fsas = src.Dim0();
@@ -1692,7 +1692,7 @@ Ragged<int32_t> GetStartStates(FsaVec &src) {
 }
 
 FsaVec FsaVecFromArcIndexes(FsaVec &fsas, Ragged<int32_t> &best_arc_indexes) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   K2_CHECK_EQ(best_arc_indexes.NumAxes(), 2);
   K2_CHECK(IsCompatible(fsas, best_arc_indexes));

--- a/k2/csrc/host_shim.cu
+++ b/k2/csrc/host_shim.cu
@@ -20,7 +20,7 @@
 namespace k2 {
 
 k2host::Fsa FsaToHostFsa(Fsa &fsa) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsa.NumAxes(), 2);
   K2_CHECK_EQ(fsa.Context()->GetDeviceType(), kCpu);
   // reinterpret_cast works because the arcs have the same members
@@ -30,7 +30,7 @@ k2host::Fsa FsaToHostFsa(Fsa &fsa) {
 }
 
 k2host::Fsa FsaVecToHostFsa(FsaVec &fsa_vec, int32_t index) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsa_vec.NumAxes(), 3);
   K2_CHECK_LT(static_cast<uint32_t>(index),
               static_cast<uint32_t>(fsa_vec.Dim0()));
@@ -55,7 +55,7 @@ k2host::Fsa FsaVecToHostFsa(FsaVec &fsa_vec, int32_t index) {
 
 void FsaVecCreator::Init(
     const std::vector<k2host::Array2Size<int32_t>> &sizes) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t num_fsas = static_cast<int32_t>(sizes.size());
   K2_CHECK_GT(num_fsas, 0);
   ContextPtr c = GetCpuContext();
@@ -81,7 +81,7 @@ void FsaVecCreator::Init(
 }
 
 void FsaVecCreator::FinalizeRowSplits2() {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (finalized_row_splits2_) return;
   finalized_row_splits2_ = true;
   int32_t num_fsas = row_splits1_.Dim() - 1;
@@ -106,7 +106,7 @@ void FsaVecCreator::FinalizeRowSplits2() {
 }
 
 k2host::Fsa FsaVecCreator::GetHostFsa(int32_t i) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(i, next_fsa_idx_);  // make sure they are called in order.
   next_fsa_idx_++;
 
@@ -122,7 +122,7 @@ k2host::Fsa FsaVecCreator::GetHostFsa(int32_t i) {
 }
 
 FsaVec FsaVecCreator::GetFsaVec() {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   FinalizeRowSplits2();
   return Ragged<Arc>(
       RaggedShape3(&row_splits1_, nullptr, -1, &row_splits2_, nullptr, -1),
@@ -142,7 +142,7 @@ FsaVec FsaVecCreator::GetFsaVec() {
 */
 static Array1<bool> CheckProperties(FsaOrVec &fsas,
                                     bool (*f)(const k2host::Fsa &)) {
-  NVTX_RANGE("CheckProperties");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = fsas.Context();
   K2_CHECK_EQ(c->GetDeviceType(), kCpu);
   if (fsas.NumAxes() == 2) {
@@ -163,17 +163,17 @@ static Array1<bool> CheckProperties(FsaOrVec &fsas,
 }
 
 Array1<bool> IsTopSorted(FsaOrVec &fsas) {
-  NVTX_RANGE("IsTopSorted");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, k2host::IsTopSorted);
 }
 
 Array1<bool> IsArcSorted(FsaOrVec &fsas) {
-  NVTX_RANGE("IsArcSorted");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, k2host::IsArcSorted);
 }
 
 Array1<bool> HasSelfLoops(FsaOrVec &fsas) {
-  NVTX_RANGE("HasSelfLoops");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, k2host::HasSelfLoops);
 }
 
@@ -183,29 +183,29 @@ static bool IsAcyclicWapper(const k2host::Fsa &fsa) {
   return k2host::IsAcyclic(fsa, nullptr);
 }
 Array1<bool> IsAcyclic(FsaOrVec &fsas) {
-  NVTX_RANGE("IsAcyclic");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, IsAcyclicWapper);
 }
 
 Array1<bool> IsDeterministic(FsaOrVec &fsas) {
-  NVTX_RANGE("IsDeterministic");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, k2host::IsDeterministic);
 }
 
 Array1<bool> IsEpsilonFree(FsaOrVec &fsas) {
-  NVTX_RANGE("IsEpsilonFree");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, k2host::IsEpsilonFree);
 }
 
 Array1<bool> IsConnected(FsaOrVec &fsas) {
-  NVTX_RANGE("IsConnected");
+  NVTX_RANGE(K2_FUNC);
   return CheckProperties(fsas, k2host::IsConnected);
 }
 
 bool IsRandEquivalentUnweighted(FsaOrVec &a, FsaOrVec &b,
                                 bool treat_epsilons_specially /*=true*/,
                                 std::size_t npath /*= 100*/) {
-  NVTX_RANGE("IsRandEquivalentUnweighted");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(a.NumAxes(), 2);
   K2_CHECK_EQ(b.NumAxes(), a.NumAxes());
   if (a.Context()->GetDeviceType() != kCpu ||
@@ -233,7 +233,7 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, bool log_semiring,
                       float beam /*=k2host::kFloatInfinity*/,
                       bool treat_epsilons_specially /*=true*/,
                       float delta /*=1e-6*/, std::size_t npath /*= 100*/) {
-  NVTX_RANGE("IsRandEquivalent");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(a.NumAxes(), 2);
   K2_CHECK_EQ(b.NumAxes(), a.NumAxes());
   if (a.Context()->GetDeviceType() != kCpu ||
@@ -266,7 +266,7 @@ bool IsRandEquivalent(Fsa &a, Fsa &b, bool log_semiring,
 
 template <typename FloatType>
 Array1<FloatType> GetForwardScores(FsaVec &fsas, bool log_semiring) {
-  NVTX_RANGE("GetForwardScores");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = fsas.Context();
   K2_CHECK_EQ(c->GetDeviceType(), kCpu);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
@@ -293,7 +293,7 @@ template <typename FloatType>
 Array1<FloatType> GetBackwardScores(
     FsaVec &fsas, const Array1<FloatType> *tot_scores /*= nullptr*/,
     bool log_semiring /*= true*/) {
-  NVTX_RANGE("GetBackwardScores");
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &c = fsas.Context();
   K2_CHECK_EQ(c->GetDeviceType(), kCpu);
   K2_CHECK_EQ(fsas.NumAxes(), 3);

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <string>
 
+#include "k2/csrc/macros.h"
+
 #ifdef __CUDA_ARCH__
 #define K2_CUDA_HOSTDEV __host__ __device__
 #else
@@ -157,11 +159,11 @@ class Voidifier {
 
 #define K2_STATIC_ASSERT(x) static_assert(x, "")
 
-#define K2_CHECK(x)                                              \
-  (x) ? (void)0                                                  \
-      : ::k2::internal::Voidifier() &                            \
-            ::k2::internal::Logger(__FILE__, __func__, __LINE__, \
-                                   ::k2::internal::FATAL)        \
+#define K2_CHECK(x)                                             \
+  (x) ? (void)0                                                 \
+      : ::k2::internal::Voidifier() &                           \
+            ::k2::internal::Logger(__FILE__, K2_FUNC, __LINE__, \
+                                   ::k2::internal::FATAL)       \
                 << "Check failed: " << #x << " "
 
 // WARNING: x and y may be evaluated multiple times, but this happens only
@@ -183,7 +185,7 @@ class Voidifier {
 #define _K2_CHECK_OP(x, y, op)                                              \
   ((x)op(y)) ? (void)0                                                      \
              : ::k2::internal::Voidifier() &                                \
-                   ::k2::internal::Logger(__FILE__, __func__, __LINE__,     \
+                   ::k2::internal::Logger(__FILE__, K2_FUNC, __LINE__,      \
                                           ::k2::internal::FATAL)            \
                        << "Check failed: " << #x << " " << #op << " " << #y \
                        << " (" << (x) << " vs. " << (y) << ") "
@@ -196,7 +198,7 @@ class Voidifier {
 #define K2_CHECK_GE(x, y) _K2_CHECK_OP(x, y, >=)
 
 #define K2_LOG(x) \
-  ::k2::internal::Logger(__FILE__, __func__, __LINE__, ::k2::internal::x)
+  ::k2::internal::Logger(__FILE__, K2_FUNC, __LINE__, ::k2::internal::x)
 
 // `x` would be error code returned from any cuda function call or kernel
 // launch.

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -1,0 +1,24 @@
+/**
+ * @brief
+ * macros
+ *
+ * @copyright
+ * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ */
+
+#ifndef K2_MACROS_H_
+#define K2_MACROS_H_
+
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__) || \
+    defined(__PRETTY_FUNCTION__)
+// for clang and GCC
+#define K2_FUNC __PRETTY_FUNCTION__
+#else
+// for other compilers
+#define K2_FUNC __func__
+#endif
+
+#endif  // K2_MACROS_H_

--- a/k2/csrc/math.cu
+++ b/k2/csrc/math.cu
@@ -9,6 +9,7 @@
  * See LICENSE for clarification regarding multiple authors
  */
 
+#include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/nvtx.h"
 
@@ -21,7 +22,7 @@ namespace k2 {
   ...
  */
 int32_t HighestBitSet(int32_t i) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(i, 0);
   for (int64_t j = 0; j < 32; j++) {
     if (i < (1 << j)) {
@@ -32,7 +33,7 @@ int32_t HighestBitSet(int32_t i) {
 }
 
 int32_t RoundUpToNearestPowerOfTwo(int32_t n) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(n, 0);
   n--;
   n |= n >> 1;
@@ -45,7 +46,7 @@ int32_t RoundUpToNearestPowerOfTwo(int32_t n) {
 
 // returns random int32_t from [min..max]
 int32_t RandInt(int32_t min, int32_t max) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(max, min);
   // declare as static intentionally here to make it constructed only once and
   // retain its state between calls
@@ -57,7 +58,7 @@ int32_t RandInt(int32_t min, int32_t max) {
 // values.  I'm not implying this is a geometric distribution.  Anyway
 // we aren't relying on any exact properties.
 int32_t RandIntGeometric(int32_t min, int32_t max) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   static RandIntGeometricGenerator geneartor;
   return geneartor(min, max);
 }
@@ -65,7 +66,7 @@ int32_t RandIntGeometric(int32_t min, int32_t max) {
 namespace internal {
 template <typename Real>
 Real FixedRead(std::istream &is) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   is >> std::ws;
   char c = is.peek();
   if (c == '-') {
@@ -74,15 +75,14 @@ Real FixedRead(std::istream &is) {
   } else if (c == 'i' || c == 'I') {
     char c[10];
     int pos = 0;
-    while (pos < 9 && isalpha(is.peek()))
-      c[pos++] = tolower(is.get());
+    while (pos < 9 && isalpha(is.peek())) c[pos++] = tolower(is.get());
     c[pos] = '\0';
-    if (strcmp(c, "inf")  && strcmp(c, "infinity"))
+    if (strcmp(c, "inf") && strcmp(c, "infinity"))
       is.setstate(std::ios::failbit);
     return std::numeric_limits<Real>::infinity();
-  // can handle NaN's later, with:
-  //} else if (c == 'n' || c == 'N') {
-  // (NaN's are printed in a more complicated way though.
+    // can handle NaN's later, with:
+    //} else if (c == 'n' || c == 'N') {
+    // (NaN's are printed in a more complicated way though.
   } else {
     Real r;
     is >> r;

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -16,6 +16,7 @@
 
 #include "cub/cub.cuh"
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/moderngpu_allocator.h"
 #include "k2/csrc/ragged.h"
@@ -49,7 +50,7 @@ namespace k2 {
 RaggedShape RandomRaggedShape(bool set_row_ids, int32_t min_num_axes,
                               int32_t max_num_axes, int32_t min_num_elements,
                               int32_t max_num_elements) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = GetCpuContext();
   K2_CHECK(min_num_axes >= 2 && max_num_axes >= min_num_axes &&
            min_num_elements >= 0 && max_num_elements >= min_num_elements);
@@ -97,7 +98,7 @@ RaggedShape RandomRaggedShape(bool set_row_ids, int32_t min_num_axes,
 
 RaggedShape RaggedShape2(Array1<int32_t> *row_splits, Array1<int32_t> *row_ids,
                          int32_t cached_tot_size) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(row_splits != nullptr || row_ids != nullptr)
       << "At least one of row_splits and row_ids must be defined";
   ContextPtr ctx = ::GetContext(row_splits, row_ids);
@@ -132,7 +133,7 @@ RaggedShape RaggedShape2(Array1<int32_t> *row_splits, Array1<int32_t> *row_ids,
 }
 
 RaggedShape ComposeRaggedShapes(const RaggedShape &a, const RaggedShape &b) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (a.NumElements() != b.Dim0()) {
     K2_LOG(FATAL) << "ComposeRaggedShapes: shape mismatch: " << a.NumElements()
                   << " vs. " << b.Dim0();
@@ -150,7 +151,7 @@ RaggedShape RaggedShape3(Array1<int32_t> *row_splits1,
                          Array1<int32_t> *row_ids1, int32_t cached_tot_size1,
                          Array1<int32_t> *row_splits2,
                          Array1<int32_t> *row_ids2, int32_t cached_tot_size2) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(row_splits1 != nullptr || row_ids1 != nullptr)
       << "At least one of row_splits1 and row_ids1 must be defined";
   K2_CHECK(row_splits2 != nullptr || row_ids2 != nullptr)
@@ -224,7 +225,7 @@ RaggedShape RaggedShape3(Array1<int32_t> *row_splits1,
 
 RaggedShape RaggedShapeFromTotSizes(ContextPtr c, int32_t num_axes,
                                     int32_t *tot_sizes) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(num_axes, 2);
   std::vector<RaggedShapeDim> axes(num_axes - 1);
   // In future we might choose to allocate everything in one big array, to avoid
@@ -239,7 +240,7 @@ RaggedShape RaggedShapeFromTotSizes(ContextPtr c, int32_t num_axes,
 }
 
 Array1<int32_t *> GetRowSplitsPtr(RaggedShape &src) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t axes = src.NumAxes();
   K2_CHECK_GE(axes, 2);
   std::vector<int32_t *> row_splits_start(axes - 1);
@@ -267,7 +268,7 @@ RaggedShape Unsqueeze(const RaggedShape &src, int32_t axis) {
   // an idx_0 to idx_minus1, where idx_minus1 is always 0 and 0 <= idx0 <
   // Dim0().
 
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = src.Context();
   K2_CHECK(axis >= 0 && axis <= src.NumAxes());
 
@@ -316,7 +317,7 @@ RaggedShape Unsqueeze(const RaggedShape &src, int32_t axis) {
 
 std::vector<RaggedShape> UnsqueezeParallel(int32_t num_srcs, RaggedShape **src,
                                            int32_t axis) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(axis, 0);
   std::vector<RaggedShape> ans;
   if (num_srcs == 0) return ans;
@@ -377,7 +378,7 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
                                 const Array1<int32_t> &new2old,
                                 Array2<int32_t> *old_offsets,
                                 Array2<int32_t> *new_offsets) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(src.NumAxes() > 1);
   ContextPtr &c = src.Context();
   int32_t num_axes = src.NumAxes(), ans_dim0 = new2old.Dim();
@@ -408,7 +409,7 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
 
 RaggedShape Index(RaggedShape &src, const Array1<int32_t> &new2old,
                   Array1<int32_t> *elem_indexes /*=nullptr*/) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr c = src.Context();
   bool is_cpu = (c->GetDeviceType() == kCpu);
   K2_CHECK(IsCompatible(src, new2old));
@@ -586,7 +587,7 @@ Array2<int32_t> GetOffsets(int32_t num_srcs, RaggedShape **src) {
 
 void GetRowInfo(RaggedShape &src, Array1<int32_t *> *row_splits,
                 Array1<int32_t *> *row_ids) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t axes = src.NumAxes();
   K2_CHECK_GE(axes, 2);
   src.Populate();
@@ -604,7 +605,7 @@ void GetRowInfo(RaggedShape &src, Array1<int32_t *> *row_splits,
 void GetRowInfoMulti(int32_t num_srcs, RaggedShape **src,
                      Array2<int32_t *> *row_splits,
                      Array2<int32_t *> *row_ids) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(num_srcs, 0);
   int32_t num_axes_in = src[0]->NumAxes();
   K2_CHECK_GE(num_axes_in, 2);
@@ -635,7 +636,7 @@ void GetRowInfoMulti(int32_t num_srcs, RaggedShape **src,
 }
 
 RaggedShape Append(int32_t axis, int32_t num_srcs, RaggedShape **src) {
-  NVTX_RANGE("Append(RaggedShape)");
+  NVTX_RANGE(K2_FUNC);
   if (num_srcs == 1) return **src;
   K2_CHECK_GT(num_srcs, 1);
   if (axis == 1) {
@@ -756,7 +757,7 @@ RaggedShape Append(int32_t axis, int32_t num_srcs, RaggedShape **src) {
 }
 
 RaggedShape RemoveAxis(RaggedShape &src, int32_t axis) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(src.NumAxes(), 2);
   K2_CHECK(axis >= 0 && axis < src.NumAxes());
 
@@ -784,7 +785,7 @@ RaggedShape RemoveAxis(RaggedShape &src, int32_t axis) {
 }
 
 RaggedShape MakeTransposable(RaggedShape &src) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(src.NumAxes(), 2);
   int32_t src_dim0 = src.Dim0(), src_tot_size1 = src.TotSize(1);
   if (src_dim0 <= 1) return src;
@@ -872,7 +873,7 @@ RaggedShape MakeTransposable(RaggedShape &src) {
 
 // transpose axes 0 and 1.
 RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(src.NumAxes(), 2);
   ContextPtr c = src.Context();
   int32_t src_dim0 = src.Dim0(), src_tot_size1 = src.TotSize(1);
@@ -929,7 +930,7 @@ RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
 }
 
 RaggedShape Stack(int32_t axis, int32_t num_srcs, RaggedShape **src) {
-  NVTX_RANGE("Stack(RaggedShape)");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GT(num_srcs, 0);
   K2_CHECK(axis >= 0 && axis <= 1);
 
@@ -952,7 +953,7 @@ RaggedShape Stack(int32_t axis, int32_t num_srcs, RaggedShape **src) {
 }
 
 RaggedShape TrivialShape(ContextPtr &c, int32_t num_elems) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   // row_splits= [
   Array1<int32_t> row_splits = Range<int32_t>(c, 2, 0, num_elems);
   Array1<int32_t> row_ids(c, num_elems, 0);
@@ -960,7 +961,7 @@ RaggedShape TrivialShape(ContextPtr &c, int32_t num_elems) {
 }
 
 RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   Array1<int32_t> row_splits = Range<int32_t>(c, dim0 + 1, 0, dim1);
   int32_t *row_splits_data = row_splits.Data();
   Array1<int32_t> row_ids(c, dim0 * dim1);
@@ -974,7 +975,7 @@ RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1) {
 
 Ragged<int32_t> GetCountsPartitioned(Ragged<int32_t> &src,
                                      RaggedShape &ans_ragged_shape) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(src.NumAxes(), 2);
   K2_CHECK_EQ(ans_ragged_shape.NumAxes(), 2);
   K2_CHECK(IsCompatible(src, ans_ragged_shape));
@@ -988,7 +989,7 @@ Ragged<int32_t> GetCountsPartitioned(Ragged<int32_t> &src,
 
 static Array1<int32_t> GetTransposeReorderingCpu(Ragged<int32_t> &src,
                                                  int32_t num_cols) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   std::vector<std::vector<int32_t>> column_indexes(num_cols);  // [column][row]
   const int32_t *values_data = src.values.Data();
   int32_t n = src.values.Dim();
@@ -1009,7 +1010,7 @@ static Array1<int32_t> GetTransposeReorderingCpu(Ragged<int32_t> &src,
 
 static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
                                                            int32_t num_cols) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(src.NumAxes(), 3);
   ContextPtr &context = src.Context();
   K2_CHECK_EQ(context->GetDeviceType(), kCuda);
@@ -1055,7 +1056,7 @@ static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
 }
 
 Array1<int32_t> GetTransposeReordering(Ragged<int32_t> &src, int32_t num_cols) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   ContextPtr &context = src.Context();
   if (src.NumAxes() < 2) {
     // src is empty
@@ -1105,7 +1106,7 @@ Array1<int32_t> GetTransposeReordering(Ragged<int32_t> &src, int32_t num_cols) {
 }
 
 RaggedShape ChangeSublistSize(RaggedShape &src, int32_t size_delta) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(src.NumAxes(), 2);
   // the result will have the same num-axes as `src` (the NumAxes() of the
   // object is not the same as the number of RaggedShapeDim axes).
@@ -1176,7 +1177,7 @@ RaggedShape ChangeSublistSize(RaggedShape &src, int32_t size_delta) {
 }
 
 RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &renumbering) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(renumbering.NumOldElems(), src.NumElements());
 
   // Make sure final row-ids are populated.
@@ -1190,7 +1191,7 @@ RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &renumbering) {
 
 RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &r_before_last,
                                  Renumbering &r_last) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(r_before_last.NumOldElems(), src.TotSize(src.NumAxes() - 2));
   K2_CHECK_EQ(r_last.NumOldElems(), src.NumElements());
 
@@ -1276,7 +1277,7 @@ RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &r_before_last,
 }
 
 RaggedShape EmptyRaggedShape(ContextPtr &c, int32_t num_axes) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(num_axes, 2);
   std::vector<RaggedShapeDim> axes(num_axes - 1);
   axes[0].row_splits = Array1<int32_t>(c, 1, 0);

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -19,6 +19,7 @@
 #include "k2/csrc/algorithms.h"
 #include "k2/csrc/array.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/ragged.h"
 #include "k2/csrc/utils.h"
 
@@ -300,7 +301,7 @@ RaggedShape Transpose(RaggedShape &src,
 template <typename T>
 Ragged<T> Transpose(Ragged<T> &src,
                     Array1<int32_t> *value_indexes_out = nullptr) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   Array1<int32_t> value_indexes;
   RaggedShape ans_shape = Transpose(src.shape, &value_indexes);
   if (value_indexes_out) *value_indexes_out = value_indexes;

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/moderngpu_allocator.h"
 #include "moderngpu/kernel_segsort.hxx"
 
@@ -34,8 +35,7 @@ namespace k2 {
 
 template <typename T, typename Op>
 void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst) {
-  NVTX_RANGE("ApplyOpPerSublist");
-  NVTX_RANGE(typeid(T).name());  // hopefully we'll see what the op was from this.
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(src.NumAxes(), 2);
   K2_CHECK(IsCompatible(src.shape, *dst));
 
@@ -84,7 +84,7 @@ void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst) {
 
 template <typename T>
 Ragged<T> Stack(int32_t axis, int32_t num_srcs, Ragged<T> **src) {
-  NVTX_RANGE("Stack1");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(axis == 0 || axis == 1);
   K2_CHECK_GT(num_srcs, 0);  // can later relax this, maybe
   std::vector<RaggedShape *> src_shapes(num_srcs);
@@ -106,7 +106,7 @@ Ragged<T> Stack(int32_t axis, int32_t num_srcs, Ragged<T> **src) {
 
 template <typename T>
 Ragged<T> Stack(int32_t axis, int32_t num_srcs, Ragged<T> *src) {
-  NVTX_RANGE("Stack2");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(axis == 0 || axis == 1);
   K2_CHECK_GT(num_srcs, 0);
   std::vector<Ragged<T> *> temp(num_srcs);
@@ -116,7 +116,7 @@ Ragged<T> Stack(int32_t axis, int32_t num_srcs, Ragged<T> *src) {
 
 template <typename T>
 Ragged<T> Append(int32_t axis, int32_t num_srcs, Ragged<T> **src) {
-  NVTX_RANGE("Append1");
+  NVTX_RANGE(K2_FUNC);
   if (num_srcs == 1) return **src;
   K2_CHECK_GT(num_srcs, 1);
   if (axis == 1) {
@@ -139,7 +139,7 @@ Ragged<T> Append(int32_t axis, int32_t num_srcs, Ragged<T> **src) {
 
 template <typename T>
 Ragged<T> Append(int32_t axis, int32_t num_srcs, Ragged<T> *src) {
-  NVTX_RANGE("Append2");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(axis == 0 || axis == 1);
   K2_CHECK_GT(num_srcs, 0);
   std::vector<Ragged<T> *> temp(num_srcs);
@@ -200,7 +200,7 @@ Ragged<T> RandomRagged(T min_value, T max_value, int32_t min_num_axes,
 // TODO(fangjun): add test cases for `order`
 template <typename T, typename Op>
 static void SortSublistsCpu(Ragged<T> *src, Array1<int32_t> *order) {
-  NVTX_RANGE("SortSublistsCpu");
+  NVTX_RANGE(K2_FUNC);
   T *p = src->values.Data();
   Op comp = Op();
 
@@ -224,7 +224,7 @@ static void SortSublistsCpu(Ragged<T> *src, Array1<int32_t> *order) {
 
 template <typename T, typename Op /* = LessThan<T> */>
 void SortSublists(Ragged<T> *src, Array1<int32_t> *order /* = nullptr */) {
-  NVTX_RANGE("SortSublists");
+  NVTX_RANGE(K2_FUNC);
   if (order) {
     K2_DCHECK(IsCompatible(src->values, *order));
     K2_DCHECK_EQ(src->values.Dim(), order->Dim());
@@ -261,7 +261,7 @@ void SortSublists(Ragged<T> *src, Array1<int32_t> *order /* = nullptr */) {
 
 template <typename T>
 bool Ragged<T>::Validate(bool print_warnings) const {
-  NVTX_RANGE("Ragged::Validate");
+  NVTX_RANGE(K2_FUNC);
   if (values.Dim() != shape.NumElements()) {
     if (print_warnings) {
       K2_LOG(WARNING) << "Dimension mismatch: values.Dim() == " << values.Dim()
@@ -275,7 +275,7 @@ bool Ragged<T>::Validate(bool print_warnings) const {
 // Defined here and not in ragged.h because it needs RemoveAxis.
 template <typename T>
 Ragged<T> Ragged<T>::RemoveAxis(int32_t axis) {
-  NVTX_RANGE("Ragged::RemoveAxis");
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(axis >= 0 && axis < NumAxes());
   RaggedShape new_shape = ::k2::RemoveAxis(shape, axis);
   return Ragged<T>(new_shape, values);

--- a/k2/csrc/tensor.cu
+++ b/k2/csrc/tensor.cu
@@ -15,8 +15,9 @@
 #include <vector>
 
 #include "k2/csrc/dtype.h"
-#include "k2/csrc/nvtx.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/macros.h"
+#include "k2/csrc/nvtx.h"
 #include "k2/csrc/tensor.h"
 #include "k2/csrc/tensor_ops.h"
 
@@ -24,7 +25,7 @@ namespace k2 {
 
 Shape::Shape(const std::vector<int32_t> &dims)
     : num_axes_(static_cast<int32_t>(dims.size())) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_LT(num_axes_, kMaxDim);
 
   std::copy(dims.begin(), dims.end(), dims_);
@@ -44,7 +45,7 @@ Shape::Shape(const std::vector<int32_t> &dims)
 Shape::Shape(const std::vector<int32_t> &dims,
              const std::vector<int32_t> strides)
     : num_axes_(static_cast<int32_t>(dims.size())) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_LT(num_axes_, kMaxDim);
   K2_CHECK_EQ(static_cast<int32_t>(strides.size()), num_axes_);
   std::copy(dims.begin(), dims.end(), dims_);
@@ -55,7 +56,7 @@ Shape::Shape(const std::vector<int32_t> &dims,
 }
 
 int32_t Shape::ComputeNumElement() const {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (num_axes_ == 0) return 0;
 
   int32_t elements = 1;
@@ -66,7 +67,7 @@ int32_t Shape::ComputeNumElement() const {
 }
 
 int32_t Shape::ComputeStorageSize() const {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (num_axes_ == 0) return 0;
 
   int32_t size = 1;
@@ -77,7 +78,7 @@ int32_t Shape::ComputeStorageSize() const {
 }
 
 bool Shape::ComputeIsContiguous() const {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t z = 1;
   for (int32_t i = num_axes_ - 1; i >= 0; --i) {
     K2_CHECK_GE(strides_[i], z);
@@ -91,7 +92,7 @@ bool Shape::ComputeIsContiguous() const {
 
 Tensor::Tensor(ContextPtr c, Dtype type, const Shape &shape)
     : impl_(std::make_shared<TensorImpl>()) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   impl_->dtype = type;
   impl_->shape = shape;
   Init(c);
@@ -99,7 +100,7 @@ Tensor::Tensor(ContextPtr c, Dtype type, const Shape &shape)
 
 Tensor::Tensor(ContextPtr c, Dtype type, const std::vector<int32_t> &dims)
     : impl_(std::make_shared<TensorImpl>()) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   impl_->dtype = type;
   impl_->shape = Shape(dims);
   Init(c);
@@ -108,7 +109,7 @@ Tensor::Tensor(ContextPtr c, Dtype type, const std::vector<int32_t> &dims)
 Tensor::Tensor(Dtype type, const Shape &shape, RegionPtr region,
                int32_t byte_offset)
     : impl_(std::make_shared<TensorImpl>()) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t storage_size = shape.StorageSize();
   int32_t element_size = TraitsOf(type).NumBytes();
   impl_->dtype = type;
@@ -120,7 +121,7 @@ Tensor::Tensor(Dtype type, const Shape &shape, RegionPtr region,
 }
 
 Tensor Tensor::Index(int32_t axis, int32_t index) const {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   const auto &this_shape = impl_->shape;
   K2_CHECK_LT(axis, this_shape.NumAxes());
   K2_CHECK_LT(index, this_shape.Dim(axis));
@@ -136,7 +137,7 @@ Tensor Tensor::Index(int32_t axis, int32_t index) const {
 }
 
 void Tensor::Init(ContextPtr c) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   int32_t storage_size = impl_->shape.StorageSize();
   int32_t element_size = TraitsOf(impl_->dtype).NumBytes();
   impl_->data = NewRegion(c, static_cast<size_t>(storage_size * element_size));

--- a/k2/csrc/tensor_ops.cu
+++ b/k2/csrc/tensor_ops.cu
@@ -5,7 +5,9 @@
 // See ../../LICENSE for clarification regarding multiple authors
 
 #include <vector>
+
 #include "k2/csrc/dtype.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/nvtx.h"
 #include "k2/csrc/tensor_ops.h"
 
@@ -16,7 +18,7 @@ void CopyTensorElements2d(ContextPtr c, int32_t dim0, int32_t dim1,
                           const T *src_data, int32_t src_stride0,
                           int32_t src_stride1, T *dest_data,
                           int32_t dest_stride0, int32_t dest_stride1) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   DeviceType d = c->GetDeviceType();
   if (d == kCpu) {
     // this is just an optimization, the other branch would work for CPU too.
@@ -40,7 +42,7 @@ template <typename T>
 void CopyTensorElements1d(ContextPtr c, int32_t dim, const T *src_data,
                           int32_t src_stride, T *dest_data,
                           int32_t dest_stride) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   DeviceType d = c->GetDeviceType();
   if (d == kCpu) {
     // this is just an optimization, the other branch would work for CPU too.
@@ -59,7 +61,7 @@ void CopyTensorElements1d(ContextPtr c, int32_t dim, const T *src_data,
 // attempt to discover the simplest pattern that covers the copy, or to be smart
 // about memory loads if it turns out to be a transposition.
 void CopyTensorElements(Tensor src, Tensor dest) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(src.SameDim(dest));
   ContextPtr c = GetContext(src, dest);
   int32_t num_axes = src.NumAxes();
@@ -99,7 +101,7 @@ void CopyTensorElements(Tensor src, Tensor dest) {
 Tensor ToContiguous(const Tensor &src) {
   // things like this would be more efficient if we supported something like
   // PyTorch's ArrayRef.  not so critical to address that now though.
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   Tensor ans(src.Context(), src.GetDtype(), src.GetShape().Dims());
   CopyTensorElements(src, ans);
   return ans;
@@ -108,7 +110,7 @@ Tensor ToContiguous(const Tensor &src) {
 template <typename T, typename U>
 void CastTensorElements1dContiguous(ContextPtr c, int32_t dim,
                                     const T *src_data, U *dest_data) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   DeviceType d = c->GetDeviceType();
   if (d == kCpu) {
     // this is just an optimization, the other branch would work for CPU too.
@@ -124,7 +126,7 @@ void CastTensorElements1dContiguous(ContextPtr c, int32_t dim,
 }
 
 Tensor Cast(Tensor src, Dtype new_dtype) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (!src.IsContiguous()) src = ToContiguous(src);
 
   ContextPtr c = src.Context();
@@ -140,7 +142,5 @@ Tensor Cast(Tensor src, Dtype new_dtype) {
                                     c, dim, src.Data<T>(), ans.Data<U>()))));
   return ans;
 }
-
-
 
 }  // namespace k2

--- a/k2/csrc/test_utils.cu
+++ b/k2/csrc/test_utils.cu
@@ -16,13 +16,15 @@
 #include "k2/csrc/fsa.h"
 #include "k2/csrc/host/fsa_util.h"
 #include "k2/csrc/host_shim.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
+#include "k2/csrc/nvtx.h"
 #include "k2/csrc/test_utils.h"
 
 namespace k2 {
 
 void ToNotTopSorted(Fsa *fsa) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsa->Context()->GetDeviceType(), kCpu);
 
   int32_t num_states = fsa->TotSize(0);
@@ -54,7 +56,7 @@ void ToNotTopSorted(Fsa *fsa) {
 }
 
 Fsa GetRandFsa() {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   k2host::RandFsaOptions opts;
   opts.num_syms = 5 + RandInt(0, 100);
   opts.num_states = 10 + RandInt(0, 2000);

--- a/k2/csrc/top_sort.cu
+++ b/k2/csrc/top_sort.cu
@@ -24,7 +24,7 @@ namespace k2 {
 // See declaration in fsa_util.h
 FsaVec RenumberFsaVec(FsaVec &fsas, const Array1<int32_t> &order,
                       Array1<int32_t> *arc_map) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   ContextPtr &c = fsas.Context();
   K2_CHECK_LE(order.Dim(), fsas.TotSize(1));
@@ -138,7 +138,7 @@ class TopSorter {
     state, so we remove them.
    */
   std::unique_ptr<Ragged<int32_t>> GetInitialBatch() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     // Initialize it with a list of all states that currently have zero
     // in-degree.
     int32_t num_states = state_in_degree_.Dim();
@@ -176,7 +176,7 @@ class TopSorter {
          @return   Returns the states which, after processing.
    */
   std::unique_ptr<Ragged<int32_t>> GetNextBatch(Ragged<int32_t> &cur_states) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     // Process arcs leaving all states in `cur`
 
     // First figure out how many arcs leave each state.
@@ -281,7 +281,7 @@ class TopSorter {
     reachable from the start state).
    */
   std::unique_ptr<Ragged<int32_t>> GetFinalBatch() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     int32_t num_fsas = NumFsas();
     const int32_t *fsas_row_splits1_data = fsas_.RowSplits(1).Data();
     Array1<int32_t> has_final_state(c_, num_fsas + 1);
@@ -314,7 +314,7 @@ class TopSorter {
   }
 
   void InitDestStatesAndInDegree() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     int32_t num_fsas = fsas_.shape.TotSize(0),
             num_states = fsas_.shape.TotSize(1);
 
@@ -364,7 +364,7 @@ class TopSorter {
                  states.)
    */
   FsaVec TopSort(Array1<int32_t> *arc_map) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     InitDestStatesAndInDegree();
 
     std::vector<std::unique_ptr<Ragged<int32_t>>> iters;
@@ -430,7 +430,7 @@ class TopSorter {
 };
 
 void TopSort(FsaVec &src, FsaVec *dest, Array1<int32_t> *arc_map) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK_GE(src.NumAxes(), 2);
   K2_CHECK_LE(src.NumAxes(), 3);
   if (src.NumAxes() == 2) {

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 
+#include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/nvtx.h"
 #include "k2/csrc/utils.h"
@@ -113,7 +114,7 @@ __global__ void RowSplitsToRowIdsKernel(int32_t num_rows,
 void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
                        const int32_t *row_splits, int32_t num_elems,
                        int32_t *row_ids) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (num_rows <= 0 || num_elems <= 0) return;
   DeviceType d = c->GetDeviceType();
   if (d == kCpu) {
@@ -269,7 +270,7 @@ __global__ void RowIdsToRowSplitsKernel(int32_t num_elems,
 void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
                        bool no_empty_rows, int32_t num_rows,
                        int32_t *row_splits) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   // process corner case first
   if (num_elems == 0) {
     auto lambda_set_values = [=] __host__ __device__(int32_t i) {
@@ -564,7 +565,7 @@ __global__ void GetTaskRedirect(int32_t num_tasks, const int32_t *row_splits,
 
 void GetTaskRedirect(cudaStream_t stream, int32_t num_tasks,
                      const int32_t *row_splits, TaskRedirect *redirect_out) {
-  NVTX_RANGE(__func__);
+  NVTX_RANGE(K2_FUNC);
   if (num_tasks <= 0) return;
   if (stream == kCudaStreamInvalid) {
     // there's not much point in using this on CPU as there are better ways


### PR DESCRIPTION
The output of
```bash
nsys nvprof ./bin/cu_fsa_algo_test --gtest_filter="FsaAlgo.Closure*"
```
is now more readable.

It is listed as follows:

```
k2/build$ nsys nvprof ./bin/cu_fsa_algo_test --gtest_filter="FsaAlgo.Closure*"
WARNING: cu_fsa_algo_test and any of its children processes will be profiled.

Collecting data...
Running main() from /root/fangjun/open-source/k2/build/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = FsaAlgo.Closure*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from FsaAlgo
[ RUN      ] FsaAlgo.ClosureSimpleCase
[       OK ] FsaAlgo.ClosureSimpleCase (7463 ms)
[ RUN      ] FsaAlgo.ClosureStartStateWithoutLeavingArcs
[       OK ] FsaAlgo.ClosureStartStateWithoutLeavingArcs (2 ms)
[ RUN      ] FsaAlgo.ClosureRandomCase
[       OK ] FsaAlgo.ClosureRandomCase (1 ms)
[----------] 3 tests from FsaAlgo (7466 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (7466 ms total)
[  PASSED  ] 3 tests.
Processing events...
Saving temporary "/tmp/nsys-report-6869-a100-a89f-853f.qdstrm" file to disk...
Creating final output files...

Processing [==============================================================100%]
Saved report file to "/tmp/nsys-report-6869-a100-a89f-853f.qdrep"
Exporting 2114 events: [==================================================100%]

Exported successfully to
/tmp/nsys-report-6869-a100-a89f-853f.sqlite

Generating CUDA API Statistics...
CUDA API Statistics (nanoseconds)

Time(%)      Total Time       Calls         Average         Minimum         Maximum  Name                                                                            
-------  --------------  ----------  --------------  --------------  --------------  --------------------------------------------------------------------------------
  100.0      7375682462           1    7375682462.0      7375682462      7375682462  cudaMalloc                                                                      
    0.0          835071          38         21975.6            8390           54240  cudaMemcpy                                                                      
    0.0          513789          27         19029.2            5483          246010  cudaLaunchKernel                                                                
    0.0          312003          27         11555.7            4042           71134  cudaDeviceSynchronize                                                           





Generating CUDA Memory Operation Statistics...
CUDA Memory Operation Statistics (nanoseconds)

Time(%)      Total Time  Operations         Average         Minimum         Maximum  Name                                                                            
-------  --------------  ----------  --------------  --------------  --------------  --------------------------------------------------------------------------------
   85.6           60736          32          1898.0            1600            2880  [CUDA memcpy DtoH]                                                              
   14.4           10207           6          1701.2            1472            2463  [CUDA memcpy HtoD]                                                              


CUDA Memory Operation Statistics (KiB)

              Total      Operations              Average            Minimum              Maximum  Name                                                                            
-------------------  --------------  -------------------  -----------------  -------------------  --------------------------------------------------------------------------------
              0.945              32                0.030              0.004                0.266  [CUDA memcpy DtoH]                                                              
              0.402               6                0.067              0.020                0.250  [CUDA memcpy HtoD]                                                              




Generating NVTX Push-Pop Range Statistics...
NVTX Push-Pop Range Statistics (nanoseconds)

Time(%)      Total Time   Instances         Average         Minimum         Maximum  Range                                                                                               
-------  --------------  ----------  --------------  --------------  --------------  ----------------------------------------------------------------------------------------------------
   50.0      7376868606          14     526919186.1             455      7376413474  k2::RaggedShape k2::RaggedShape::To(k2::ContextPtr) const                                           
   50.0      7376448607          88      83823279.6             256      7375900954  k2::Array1<T> k2::Array1<T>::To(k2::ContextPtr) const [with T = int; k2::ContextPtr = std::shared_pt
    0.0         1715908          37         46375.9            5870          503774  bool k2::RaggedShape::Validate(bool) const                                                          
    0.0         1453194           4        363298.5          188648          712281  k2::Fsa k2::FsaFromString(const string&, bool, k2::Array1<int>*)                                    
    0.0         1400293           4        350073.3          180644          683254  k2::Fsa k2::K2AcceptorFromStream(std::istringstream&)                                               
    0.0         1182404           6        197067.3           24170          452905  k2::Fsa k2::Closure(k2::Fsa&, k2::Array1<int>*)                                                     
    0.0          923929          14         65994.9           12526          270649  k2::RaggedShape k2::RaggedShape2(k2::Array1<int>*, k2::Array1<int>*, int32_t)                       
    0.0          916519           4        229129.8          134609          372553  k2::Fsa k2::FsaFromArray1(k2::Array1<k2::Arc>&, bool*)                                              
    0.0          618687          40         15467.2             200           63502  void k2::MemoryCopy(void*, const void*, std::size_t, cudaMemcpyKind, k2::Context*)                  
    0.0          567060           4        141765.0           98605          175205  int32_t k2::GetFsaBasicProperties(const Fsa&)                                                       
    0.0          527862          21         25136.3             670           88538  void k2::Array1<T>::CopyFrom(const k2::Array1<T>&) [with T = int]                                   
    0.0          420958           2        210479.0           84863          336095  k2::Fsa k2::RandomFsa(bool, int32_t, int32_t, int32_t)                                              
    0.0          367816          14         26272.6             219          246613  k2::Array1<T> k2::Array1<T>::To(k2::ContextPtr) const [with T = k2::Arc; k2::ContextPtr = std::share
    0.0          358908         252          1424.2             193           39349  T k2::Array1<T>::operator[](int32_t) const [with T = int; int32_t = int]                            
    0.0          340643           4         85160.7           55851          111633  void k2::GetFsaVecBasicProperties(k2::FsaVec&, k2::Array1<int>*, int32_t*)                          
    0.0          312411          87          3590.9             235           84748  void k2::Array1<T>::operator=(T) [with T = int]                                                     
    0.0          243947           2        121973.5           25701          218246  k2::RaggedShape k2::RandomRaggedShape(bool, int32_t, int32_t, int32_t, int32_t)                     
    0.0          211432           4         52858.0           40572           59807  k2::FsaVec k2::FsaToFsaVec(const Fsa&)                                                              
    0.0          207168          38          5451.8             226           77929  k2::Array1<int>& k2::RaggedShape::RowIds(int32_t)                                                   
    0.0          176308          18          9794.9            1572           60181  void k2::SplitStringToVector(const string&, const char*, std::vector<std::basic_string<char> >*)    
    0.0          151837           8         18979.6           14240           25543  k2::RaggedShape k2::RemoveAxis(k2::RaggedShape&, int32_t)                                           
    0.0          151289           6         25214.8            3015          129058  k2::Array1<T>::Array1(k2::ContextPtr, const std::vector<T>&) [with T = k2::Arc; k2::ContextPtr = std
    0.0          133930           7         19132.9            9738           37099  void k2::Array1<T>::CopyFrom(const k2::Array1<T>&) [with T = k2::Arc]                               
    0.0          108313          49          2210.5             231           90763  int32_t k2::RandInt(int32_t, int32_t)                                                               
    0.0          108096          80          1351.2             202           28403  int32_t k2::RaggedShape::TotSize(int32_t) const                                                     
    0.0          103222           5         20644.4             563           44148  void k2::RowSplitsToRowIds(k2::ContextPtr, int32_t, const int32_t*, int32_t, int32_t*)              
    0.0           98632           4         24658.0           20850           28156  k2::RaggedShape k2::ComposeRaggedShapes(const k2::RaggedShape&, const k2::RaggedShape&)             
    0.0           96550           4         24137.5           17420           27338  k2::RaggedShape k2::TrivialShape(k2::ContextPtr&, int32_t)                                          
    0.0           87832          92           954.7             317           30253  void k2::TrimString(std::string*)                                                                   
    0.0           70292          13          5407.1             439           63639  int32_t k2::RandIntGeometric(int32_t, int32_t)                                                      
    0.0           51491           4         12872.7            4723           32852  bool k2::ValidateRowIds(const k2::Array1<int>&, k2::Array1<int>*)                                   
    0.0           47969           4         11992.2            5472           21011  bool k2::ValidateRowSplitsAndIds(const k2::Array1<int>&, const k2::Array1<int>&, k2::Array1<int>*)  
    0.0           38240          10          3824.0            2501            6096  void k2::RaggedShape::Populate()                                                                    
    0.0           20596          14          1471.1             600            6731  int32_t k2::RaggedShape::operator[](const std::vector<int>&)                                        
    0.0           15670           8          1958.8            1376            3913  k2::Array1<T> k2::Array1<T>::operator[](const k2::Array1<int>&) const [with T = int]                
    0.0           15628          34           459.6             194            4444  int32_t k2::StringToInt(const string&)                                                              
    0.0           14871           2          7435.5            3264           11607  k2::Array1<T>::Array1(k2::ContextPtr, const std::vector<T>&) [with T = int; k2::ContextPtr = std::sh
    0.0           13410           8          1676.3             494            4075  void k2::ApplyOpPerSublist(k2::Ragged<T>&, T, k2::Array1<T>*) [with T = char; Op = k2::BitAndOp<char
    0.0           11471          10          1147.1             336            3554  float k2::StringToFloat(const string&)                                                              
    0.0           11007          16           687.9             297            3391  k2::Array1<T> k2::Array1<T>::Range(int32_t, int32_t) const [with T = char; int32_t = int]           
    0.0            9985          10           998.5             332            2628  k2::Array1<T> k2::Array1<T>::Range(int32_t, int32_t) const [with T = int; int32_t = int]            
    0.0            9097           4          2274.2            1644            2795  k2::Array1<T> k2::Range(k2::ContextPtr, int32_t, T, T) [with T = int; k2::ContextPtr = std::shared_p
    0.0            8666           4          2166.5             895            3799  void k2::ApplyOpPerSublist(k2::Ragged<T>&, T, k2::Array1<T>*) [with T = int; Op = k2::BitAndOp<int>]
    0.0            5198          14           371.3             187             666  T k2::Array1<T>::operator[](int32_t) const [with T = k2::Arc; int32_t = int]                        
    0.0            4490           4          1122.5             434            1735  void k2::Array1<T>::operator=(T) [with T = char]                                                    
    0.0            3651           4           912.8             713            1180  void k2::RowIdsToRowSplits(k2::ContextPtr, int32_t, const int32_t*, bool, int32_t, int32_t*)        
    0.0            3181           4           795.2             437            1366  void k2::ApplyOpOnArray1(k2::Array1<T>&, T, k2::Array1<T>*) [with T = int; Op = k2::BitAndOp<int>]  
    0.0            2248           3           749.3             283            1456  int32_t k2::RoundUpToNearestPowerOfTwo(int32_t)                                                     


```