### PR TITLE
Use macros to prevent redundant code in short lambdas.

### DIFF
--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -84,6 +84,7 @@ set(cuda_tests
   host_shim_test
   intersect_test
   log_test
+  macros_test
   nvtx_test
   ragged_shape_test
   ragged_test

--- a/k2/csrc/algorithms.cu
+++ b/k2/csrc/algorithms.cu
@@ -37,19 +37,13 @@ inline void ComputeNew2OldHelper(ContextPtr &c, const int32_t *old2new_data,
   NVTX_RANGE(K2_FUNC);
   // Note: the following accesses data one past the end of (current)
   // old2new_, but it does actually exist.
-  if (c->GetDeviceType() == kCpu) {
-    for (int32_t old_idx = 0; old_idx < old_dim; old_idx++)
-      if (old2new_data[old_idx + 1] > old2new_data[old_idx])
-        new2old_data[old2new_data[old_idx]] = old_idx;
-    new2old_data[old2new_data[old_dim]] = old_dim;
-  } else {
-    auto lambda_set_new2old = [=] __device__(int32_t old_idx) {
-      if (old_idx == old_dim ||
-          old2new_data[old_idx + 1] > old2new_data[old_idx])
-        new2old_data[old2new_data[old_idx]] = old_idx;
-    };
-    EvalDevice(c, old_dim + 1, lambda_set_new2old);
-  }
+
+  K2_EVAL(
+      c, old_dim + 1, lambda_set_new2old, (int32_t old_idx) {
+        if (old_idx == old_dim ||
+            old2new_data[old_idx + 1] > old2new_data[old_idx])
+          new2old_data[old2new_data[old_idx]] = old_idx;
+      });
 }
 
 }  // namespace

--- a/k2/csrc/array_ops.cu
+++ b/k2/csrc/array_ops.cu
@@ -351,15 +351,9 @@ Array1<int32_t> InvertPermutation(const Array1<int32_t> &src) {
   const int32_t *src_data = src.Data();
   int32_t *ans_data = ans.Data();
 
-  if (c->GetDeviceType() == kCpu) {
-    for (int32_t i = 0; i < dim; i++)
-      ans_data[src_data[i]] = i;
-  } else {
-    auto lambda_set_ans = [=] __device__ (int32_t i) -> void {
-      ans_data[src_data[i]] = i;
-    };
-    EvalDevice(c, dim, lambda_set_ans);
-  }
+  K2_EVAL(
+      c, dim, lambda_set_ans, (int32_t i)->void { ans_data[src_data[i]] = i; });
+
   return ans;
 }
 
@@ -370,17 +364,13 @@ Array1<int32_t> RowSplitsToSizes(const Array1<int32_t> &row_splits) {
   Array1<int32_t> sizes(c, num_rows);
   const int32_t *row_splits_data = row_splits.Data();
   int32_t *sizes_data = sizes.Data();
-  if (c->GetDeviceType() == kCpu) {
-    for (int32_t i = 0; i < num_rows; i++)
-      sizes_data[i] = row_splits_data[i + 1] - row_splits_data[i];
-  } else {
-    auto lambda_set_sizes = [=] __device__ (int32_t i) -> void {
-      sizes_data[i] = row_splits_data[i + 1] - row_splits_data[i];
-    };
-    EvalDevice(c, num_rows, lambda_set_sizes);
-  }
+
+  K2_EVAL(
+      c, num_rows, lambda_set_sizes, (int32_t i)->void {
+        sizes_data[i] = row_splits_data[i + 1] - row_splits_data[i];
+      });
+
   return sizes;
 }
-
 
 }  // namespace k2

--- a/k2/csrc/array_ops_inl.h
+++ b/k2/csrc/array_ops_inl.h
@@ -592,7 +592,7 @@ bool IsMonotonic(const Array1<T> &a) {
   } else {
     Array1<int32_t> is_monotonic(c, 1, 1);
     int32_t *is_monotonic_data = is_monotonic.Data();
-    auto lambda_test = [=] __host__ __device__(int32_t i) -> void {
+    auto lambda_test = [=]  __device__(int32_t i) -> void {
       if (data[i + 1] < data[i]) *is_monotonic_data = 0;
     };
     EvalDevice(c, dim - 1, lambda_test);
@@ -614,7 +614,7 @@ bool IsMonotonicDecreasing(const Array1<T> &a) {
   } else {
     Array1<int32_t> is_monotonic(c, 1, 1);
     int32_t *is_monotonic_data = is_monotonic.Data();
-    auto lambda_test = [=] __host__ __device__(int32_t i) -> void {
+    auto lambda_test = [=]  __device__(int32_t i) -> void {
       if (data[i + 1] > data[i]) *is_monotonic_data = 0;
     };
     EvalDevice(c, dim - 1, lambda_test);

--- a/k2/csrc/array_ops_inl.h
+++ b/k2/csrc/array_ops_inl.h
@@ -592,14 +592,13 @@ bool IsMonotonic(const Array1<T> &a) {
   } else {
     Array1<int32_t> is_monotonic(c, 1, 1);
     int32_t *is_monotonic_data = is_monotonic.Data();
-    auto lambda_test = [=]  __device__(int32_t i) -> void {
+    auto lambda_test = [=] __device__(int32_t i) -> void {
       if (data[i + 1] < data[i]) *is_monotonic_data = 0;
     };
     EvalDevice(c, dim - 1, lambda_test);
     return is_monotonic[0];
   }
 }
-
 
 template <typename T>
 bool IsMonotonicDecreasing(const Array1<T> &a) {
@@ -614,14 +613,13 @@ bool IsMonotonicDecreasing(const Array1<T> &a) {
   } else {
     Array1<int32_t> is_monotonic(c, 1, 1);
     int32_t *is_monotonic_data = is_monotonic.Data();
-    auto lambda_test = [=]  __device__(int32_t i) -> void {
+    auto lambda_test = [=] __device__(int32_t i) -> void {
       if (data[i + 1] > data[i]) *is_monotonic_data = 0;
     };
     EvalDevice(c, dim - 1, lambda_test);
     return is_monotonic[0];
   }
 }
-
 
 template <typename S, typename T>
 void MonotonicLowerBound(const Array1<S> &src, Array1<T> *dest) {
@@ -848,16 +846,16 @@ template <typename T>
 void Assign(Array2<T> &src, Array2<T> *dest) {
   K2_CHECK_EQ(src.Dim0(), dest->Dim0());
   K2_CHECK_EQ(src.Dim1(), dest->Dim1());
-  int32_t dim0 = src.Dim0(), dim1 = src.Dim1(),
-    src_stride = src.ElemStride0(),
-   dest_stride = dest->ElemStride0();
+  int32_t dim0 = src.Dim0(), dim1 = src.Dim1(), src_stride = src.ElemStride0(),
+          dest_stride = dest->ElemStride0();
 
   if (src_stride == dim1 && dest_stride == dim1) {
-    cudaMemcpyKind memcpy_kind = GetMemoryCopyKind(*src.Context(),
-                                                   *dest->Context());
+    cudaMemcpyKind memcpy_kind =
+        GetMemoryCopyKind(*src.Context(), *dest->Context());
     size_t num_bytes = dim0 * src.ElementSize() * dim1;
-    MemoryCopy((void*)dest->Data(), (const void*)src.Data(),
-               num_bytes, memcpy_kind, src.Context().get());
+    MemoryCopy(reinterpret_cast<void *>(dest->Data()),
+               reinterpret_cast<const void *>(src.Data()), num_bytes,
+               memcpy_kind, src.Context().get());
   } else {
     // this branch does not support cross-device copy.
     ContextPtr c = GetContext(src, *dest);
@@ -867,19 +865,17 @@ void Assign(Array2<T> &src, Array2<T> *dest) {
       size_t row_length_bytes = src.ElementSize() * dim1;
       for (int32_t r = 0; r < dim0;
            r++, dest_data += dest_stride, src_data += src_stride) {
-        memcpy(static_cast<void*>(dest_data),
-               static_cast<const void*>(src_data),
-               row_length_bytes);
+        memcpy(static_cast<void *>(dest_data),
+               static_cast<const void *>(src_data), row_length_bytes);
       }
     } else {
-      auto lambda_copy_data = [=] __device__ (int32_t i, int32_t j) {
+      auto lambda_copy_data = [=] __device__(int32_t i, int32_t j) {
         dest_data[i * dest_stride + j] = src_data[i * src_stride + j];
       };
       Eval2Device(c, dim0, dim1, lambda_copy_data);
     }
   }
 }
-
 
 }  // namespace k2
 

--- a/k2/csrc/array_ops_test.cu
+++ b/k2/csrc/array_ops_test.cu
@@ -1502,7 +1502,6 @@ TEST(OpsTest, Array1IndexTest) {
   }
 }
 
-
 TEST(OpsTest, InvertPermutationTest) {
   for (int loop = 0; loop < 2; loop++) {
     ContextPtr c = (loop == 0 ? GetCpuContext() : GetCudaContext()),
@@ -1513,9 +1512,10 @@ TEST(OpsTest, InvertPermutationTest) {
       std::iota(permutation.begin(), permutation.end(), 0);
       std::random_shuffle(permutation.begin(), permutation.end());
       Array1<int32_t> permutation_array(c, permutation);
-      Array1<int32_t> permutation_array_inv = InvertPermutation(permutation_array);
+      Array1<int32_t> permutation_array_inv =
+          InvertPermutation(permutation_array);
       Array1<int32_t> range = permutation_array[permutation_array_inv],
-                     range2 = Range(c, len, 0);
+                      range2 = Range(c, len, 0);
       K2_CHECK(Equal(range, range2));
     }
   }
@@ -1636,7 +1636,6 @@ TEST(OpsTest, Array1Sort) {
   Array1SortTestRandom<int32_t>();
   Array1SortTestRandom<float>();
 }
-
 
 TEST(OpsTest, Array2Assign) {
   for (int loop = 0; loop < 10; loop++) {

--- a/k2/csrc/array_ops_test.cu
+++ b/k2/csrc/array_ops_test.cu
@@ -25,6 +25,7 @@
 #include "k2/csrc/array.h"
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/context.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/ragged.h"
 #include "k2/csrc/ragged_ops.h"
@@ -251,10 +252,9 @@ void TestExclusiveSumArray1(int32_t num_elem) {
       int32_t num_bytes = num_elem * sizeof(S *);
       RegionPtr region = NewRegion(context, num_bytes);
       S **region_data = region->GetData<S *>();
-      auto lambda_set_values = [=] __host__ __device__(int32_t i) -> void {
-        region_data[i] = &src_data[i];
-      };
-      Eval(context, num_elem, lambda_set_values);
+      K2_EVAL(
+          context, num_elem, lambda_set_values,
+          (int32_t i)->void { region_data[i] = &src_data[i]; });
       // not src_ptr.Dim() == src_dim == num_elem - 1
       Array1<const S *> src_ptr(src_dim, region, 0);
       Array1<S> dest(context, num_elem);
@@ -361,11 +361,10 @@ void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
       int32_t num_bytes = rows * stride0 * sizeof(T);
       RegionPtr region = NewRegion(context, num_bytes);
       T *region_data = region->GetData<T>();
-      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                      int32_t j) -> void {
-        region_data[i * stride0 + j] = src_data[i * cols + j];
-      };
-      Eval2(context, rows, cols, lambda_set_elems);
+      K2_EVAL2(
+          context, rows, cols, lambda_set_elems, (int32_t i, int32_t j)->void {
+            region_data[i * stride0 + j] = src_data[i * cols + j];
+          });
       Array2<T> src(rows, cols, stride0, 0, region);
       ExclusiveSum(src, &src, axis);
       CheckExclusiveSumArray2Result(data, src, axis);
@@ -397,11 +396,10 @@ void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
       int32_t num_bytes = rows * stride0 * sizeof(T);
       RegionPtr region = NewRegion(context, num_bytes);
       T *region_data = region->GetData<T>();
-      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                      int32_t j) -> void {
-        region_data[i * stride0 + j] = src_data[i * cols + j];
-      };
-      Eval2(context, rows, cols, lambda_set_elems);
+      K2_EVAL2(
+          context, rows, cols, lambda_set_elems, (int32_t i, int32_t j)->void {
+            region_data[i * stride0 + j] = src_data[i * cols + j];
+          });
       Array2<T> src(rows, cols, stride0, 0, region);
       Array2<T> dest(context, rows, cols);
       ExclusiveSum(src, &dest, axis);
@@ -420,11 +418,10 @@ void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
       int32_t num_bytes = (rows * cols + 1) * sizeof(T);
       RegionPtr region = NewRegion(context, num_bytes);
       T *region_data = region->GetData<T>();
-      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                      int32_t j) -> void {
-        region_data[i * cols + j] = src_data[i * cols + j];
-      };
-      Eval2(context, rows, cols, lambda_set_elems);
+      K2_EVAL2(
+          context, rows, cols, lambda_set_elems, (int32_t i, int32_t j)->void {
+            region_data[i * cols + j] = src_data[i * cols + j];
+          });
       Array2<T> src(rows, cols, cols, 0, region);
       {
         // dest.stride0 == dest.cols
@@ -469,11 +466,10 @@ void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
       int32_t num_bytes = rows * stride0 * sizeof(T);
       RegionPtr region = NewRegion(context, num_bytes);
       T *region_data = region->GetData<T>();
-      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                      int32_t j) -> void {
-        region_data[i * stride0 + j] = src_data[i * cols + j];
-      };
-      Eval2(context, rows, cols, lambda_set_elems);
+      K2_EVAL2(
+          context, rows, cols, lambda_set_elems, (int32_t i, int32_t j)->void {
+            region_data[i * stride0 + j] = src_data[i * cols + j];
+          });
       Array2<T> src(rows, cols, stride0, 0, region);
       ExclusiveSum(src, &src, axis);
       CheckExclusiveSumArray2Result(data, src, axis);
@@ -504,11 +500,10 @@ void TestExclusiveSumArray2(int32_t rows, int32_t cols) {
       int32_t num_bytes = (rows * cols + 1) * sizeof(T);
       RegionPtr region = NewRegion(context, num_bytes);
       T *region_data = region->GetData<T>();
-      auto lambda_set_elems = [=] __host__ __device__(int32_t i,
-                                                      int32_t j) -> void {
-        region_data[i * cols + j] = src_data[i * cols + j];
-      };
-      Eval2(context, rows, cols, lambda_set_elems);
+      K2_EVAL2(
+          context, rows, cols, lambda_set_elems, (int32_t i, int32_t j)->void {
+            region_data[i * cols + j] = src_data[i * cols + j];
+          });
       Array2<T> src(rows, cols, cols, 0, region);
       {
         // dest.stride0 == dest.cols

--- a/k2/csrc/array_test.cu
+++ b/k2/csrc/array_test.cu
@@ -21,6 +21,7 @@
 #include "k2/csrc/context.h"
 #include "k2/csrc/dtype.h"
 #include "k2/csrc/log.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/tensor.h"
 
 namespace k2 {
@@ -33,10 +34,9 @@ void CheckArrayEqual(const Array1<T> &a, const Array1<T> &b) {
   const T *da = a.Data();
   const T *db = b.Data();
   auto n = a.Dim();
-  auto compare = [=] __host__ __device__(int32_t i) -> void {
-    K2_CHECK_EQ(da[i], db[i]);
-  };
-  Eval(a.Context(), n, compare);
+  K2_EVAL(
+      a.Context(), n, compare,
+      (int32_t i)->void { K2_CHECK_EQ(da[i], db[i]); });
 }
 
 template <typename T>

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -569,22 +569,22 @@ Array1<int32_t> GetDestStates(FsaVec &fsas, bool as_idx01) {
   const Arc *arcs_data = fsas.values.Data();
   int32_t *ans_data = ans.Data();
   if (!as_idx01) {
-    auto lambda_set_dest_states1 = [=] __host__ __device__(int32_t arc_idx012) {
-      ans_data[arc_idx012] = arcs_data[arc_idx012].dest_state;
-    };
-    Eval(c, num_arcs, lambda_set_dest_states1);
+    K2_EVAL(
+        c, num_arcs, lambda_set_dest_states1, (int32_t arc_idx012) {
+          ans_data[arc_idx012] = arcs_data[arc_idx012].dest_state;
+        });
   } else {
     const int32_t *row_ids2 = fsas.RowIds(2).Data();
-    auto lambda_set_dest_states01 = [=] __host__ __device__(
-                                        int32_t arc_idx012) {
-      int32_t src_state = arcs_data[arc_idx012].src_state,
-              dest_state = arcs_data[arc_idx012].dest_state;
-      // (row_ids2[arc_idx012] - src_state) is the same as
-      // row_splits1[row_ids1[row_ids2[arc_idx012]]]; it's the idx01 of the 1st
-      // state in this FSA.
-      ans_data[arc_idx012] = dest_state + (row_ids2[arc_idx012] - src_state);
-    };
-    Eval(c, num_arcs, lambda_set_dest_states01);
+    K2_EVAL(
+        c, num_arcs, lambda_set_dest_states01, (int32_t arc_idx012) {
+          int32_t src_state = arcs_data[arc_idx012].src_state,
+                  dest_state = arcs_data[arc_idx012].dest_state;
+          // (row_ids2[arc_idx012] - src_state) is the same as
+          // row_splits1[row_ids1[row_ids2[arc_idx012]]]; it's the idx01 of the
+          // 1st state in this FSA.
+          ans_data[arc_idx012] =
+              dest_state + (row_ids2[arc_idx012] - src_state);
+        });
   }
   return ans;
 }
@@ -622,32 +622,33 @@ Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
   int32_t *dest_states_power_data =
       dest_states_powers.Data();  // only process Row[0] below
   const int32_t int_max = std::numeric_limits<int32_t>::max();
-  auto lambda_set_dest_states =
-      [=] __host__ __device__(int32_t state_idx01) -> void {
-    int32_t arc_idx01x = fsas_row_splits2_data[state_idx01];
-    // If this state has arcs, let its `dest_state` be the smallest `dest_state`
-    // of any of its arcs (which is the first element of those arcs' dest states
-    // in `arc_dest_states_data`); otherwise, take the `dest_state` from the 1st
-    // arc of the next state, which is the largest value we can take (if the
-    // definition is: the highest-numbered state s for which neither this state
-    // nor any later-numbered state has an arc to a state lower than s).
+  K2_EVAL(
+      c, num_states, lambda_set_dest_states, (int32_t state_idx01)->void {
+        int32_t arc_idx01x = fsas_row_splits2_data[state_idx01];
+        // If this state has arcs, let its `dest_state` be the smallest
+        // `dest_state` of any of its arcs (which is the first element of those
+        // arcs' dest states in `arc_dest_states_data`); otherwise, take the
+        // `dest_state` from the 1st arc of the next state, which is the largest
+        // value we can take (if the definition is: the highest-numbered state s
+        // for which neither this state nor any later-numbered state has an arc
+        // to a state lower than s).
 
-    // if this state has arcs,
-    //    arc_idx01x is the first arc index of this state, we get the
-    //    smallest dest state of this state's arcs using
-    //    arc_dest_states_data[arc_idx01x]
-    // else
-    //    arc_idx01x is the first arc index of the next state, then
-    //    arc_dest_states_data[arc_idx01x] is the largest value we can take,
-    //    which is also the smallest dest state in the next state.
-    int32_t dest_state =
-        (arc_idx01x < num_arcs ? arc_dest_states_data[arc_idx01x] : int_max);
-    dest_states_power_data[state_idx01] = dest_state;
-    // if the following fails, it's either a code error or the input FSA had
-    // cycles.
-    K2_CHECK_GT(dest_state, state_idx01);
-  };
-  Eval(c, num_states, lambda_set_dest_states);
+        // if this state has arcs,
+        //    arc_idx01x is the first arc index of this state, we get the
+        //    smallest dest state of this state's arcs using
+        //    arc_dest_states_data[arc_idx01x]
+        // else
+        //    arc_idx01x is the first arc index of the next state, then
+        //    arc_dest_states_data[arc_idx01x] is the largest value we can take,
+        //    which is also the smallest dest state in the next state.
+        int32_t dest_state =
+            (arc_idx01x < num_arcs ? arc_dest_states_data[arc_idx01x]
+                                   : int_max);
+        dest_states_power_data[state_idx01] = dest_state;
+        // if the following fails, it's either a code error or the input FSA had
+        // cycles.
+        K2_CHECK_GT(dest_state, state_idx01);
+      });
 
   // `num_batches_per_fsa` will be set to the number of batches of states that
   // we'll use for each FSA... it corresponds to the number of times we have
@@ -670,31 +671,31 @@ Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
 #if 0
   // This is a simple version of the kernel that demonstrates what we're trying
   // to do with the more complex code.
-  auto lambda_set_batch_info_simple = [=] __host__ __device__(int32_t fsa_idx) {
-    int32_t begin_state_idx01 = fsas_row_splits1_data[fsa_idx],
-            end_state_idx01 = fsas_row_splits1_data[fsa_idx + 1];
-    int32_t i = 0, cur_state_idx01 = begin_state_idx01;
-    while (cur_state_idx01 < end_state_idx01) {
-      batch_starts_data[begin_state_idx01 + i] = cur_state_idx01;
-      cur_state_idx01 = dest_states_power_data[cur_state_idx01];
-      ++i;
-    }
-    num_batches_per_fsa_data[fsa_idx] = i;
-  };
-  Eval(c, num_fsas, lambda_set_batch_info_simple);
+  K2_EVAL(
+      c, num_fsas, lambda_set_batch_info_simple, (int32_t fsa_idx) {
+        int32_t begin_state_idx01 = fsas_row_splits1_data[fsa_idx],
+                end_state_idx01 = fsas_row_splits1_data[fsa_idx + 1];
+        int32_t i = 0, cur_state_idx01 = begin_state_idx01;
+        while (cur_state_idx01 < end_state_idx01) {
+          batch_starts_data[begin_state_idx01 + i] = cur_state_idx01;
+          cur_state_idx01 = dest_states_power_data[cur_state_idx01];
+          ++i;
+        }
+        num_batches_per_fsa_data[fsa_idx] = i;
+      });
 #else
   int32_t stride = dest_states_powers.ElemStride0();
   for (int32_t power = 1; power <= log_power; power++) {
     const int32_t *src_data = dest_states_powers.Data() + (power - 1) * stride;
     int32_t *dest_data = dest_states_powers.Data() + power * stride;
-    auto lambda_square_array =
-        [=] __host__ __device__(int32_t state_idx01) -> void {
-      int32_t dest_state = src_data[state_idx01],
-              dest_state_sq =
-                  (dest_state < num_states ? src_data[dest_state] : int_max);
-      dest_data[state_idx01] = dest_state_sq;
-    };
-    Eval(c, num_states, lambda_square_array);
+    K2_EVAL(
+        c, num_states, lambda_square_array, (int32_t state_idx01)->void {
+          int32_t dest_state = src_data[state_idx01],
+                  dest_state_sq =
+                      (dest_state < num_states ? src_data[dest_state]
+                                               : int_max);
+          dest_data[state_idx01] = dest_state_sq;
+        });
   }
   // jobs_per_fsa tells us how many separate chains of states we'll follow for
   // each FSA.
@@ -708,62 +709,65 @@ Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
                          // num-jobs is ridiculous.
 
   auto dest_states_powers_acc = dest_states_powers.Accessor();
-  auto lambda_set_batch_info = [=] __host__ __device__(int32_t fsa_idx,
-                                                       int32_t j) {
-    if (j % jobs_multiple != 0)
-      return;                              // a trick to avoid too much random
-                                           // memory access for any given warp
-    int32_t task_idx = j / jobs_multiple;  // Now 0 <= task_idx < jobs_per_fsa.
+  K2_EVAL2(
+      c, num_fsas, jobs_per_fsa * jobs_multiple, lambda_set_batch_info,
+      (int32_t fsa_idx, int32_t j) {
+        if (j % jobs_multiple != 0)
+          return;  // a trick to avoid too much random
+                   // memory access for any given warp
+        int32_t task_idx =
+            j / jobs_multiple;  // Now 0 <= task_idx < jobs_per_fsa.
 
-    // The task indexed `task_idx` is responsible for batches numbered
-    // task_idx, task_idx + jobs_per_fsa, task_index + 2 * job_per_fsa and so
-    // on, for the FSA numbered `fsa_idx`. Comparing this code to
-    // `lambda_set_batch_info_simple`, this task is responsible for the
-    // assignment to batch_starts_data for all i such that i % jobs_per_fsas ==
-    // task_idx, together with the assignment to num_batchess_per_fsa_data if
-    //  i % jobs_per_fsas == task_idx (here referring to the i value finally
-    // assigned to that location).
+        // The task indexed `task_idx` is responsible for batches numbered
+        // task_idx, task_idx + jobs_per_fsa, task_index + 2 * job_per_fsa and
+        // so on, for the FSA numbered `fsa_idx`. Comparing this code to
+        // `lambda_set_batch_info_simple`, this task is responsible for the
+        // assignment to batch_starts_data for all i such that i % jobs_per_fsas
+        // == task_idx, together with the assignment to
+        // num_batchess_per_fsa_data if
+        //  i % jobs_per_fsas == task_idx (here referring to the i value finally
+        // assigned to that location).
 
-    int32_t begin_state_idx01 = fsas_row_splits1_data[fsa_idx],
-            end_state_idx01 = fsas_row_splits1_data[fsa_idx + 1];
-    int32_t num_states_this_fsa = end_state_idx01 - begin_state_idx01;
-    int32_t i = 0, cur_state_idx01 = begin_state_idx01;
+        int32_t begin_state_idx01 = fsas_row_splits1_data[fsa_idx],
+                end_state_idx01 = fsas_row_splits1_data[fsa_idx + 1];
+        int32_t num_states_this_fsa = end_state_idx01 - begin_state_idx01;
+        int32_t i = 0, cur_state_idx01 = begin_state_idx01;
 
-    if (task_idx >= num_states_this_fsa) return;
+        if (task_idx >= num_states_this_fsa) return;
 
-    // The next loop advances `cur_state_idx01` by
-    // a number of steps equal to `task_idx`.
-    for (int32_t m = 0; m < log_power; ++m) {
-      int32_t n = 1 << m;
-      if ((task_idx & n) != 0) {
-        i += n;
-        int32_t next = dest_states_powers_acc(m, cur_state_idx01);
-        if (next >= end_state_idx01) return;
-        cur_state_idx01 = next;
-      }
-    }
-    K2_CHECK_EQ(i, task_idx);
-
-    while (1) {
-      if (i >= num_states_this_fsa) return;
-      batch_starts_data[begin_state_idx01 + i] = cur_state_idx01;
-      int32_t next_state_idx01 = dest_states_powers_acc(
-          log_power,
-          cur_state_idx01);  // advance jobs_per_fsa = (1 << log_power) steps
-      if (next_state_idx01 >= end_state_idx01) {
-        // if exactly one step would also be enough to take us past the
-        // boundary...
-        if (dest_states_powers_acc(0, cur_state_idx01) >= end_state_idx01) {
-          num_batches_per_fsa_data[fsa_idx] = i + 1;
+        // The next loop advances `cur_state_idx01` by
+        // a number of steps equal to `task_idx`.
+        for (int32_t m = 0; m < log_power; ++m) {
+          int32_t n = 1 << m;
+          if ((task_idx & n) != 0) {
+            i += n;
+            int32_t next = dest_states_powers_acc(m, cur_state_idx01);
+            if (next >= end_state_idx01) return;
+            cur_state_idx01 = next;
+          }
         }
-        return;
-      } else {
-        i += jobs_per_fsa;
-        cur_state_idx01 = next_state_idx01;
-      }
-    }
-  };
-  Eval2(c, num_fsas, jobs_per_fsa * jobs_multiple, lambda_set_batch_info);
+        K2_CHECK_EQ(i, task_idx);
+
+        while (1) {
+          if (i >= num_states_this_fsa) return;
+          batch_starts_data[begin_state_idx01 + i] = cur_state_idx01;
+          int32_t next_state_idx01 = dest_states_powers_acc(
+              log_power,
+              cur_state_idx01);  // advance jobs_per_fsa = (1 << log_power)
+                                 // steps
+          if (next_state_idx01 >= end_state_idx01) {
+            // if exactly one step would also be enough to take us past the
+            // boundary...
+            if (dest_states_powers_acc(0, cur_state_idx01) >= end_state_idx01) {
+              num_batches_per_fsa_data[fsa_idx] = i + 1;
+            }
+            return;
+          } else {
+            i += jobs_per_fsa;
+            cur_state_idx01 = next_state_idx01;
+          }
+        }
+      });
 #endif
   ExclusiveSum(num_batches_per_fsa, &num_batches_per_fsa);
   Array1<int32_t> &ans_row_splits1 = num_batches_per_fsa;
@@ -776,20 +780,20 @@ Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
   int32_t *ans_row_splits2_data = ans_row_splits2.Data();
   ans_row_splits2.Range(num_batches, 1) = num_states;  // The kernel below won't
                                                        // set this last element
-  auto lambda_set_ans_row_splits2 =
-      [=] __host__ __device__(int32_t idx01) -> void {
-    int32_t idx0 = ans_row_ids1_data[idx01],  // Fsa index
-        idx0x = ans_row_splits1_data[idx0], idx1 = idx01 - idx0x,
-            fsas_idx0x = fsas_row_splits1_data[idx0],  // 1st state-idx (idx01)
-                                                       // in fsas_, for this FSA
-        fsas_idx01 = fsas_idx0x + idx1,  // the idx1 is actually the
-                                         // batch-index, this statement reflects
-                                         // the 'un-consolidated' format of
-                                         // `batch_starts`.
-        this_batch_start = batch_starts_data[fsas_idx01];
-    ans_row_splits2_data[idx01] = this_batch_start;
-  };
-  Eval(c, num_batches, lambda_set_ans_row_splits2);
+  K2_EVAL(
+      c, num_batches, lambda_set_ans_row_splits2, (int32_t idx01)->void {
+        int32_t idx0 = ans_row_ids1_data[idx01],  // Fsa index
+            idx0x = ans_row_splits1_data[idx0], idx1 = idx01 - idx0x,
+                fsas_idx0x =
+                    fsas_row_splits1_data[idx0],  // 1st state-idx (idx01)
+                                                  // in fsas_, for this FSA
+            fsas_idx01 = fsas_idx0x + idx1,       // the idx1 is actually the
+                                                  // batch-index, this statement
+            // reflects the 'un-consolidated'
+            // format of `batch_starts`.
+            this_batch_start = batch_starts_data[fsas_idx01];
+        ans_row_splits2_data[idx01] = this_batch_start;
+      });
 
   RaggedShape ans_shape =
       RaggedShape3(&ans_row_splits1, &ans_row_ids1, num_batches,
@@ -851,12 +855,12 @@ Ragged<int32_t> GetLeavingArcIndexBatches(FsaVec &fsas,
   int32_t *ans_row_splits3_data = ans_row_splits3.Data();
   const int32_t *fsa_states_row_splits_data = fsas.RowSplits(2).Data();
   const int32_t *batch_states_data = state_batches.values.Data();
-  auto lambda_set_ans_row_splits3 = [=] __host__ __device__(int32_t idx) {
-    int32_t state_idx = batch_states_data[idx];
-    ans_row_splits3_data[idx] = fsa_states_row_splits_data[state_idx + 1] -
-                                fsa_states_row_splits_data[state_idx];
-  };
-  Eval(c, num_states, lambda_set_ans_row_splits3);
+  K2_EVAL(
+      c, num_states, lambda_set_ans_row_splits3, (int32_t idx) {
+        int32_t state_idx = batch_states_data[idx];
+        ans_row_splits3_data[idx] = fsa_states_row_splits_data[state_idx + 1] -
+                                    fsa_states_row_splits_data[state_idx];
+      });
   ExclusiveSum(ans_row_splits3, &ans_row_splits3);
   Array1<int32_t> ans_row_ids3(c, num_arcs);
   RowSplitsToRowIds(ans_row_splits3, &ans_row_ids3);
@@ -868,16 +872,16 @@ Ragged<int32_t> GetLeavingArcIndexBatches(FsaVec &fsas,
   Array1<int32_t> ans_values(c, num_arcs);
   int32_t *ans_values_data = ans_values.Data();
   const int32_t *ans_row_ids3_data = ans_row_ids3.Data();
-  auto lambda_set_ans_values = [=] __host__ __device__(int32_t idx0123) {
-    int32_t ans_idx012 = ans_row_ids3_data[idx0123];
-    int32_t state_idx =
-        batch_states_data[ans_idx012];  // state_idx is idx01 in fsas
-    int32_t fsa_idx01x = fsa_states_row_splits_data[state_idx];
-    // ans_idx3 is fsas_idx2, i.e. the arc idx in a state
-    int32_t ans_idx3 = idx0123 - ans_row_splits3_data[ans_idx012];
-    ans_values_data[idx0123] = fsa_idx01x + ans_idx3;
-  };
-  Eval(c, num_arcs, lambda_set_ans_values);
+  K2_EVAL(
+      c, num_arcs, lambda_set_ans_values, (int32_t idx0123) {
+        int32_t ans_idx012 = ans_row_ids3_data[idx0123];
+        int32_t state_idx =
+            batch_states_data[ans_idx012];  // state_idx is idx01 in fsas
+        int32_t fsa_idx01x = fsa_states_row_splits_data[state_idx];
+        // ans_idx3 is fsas_idx2, i.e. the arc idx in a state
+        int32_t ans_idx3 = idx0123 - ans_row_splits3_data[ans_idx012];
+        ans_values_data[idx0123] = fsa_idx01x + ans_idx3;
+      });
 
   return Ragged<int32_t>(ans_shape, ans_values);
 }
@@ -908,12 +912,13 @@ Ragged<int32_t> GetEnteringArcIndexBatches(FsaVec &fsas,
   const int32_t *incoming_arcs_row_splits_data =
       incoming_arcs.RowSplits(2).Data();
   const int32_t *batch_states_data = state_batches.values.Data();
-  auto lambda_set_ans_row_splits3 = [=] __host__ __device__(int32_t idx) {
-    int32_t state_idx = batch_states_data[idx];
-    ans_row_splits3_data[idx] = incoming_arcs_row_splits_data[state_idx + 1] -
-                                incoming_arcs_row_splits_data[state_idx];
-  };
-  Eval(c, num_states, lambda_set_ans_row_splits3);
+  K2_EVAL(
+      c, num_states, lambda_set_ans_row_splits3, (int32_t idx) {
+        int32_t state_idx = batch_states_data[idx];
+        ans_row_splits3_data[idx] =
+            incoming_arcs_row_splits_data[state_idx + 1] -
+            incoming_arcs_row_splits_data[state_idx];
+      });
   ExclusiveSum(ans_row_splits3, &ans_row_splits3);
   Array1<int32_t> ans_row_ids3(c, num_arcs);
   RowSplitsToRowIds(ans_row_splits3, &ans_row_ids3);
@@ -926,17 +931,18 @@ Ragged<int32_t> GetEnteringArcIndexBatches(FsaVec &fsas,
   int32_t *ans_values_data = ans_values.Data();
   const int32_t *ans_row_ids3_data = ans_row_ids3.Data();
   const int32_t *incoming_arcs_data = incoming_arcs.values.Data();
-  auto lambda_set_ans_values = [=] __host__ __device__(int32_t idx0123) {
-    int32_t ans_idx012 = ans_row_ids3_data[idx0123];
-    int32_t state_idx =
-        batch_states_data[ans_idx012];  // state_idx is idx01 in incoming_arcs
-    int32_t incoming_arcs_idx01x = incoming_arcs_row_splits_data[state_idx];
-    // ans_idx3 is incoming_arcs_idx2, i.e. the entering arc idx for a state
-    int32_t ans_idx3 = idx0123 - ans_row_splits3_data[ans_idx012];
-    int32_t incoming_arcs_idx012 = incoming_arcs_idx01x + ans_idx3;
-    ans_values_data[idx0123] = incoming_arcs_data[incoming_arcs_idx012];
-  };
-  Eval(c, num_arcs, lambda_set_ans_values);
+  K2_EVAL(
+      c, num_arcs, lambda_set_ans_values, (int32_t idx0123) {
+        int32_t ans_idx012 = ans_row_ids3_data[idx0123];
+        int32_t state_idx =
+            batch_states_data[ans_idx012];  // state_idx is idx01 in
+                                            // incoming_arcs
+        int32_t incoming_arcs_idx01x = incoming_arcs_row_splits_data[state_idx];
+        // ans_idx3 is incoming_arcs_idx2, i.e. the entering arc idx for a state
+        int32_t ans_idx3 = idx0123 - ans_row_splits3_data[ans_idx012];
+        int32_t incoming_arcs_idx012 = incoming_arcs_idx01x + ans_idx3;
+        ans_values_data[idx0123] = incoming_arcs_data[incoming_arcs_idx012];
+      });
 
   return Ragged<int32_t>(ans_shape, ans_values);
 }
@@ -973,53 +979,53 @@ FsaVec ConvertDenseToFsaVec(DenseFsaVec &src) {
 
   // 0 <= s < num_symbols; note, `num_symbols` excludes the final-symbol (-1).
   // note: `src` means: w.r.t. the numbering in the original DenseFsaVec.
-  auto lambda_set_arcs_etc = [=] __host__ __device__(int32_t src_state_idx01,
-                                                     int32_t s) -> void {
-    int32_t fsa_idx0 = src_row_ids1_data[src_state_idx01],
-            src_state_idx0x = src_row_splits1_data[fsa_idx0],
-            state_idx1 = src_state_idx01 - src_state_idx0x,
-            src_next_state_idx0x = src_row_splits1_data[fsa_idx0 + 1],
-            src_num_states1 = src_next_state_idx0x - src_state_idx0x,
-            ans_state_idx01 =
-                src_state_idx01 + fsa_idx0;  // we add one final-state per FSA..
+  K2_EVAL2(
+      c, src.shape.NumElements(), num_symbols, lambda_set_arcs_etc,
+      (int32_t src_state_idx01, int32_t s)->void {
+        int32_t fsa_idx0 = src_row_ids1_data[src_state_idx01],
+                src_state_idx0x = src_row_splits1_data[fsa_idx0],
+                state_idx1 = src_state_idx01 - src_state_idx0x,
+                src_next_state_idx0x = src_row_splits1_data[fsa_idx0 + 1],
+                src_num_states1 = src_next_state_idx0x - src_state_idx0x,
+                ans_state_idx01 = src_state_idx01 +
+                                  fsa_idx0;  // we add one final-state per FSA..
                                              // "+ fsa_idx0" gives the
                                              // difference from old->new
                                              // numbering.
 
-    // arc_idx0xx is the 1st arc-index of the FSA we are creating.. each source
-    // state has `num_symbols` arcs leaving it except the last one of each FSA,
-    // which has 1 arc leaving it (to the final-state).
-    int32_t arc_idx0xx =
-                (src_state_idx0x * num_symbols) - fsa_idx0 * (num_symbols - 1),
-            arc_idx01x = arc_idx0xx + (state_idx1 * num_symbols),
-            arc_idx012 = arc_idx01x + s;
-    int32_t symbol_offset;
-    if (state_idx1 + 1 == src_num_states1) {
-      symbol_offset = -1;
-      if (s > 0) return;  // we just need the arc with -1.
+        // arc_idx0xx is the 1st arc-index of the FSA we are creating.. each
+        // source state has `num_symbols` arcs leaving it except the last one of
+        // each FSA, which has 1 arc leaving it (to the final-state).
+        int32_t arc_idx0xx = (src_state_idx0x * num_symbols) -
+                             fsa_idx0 * (num_symbols - 1),
+                arc_idx01x = arc_idx0xx + (state_idx1 * num_symbols),
+                arc_idx012 = arc_idx01x + s;
+        int32_t symbol_offset;
+        if (state_idx1 + 1 == src_num_states1) {
+          symbol_offset = -1;
+          if (s > 0) return;  // we just need the arc with -1.
 
-      // if this is the state before the final state of this FSA. it has the
-      // responsibility to write the row_splits2 value for the final state.
-      // It's arc_idx012 + 1; the "+1" corresponds to the single arc with the
-      // final-symbol on it.
-      row_splits2_data[ans_state_idx01 + 1] = arc_idx012 + 1;
-    } else {
-      symbol_offset = 0;
-    }
-    // the "+ 1" is because index 0 in `scores` is for the final-symbol -1,
-    // then 0, 1, etc.
-    int32_t symbol_index_in_scores = s + symbol_offset + 1;
-    arcs_data[arc_idx012] =
-        Arc(state_idx1, state_idx1 + 1, s + symbol_offset,
-            scores_acc(src_state_idx01, symbol_index_in_scores));
-    row_ids2_data[arc_idx012] = ans_state_idx01;
-    if (s == 0) {  // 1st arc for this state.
-      row_splits2_data[ans_state_idx01] = arc_idx012;
-      K2_CHECK(row_ids1_data[ans_state_idx01] == fsa_idx0);
-      if (src_state_idx01 == 0) row_splits2_data[num_states] = num_arcs;
-    }
-  };
-  Eval2(c, src.shape.NumElements(), num_symbols, lambda_set_arcs_etc);
+          // if this is the state before the final state of this FSA. it has the
+          // responsibility to write the row_splits2 value for the final state.
+          // It's arc_idx012 + 1; the "+1" corresponds to the single arc with
+          // the final-symbol on it.
+          row_splits2_data[ans_state_idx01 + 1] = arc_idx012 + 1;
+        } else {
+          symbol_offset = 0;
+        }
+        // the "+ 1" is because index 0 in `scores` is for the final-symbol -1,
+        // then 0, 1, etc.
+        int32_t symbol_index_in_scores = s + symbol_offset + 1;
+        arcs_data[arc_idx012] =
+            Arc(state_idx1, state_idx1 + 1, s + symbol_offset,
+                scores_acc(src_state_idx01, symbol_index_in_scores));
+        row_ids2_data[arc_idx012] = ans_state_idx01;
+        if (s == 0) {  // 1st arc for this state.
+          row_splits2_data[ans_state_idx01] = arc_idx012;
+          K2_CHECK(row_ids1_data[ans_state_idx01] == fsa_idx0);
+          if (src_state_idx01 == 0) row_splits2_data[num_states] = num_arcs;
+        }
+      });
 
   RaggedShape state2arc = RaggedShape2(&row_splits2, &row_ids2, num_arcs);
   return Ragged<Arc>(ComposeRaggedShapes(fsa2state, state2arc), arcs);
@@ -1055,13 +1061,13 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
   FloatType *state_scores_data = state_scores.Data();
   // set the score of start state in each fsa to be 0
   const int32_t *fsa_row_splits1 = fsas.RowSplits(1).Data();
-  auto lambda_set_start_state_score = [=] __host__ __device__(int32_t fsa_idx) {
-    int32_t start_state = fsa_row_splits1[fsa_idx],
-            start_state_next_fsa = fsa_row_splits1[fsa_idx + 1];
-    if (start_state_next_fsa - start_state > 0)
-      state_scores_data[start_state] = 0;
-  };
-  Eval(c, num_fsas, lambda_set_start_state_score);
+  K2_EVAL(
+      c, num_fsas, lambda_set_start_state_score, (int32_t fsa_idx) {
+        int32_t start_state = fsa_row_splits1[fsa_idx],
+                start_state_next_fsa = fsa_row_splits1[fsa_idx + 1];
+        if (start_state_next_fsa - start_state > 0)
+          state_scores_data[start_state] = 0;
+      });
 
   // get the 1st entering arc index in each batch, +1 so we can get the number
   // of entering arcs in each batch by taking the difference of adjacent
@@ -1074,20 +1080,20 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
       entering_arc_batches.RowSplits(2).Data();
   const int32_t *arc_batches_row_splits3 =
       entering_arc_batches.RowSplits(3).Data();
-  auto lambda_set_entering_arc_start_index = [=] __host__ __device__(
-                                                 int32_t batch_idx) {
-    int32_t this_state_idx0xx = arc_batches_row_splits2[batch_idx * num_fsas];
-    int32_t this_arc_idx0xxx = arc_batches_row_splits3[this_state_idx0xx];
-    entering_arc_start_index_data[batch_idx] = this_arc_idx0xxx;
-    if (batch_idx == num_batches - 1) {
-      // process the last element
-      int32_t next_state_idx0xx =
-          arc_batches_row_splits2[num_batches * num_fsas];
-      int32_t next_arc_idx0xxx = arc_batches_row_splits3[next_state_idx0xx];
-      entering_arc_start_index_data[num_batches] = next_arc_idx0xxx;
-    }
-  };
-  Eval(c, num_batches, lambda_set_entering_arc_start_index);
+  K2_EVAL(
+      c, num_batches, lambda_set_entering_arc_start_index, (int32_t batch_idx) {
+        int32_t this_state_idx0xx =
+            arc_batches_row_splits2[batch_idx * num_fsas];
+        int32_t this_arc_idx0xxx = arc_batches_row_splits3[this_state_idx0xx];
+        entering_arc_start_index_data[batch_idx] = this_arc_idx0xxx;
+        if (batch_idx == num_batches - 1) {
+          // process the last element
+          int32_t next_state_idx0xx =
+              arc_batches_row_splits2[num_batches * num_fsas];
+          int32_t next_arc_idx0xxx = arc_batches_row_splits3[next_state_idx0xx];
+          entering_arc_start_index_data[num_batches] = next_arc_idx0xxx;
+        }
+      });
 
   const int32_t *arc_batches_row_ids1 = entering_arc_batches.RowIds(1).Data();
   const int32_t *arc_batches_row_ids2 = entering_arc_batches.RowIds(2).Data();
@@ -1142,36 +1148,37 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
       // get entering arc scores
       {
         With w(pr.NewStream());
-        auto lambda_set_entering_arc_score = [=] __host__ __device__(
-                                                 int32_t idx123) {
-          // all idx** in below code are the indexes to entering_arc_batches
-          int32_t idx0123 = entering_arc_start_index_data[i] + idx123;
-          int32_t idx012 = arc_batches_row_ids3[idx0123];
-          int32_t idx01 = arc_batches_row_ids2[idx012];
-          K2_CHECK_EQ(idx01 / num_fsas, i);  // idx01/num_fsas is batch_id
-          int32_t fsa_id = idx01 % num_fsas;
+        K2_EVAL(
+            c, num_arcs_this_batch, lambda_set_entering_arc_score,
+            (int32_t idx123) {
+              // all idx** in below code are the indexes to entering_arc_batches
+              int32_t idx0123 = entering_arc_start_index_data[i] + idx123;
+              int32_t idx012 = arc_batches_row_ids3[idx0123];
+              int32_t idx01 = arc_batches_row_ids2[idx012];
+              K2_CHECK_EQ(idx01 / num_fsas, i);  // idx01/num_fsas is batch_id
+              int32_t fsa_id = idx01 % num_fsas;
 
-          int32_t entering_arc_id = entering_arc_ids[idx0123];
-          float curr_arc_score = arcs[entering_arc_id].score;
-          int32_t src_state_idx1 = arcs[entering_arc_id].src_state;
-          int32_t src_state_idx01 = fsa_row_splits1[fsa_id] + src_state_idx1;
-          arc_scores_data[idx0123] =
-              state_scores_data[src_state_idx01] + curr_arc_score;
-        };
-        Eval(c, num_arcs_this_batch, lambda_set_entering_arc_score);
+              int32_t entering_arc_id = entering_arc_ids[idx0123];
+              float curr_arc_score = arcs[entering_arc_id].score;
+              int32_t src_state_idx1 = arcs[entering_arc_id].src_state;
+              int32_t src_state_idx01 =
+                  fsa_row_splits1[fsa_id] + src_state_idx1;
+              arc_scores_data[idx0123] =
+                  state_scores_data[src_state_idx01] + curr_arc_score;
+            });
       }
       {
         With w(pr.NewStream());
         // make entering arc row splits info in each batch starting from zero,
         // we will use it to call MaxPerSublist or LogSumPerSubList
         int32_t *sum_splits_data = arc_row_splits_part.Data();
-        auto lambda_set_row_splits_for_sum =
-            [=] __host__ __device__(int32_t idx) {
+        K2_EVAL(
+            c, num_states_this_batch + 1, lambda_set_row_splits_for_sum,
+            (int32_t idx) {
               sum_splits_data[idx] =
                   arc_batches_row_splits3[idx + this_state_idx0xx] -
                   arc_batches_row_splits3[this_state_idx0xx];
-            };
-        Eval(c, num_states_this_batch + 1, lambda_set_row_splits_for_sum);
+            });
       }
     }
     int32_t this_arc_idx0xxx = cpu_entering_arc_start[i];
@@ -1197,22 +1204,23 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
                           entering_arc_ids + this_arc_idx0xxx;
         // arc_idx01 below is an index into sub_scores, it is also an arc_idx123
         // into entering_arc_batches.
-        auto lambda_set_entering_arcs = [=] __host__ __device__(
-                                            int32_t arc_idx01) {
-          // state_idx0 below is idx0 into `sub_scores`, also an index into
-          // `sub_scores`.
-          int32_t state_idx0 = sub_scores_row_ids_data[arc_idx01];
-          if (sub_scores_data[arc_idx01] == sub_state_scores_data[state_idx0]) {
-            int32_t fsas_state_idx01 = sub_state_ids_data[state_idx0],
-                    fsas_entering_arc_idx012 =
-                        sub_entering_arc_ids_data[arc_idx01];
-            // The following statement has a race condition if there is a
-            // tie on scores, but this is OK and by design.  It makes the choice
-            // of traceback non-deterministic in these cases.
-            entering_arcs_data[fsas_state_idx01] = fsas_entering_arc_idx012;
-          }
-        };
-        Eval(c, sub_scores.NumElements(), lambda_set_entering_arcs);
+        K2_EVAL(
+            c, sub_scores.NumElements(), lambda_set_entering_arcs,
+            (int32_t arc_idx01) {
+              // state_idx0 below is idx0 into `sub_scores`, also an index into
+              // `sub_scores`.
+              int32_t state_idx0 = sub_scores_row_ids_data[arc_idx01];
+              if (sub_scores_data[arc_idx01] ==
+                  sub_state_scores_data[state_idx0]) {
+                int32_t fsas_state_idx01 = sub_state_ids_data[state_idx0],
+                        fsas_entering_arc_idx012 =
+                            sub_entering_arc_ids_data[arc_idx01];
+                // The following statement has a race condition if there is a
+                // tie on scores, but this is OK and by design.  It makes the
+                // choice of traceback non-deterministic in these cases.
+                entering_arcs_data[fsas_state_idx01] = fsas_entering_arc_idx012;
+              }
+            });
       }
     }
     const FloatType *sub_state_scores_data = sub_state_scores.Data();
@@ -1220,8 +1228,9 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
     // `state_idx12` is an idx12 w.r.t. state_batches and entering_arc_batches,
     // but an idx1 w.r.t. sub_scores and an index into the array
     // sub_state_scores.
-    auto lambda_copy_state_scores =
-        [=] __host__ __device__(int32_t state_idx12) {
+    K2_EVAL(
+        c, num_states_this_batch, lambda_copy_state_scores,
+        (int32_t state_idx12) {
           int32_t batches_idx012 = this_state_idx0xx + state_idx12;
           int32_t fsas_state_idx01 = states_data[batches_idx012];
           int32_t batches_idx01 = arc_batches_row_ids2[batches_idx012];
@@ -1231,8 +1240,7 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
           if (fsas_state_idx01 != start_state_idx01)
             state_scores_data[fsas_state_idx01] =
                 sub_state_scores_data[state_idx12];
-        };
-    Eval(c, num_states_this_batch, lambda_copy_state_scores);
+        });
   }
 
   return state_scores;
@@ -1271,8 +1279,8 @@ Array1<FloatType> GetBackwardScores(
     K2_CHECK_EQ(tot_scores->Dim(), num_fsas);
     const FloatType *tot_scores_data = tot_scores->Data();
     // set the score of final state in fsa i to be negative of tot_scores[i]
-    auto lambda_set_final_state_score =
-        [=] __host__ __device__(int32_t fsa_idx) {
+    K2_EVAL(
+        c, num_fsas, lambda_set_final_state_score, (int32_t fsa_idx) {
           int32_t start_state = fsa_row_splits1[fsa_idx],
                   start_state_next_fsa = fsa_row_splits1[fsa_idx + 1];
           if (start_state_next_fsa - start_state > 0) {
@@ -1286,18 +1294,16 @@ Array1<FloatType> GetBackwardScores(
               state_scores_data[start_state_next_fsa - 1] = negative_infinity;
             }
           }
-        };
-    Eval(c, num_fsas, lambda_set_final_state_score);
+        });
   } else {
     // set the score of final state in each fsa to be 0
-    auto lambda_set_final_state_score =
-        [=] __host__ __device__(int32_t fsa_idx) {
+    K2_EVAL(
+        c, num_fsas, lambda_set_final_state_score, (int32_t fsa_idx) {
           int32_t start_state = fsa_row_splits1[fsa_idx],
                   start_state_next_fsa = fsa_row_splits1[fsa_idx + 1];
           if (start_state_next_fsa - start_state > 0)
             state_scores_data[start_state_next_fsa - 1] = 0;
-        };
-    Eval(c, num_fsas, lambda_set_final_state_score);
+        });
   }
 
   // get the 1st leaving arc index in each batch, +1 so we can get the number of
@@ -1310,20 +1316,20 @@ Array1<FloatType> GetBackwardScores(
       leaving_arc_batches.RowSplits(2).Data();
   const int32_t *arc_batches_row_splits3 =
       leaving_arc_batches.RowSplits(3).Data();
-  auto lambda_set_leaving_arc_start_index = [=] __host__ __device__(
-                                                int32_t batch_idx) {
-    int32_t this_state_idx0xx = arc_batches_row_splits2[batch_idx * num_fsas];
-    int32_t this_arc_idx0xxx = arc_batches_row_splits3[this_state_idx0xx];
-    leaving_arc_start_index_data[batch_idx] = this_arc_idx0xxx;
-    if (batch_idx == num_batches - 1) {
-      // process the last element
-      int32_t next_state_idx0xx =
-          arc_batches_row_splits2[num_batches * num_fsas];
-      int32_t next_arc_idx0xxx = arc_batches_row_splits3[next_state_idx0xx];
-      leaving_arc_start_index_data[num_batches] = next_arc_idx0xxx;
-    }
-  };
-  Eval(c, num_batches, lambda_set_leaving_arc_start_index);
+  K2_EVAL(
+      c, num_batches, lambda_set_leaving_arc_start_index, (int32_t batch_idx) {
+        int32_t this_state_idx0xx =
+            arc_batches_row_splits2[batch_idx * num_fsas];
+        int32_t this_arc_idx0xxx = arc_batches_row_splits3[this_state_idx0xx];
+        leaving_arc_start_index_data[batch_idx] = this_arc_idx0xxx;
+        if (batch_idx == num_batches - 1) {
+          // process the last element
+          int32_t next_state_idx0xx =
+              arc_batches_row_splits2[num_batches * num_fsas];
+          int32_t next_arc_idx0xxx = arc_batches_row_splits3[next_state_idx0xx];
+          leaving_arc_start_index_data[num_batches] = next_arc_idx0xxx;
+        }
+      });
 
   const int32_t *arc_batches_row_ids1 = leaving_arc_batches.RowIds(1).Data();
   const int32_t *arc_batches_row_ids2 = leaving_arc_batches.RowIds(2).Data();
@@ -1372,36 +1378,37 @@ Array1<FloatType> GetBackwardScores(
       // get leaving arc scores
       {
         With w(pr.NewStream());
-        auto lambda_set_leaving_arc_score = [=] __host__ __device__(
-                                                int32_t idx123) {
-          // all idx** in below code are the indexes to leaving_arc_batches
-          int32_t idx0123 = leaving_arc_start_index_data[i] + idx123;
-          int32_t idx012 = arc_batches_row_ids3[idx0123];
-          int32_t idx01 = arc_batches_row_ids2[idx012];
-          K2_CHECK_EQ(idx01 / num_fsas, i);  // idx01/num_fsas is batch_id
-          int32_t fsa_id = idx01 % num_fsas;
+        K2_EVAL(
+            c, num_arcs_this_batch, lambda_set_leaving_arc_score,
+            (int32_t idx123) {
+              // all idx** in below code are the indexes to leaving_arc_batches
+              int32_t idx0123 = leaving_arc_start_index_data[i] + idx123;
+              int32_t idx012 = arc_batches_row_ids3[idx0123];
+              int32_t idx01 = arc_batches_row_ids2[idx012];
+              K2_CHECK_EQ(idx01 / num_fsas, i);  // idx01/num_fsas is batch_id
+              int32_t fsa_id = idx01 % num_fsas;
 
-          int32_t leaving_arc_id = leaving_arc_ids[idx0123];
-          float curr_arc_score = arcs[leaving_arc_id].score;
-          int32_t dest_state_idx1 = arcs[leaving_arc_id].dest_state;
-          int32_t dest_state_idx01 = fsa_row_splits1[fsa_id] + dest_state_idx1;
-          arc_scores_data[idx0123] =
-              state_scores_data[dest_state_idx01] + curr_arc_score;
-        };
-        Eval(c, num_arcs_this_batch, lambda_set_leaving_arc_score);
+              int32_t leaving_arc_id = leaving_arc_ids[idx0123];
+              float curr_arc_score = arcs[leaving_arc_id].score;
+              int32_t dest_state_idx1 = arcs[leaving_arc_id].dest_state;
+              int32_t dest_state_idx01 =
+                  fsa_row_splits1[fsa_id] + dest_state_idx1;
+              arc_scores_data[idx0123] =
+                  state_scores_data[dest_state_idx01] + curr_arc_score;
+            });
       }
       {
         With w(pr.NewStream());
         // make leaving arc row splits info in each batch starting from zero,
         // we will use it to call MaxPerSublist or LogSumPerSubList
         int32_t *sum_splits_data = arc_row_splits_part.Data();
-        auto lambda_set_row_splits_for_sum =
-            [=] __host__ __device__(int32_t idx) {
+        K2_EVAL(
+            c, num_states_this_batch + 1, lambda_set_row_splits_for_sum,
+            (int32_t idx) {
               sum_splits_data[idx] =
                   arc_batches_row_splits3[idx + this_state_idx0xx] -
                   arc_batches_row_splits3[this_state_idx0xx];
-            };
-        Eval(c, num_states_this_batch + 1, lambda_set_row_splits_for_sum);
+            });
       }
     }
     int32_t this_arc_idx0xxx = cpu_leaving_arc_start[i];
@@ -1420,21 +1427,21 @@ Array1<FloatType> GetBackwardScores(
       MaxPerSublist(sub_scores, negative_infinity, &sub_state_scores);
     const FloatType *sub_state_scores_data = sub_state_scores.Data();
     // copy those scores to corresponding state in state_scores
-    auto lambda_copy_state_scores = [=] __host__ __device__(int32_t idx2) {
-      int32_t idx012 = this_state_idx0xx + idx2;
-      int32_t state_idx012 = states_data[idx012];
-      int32_t idx01 = arc_batches_row_ids2[idx012];
-      int32_t fsa_id = idx01 % num_fsas;
-      int32_t start_state = fsa_row_splits1[fsa_id],
-              start_state_next_fsa = fsa_row_splits1[fsa_id + 1];
-      if (start_state_next_fsa - start_state > 0) {  // non-empty fsa
-        int32_t final_state_idx = start_state_next_fsa - 1;
-        // don't override score in the final state in each fsa.
-        if (state_idx012 != final_state_idx)
-          state_scores_data[state_idx012] = sub_state_scores_data[idx2];
-      }
-    };
-    Eval(c, num_states_this_batch, lambda_copy_state_scores);
+    K2_EVAL(
+        c, num_states_this_batch, lambda_copy_state_scores, (int32_t idx2) {
+          int32_t idx012 = this_state_idx0xx + idx2;
+          int32_t state_idx012 = states_data[idx012];
+          int32_t idx01 = arc_batches_row_ids2[idx012];
+          int32_t fsa_id = idx01 % num_fsas;
+          int32_t start_state = fsa_row_splits1[fsa_id],
+                  start_state_next_fsa = fsa_row_splits1[fsa_id + 1];
+          if (start_state_next_fsa - start_state > 0) {  // non-empty fsa
+            int32_t final_state_idx = start_state_next_fsa - 1;
+            // don't override score in the final state in each fsa.
+            if (state_idx012 != final_state_idx)
+              state_scores_data[state_idx012] = sub_state_scores_data[idx2];
+          }
+        });
   }
 
   return state_scores;
@@ -1456,15 +1463,15 @@ Array1<FloatType> GetTotScores(FsaVec &fsas,
 
   const int32_t *fsa_row_splits1 = fsas.RowSplits(1).Data();
   const FloatType *forward_scores_data = forward_scores.Data();
-  auto lambda_copy_tot_scores = [=] __host__ __device__(int32_t fsa_idx) {
-    int32_t start_state = fsa_row_splits1[fsa_idx],
-            start_state_next_fsa = fsa_row_splits1[fsa_idx + 1];
-    if (start_state_next_fsa > start_state) {  // non-empty fsa
-      int32_t final_state_idx = start_state_next_fsa - 1;
-      tot_scores_data[fsa_idx] = forward_scores_data[final_state_idx];
-    }
-  };
-  Eval(c, num_fsas, lambda_copy_tot_scores);
+  K2_EVAL(
+      c, num_fsas, lambda_copy_tot_scores, (int32_t fsa_idx) {
+        int32_t start_state = fsa_row_splits1[fsa_idx],
+                start_state_next_fsa = fsa_row_splits1[fsa_idx + 1];
+        if (start_state_next_fsa > start_state) {  // non-empty fsa
+          int32_t final_state_idx = start_state_next_fsa - 1;
+          tot_scores_data[fsa_idx] = forward_scores_data[final_state_idx];
+        }
+      });
 
   return tot_scores;
 }
@@ -1492,21 +1499,21 @@ Array1<FloatType> GetArcScores(FsaVec &fsas,
   const Arc *arcs = fsas.values.Data();
   const FloatType *forward_scores_data = forward_scores.Data();
   const FloatType *backward_scores_data = backward_scores.Data();
-  auto lambda_get_arc_scores = [=] __host__ __device__(int32_t arc_idx012) {
-    int32_t src_state_idx1 = arcs[arc_idx012].src_state;
-    int32_t dest_state_idx1 = arcs[arc_idx012].dest_state;
-    float arc_score = arcs[arc_idx012].score;
+  K2_EVAL(
+      c, num_arcs, lambda_get_arc_scores, (int32_t arc_idx012) {
+        int32_t src_state_idx1 = arcs[arc_idx012].src_state;
+        int32_t dest_state_idx1 = arcs[arc_idx012].dest_state;
+        float arc_score = arcs[arc_idx012].score;
 
-    int32_t idx01 = fsa_row_ids2[arc_idx012];
-    int32_t idx0 = fsa_row_ids1[idx01];
-    int32_t idx0x = fsa_row_splits1[idx0];
-    int32_t src_state_idx01 = idx0x + src_state_idx1;
-    int32_t dest_state_idx01 = idx0x + dest_state_idx1;
-    arc_scores_data[arc_idx012] = arc_score +
-                                  forward_scores_data[src_state_idx01] +
-                                  backward_scores_data[dest_state_idx01];
-  };
-  Eval(c, num_arcs, lambda_get_arc_scores);
+        int32_t idx01 = fsa_row_ids2[arc_idx012];
+        int32_t idx0 = fsa_row_ids1[idx01];
+        int32_t idx0x = fsa_row_splits1[idx0];
+        int32_t src_state_idx01 = idx0x + src_state_idx1;
+        int32_t dest_state_idx01 = idx0x + dest_state_idx1;
+        arc_scores_data[arc_idx012] = arc_score +
+                                      forward_scores_data[src_state_idx01] +
+                                      backward_scores_data[dest_state_idx01];
+      });
 
   return arc_scores;
 }
@@ -1667,27 +1674,25 @@ Ragged<int32_t> GetStartStates(FsaVec &src) {
   // will first set the elements of ans_row_splits to the number of states kept
   // from this FSA (either 0 or 1).
   int32_t *num_states_data = ans_row_splits.Data();
-  auto lambda_set_num_states =
-      [=] __host__ __device__(int32_t fsa_idx0) -> void {
-    // 1 if the FSA is not empty, 0 if empty.
-    num_states_data[fsa_idx0] =
-        (src_row_splits1_data[fsa_idx0 + 1] > src_row_splits1_data[fsa_idx0]);
-  };
-  Eval(c, num_fsas, lambda_set_num_states);
+  K2_EVAL(
+      c, num_fsas, lambda_set_num_states, (int32_t fsa_idx0)->void {
+        // 1 if the FSA is not empty, 0 if empty.
+        num_states_data[fsa_idx0] = (src_row_splits1_data[fsa_idx0 + 1] >
+                                     src_row_splits1_data[fsa_idx0]);
+      });
   ExclusiveSum(ans_row_splits, &ans_row_splits);
   int32_t ans_dim = ans_row_splits.Back();
   Ragged<int32_t> ans(RaggedShape2(&ans_row_splits, nullptr, ans_dim),
                       Array1<int32_t>(c, ans_dim));
   const int32_t *ans_row_ids1_data = ans.shape.RowIds(1).Data();
   int32_t *ans_values_data = ans.values.Data();
-  auto lambda_set_ans_values =
-      [=] __host__ __device__(int32_t ans_idx01) -> void {
-    int32_t idx0 = ans_row_ids1_data[ans_idx01];
-    int32_t src_start_state_idx01 = src_row_splits1_data[idx0];
-    K2_CHECK_GT(src_row_splits1_data[idx0 + 1], src_row_splits1_data[idx0]);
-    ans_values_data[ans_idx01] = src_start_state_idx01;
-  };
-  Eval(c, ans_dim, lambda_set_ans_values);
+  K2_EVAL(
+      c, ans_dim, lambda_set_ans_values, (int32_t ans_idx01)->void {
+        int32_t idx0 = ans_row_ids1_data[ans_idx01];
+        int32_t src_start_state_idx01 = src_row_splits1_data[idx0];
+        K2_CHECK_GT(src_row_splits1_data[idx0 + 1], src_row_splits1_data[idx0]);
+        ans_values_data[ans_idx01] = src_start_state_idx01;
+      });
   return ans;
 }
 
@@ -1724,32 +1729,33 @@ FsaVec FsaVecFromArcIndexes(FsaVec &fsas, Ragged<int32_t> &best_arc_indexes) {
   const int32_t *best_arc_indexes_data = best_arc_indexes.values.Data();
   const Arc *fsas_values_data = fsas.values.Data();
 
-  auto lambda_set_arcs = [=] __host__ __device__(int32_t best_arc_idx01) {
-    int32_t fsas_idx0 = best_arc_indexes_row_ids1_data[best_arc_idx01];
-    int32_t best_arc_idx0x = best_arc_indexes_row_splits1_data[fsas_idx0];
-    int32_t best_arc_idx0x_next =
-        best_arc_indexes_row_splits1_data[fsas_idx0 + 1];
-    int32_t num_best_arcs = best_arc_idx0x_next - best_arc_idx0x;
-    int32_t best_arc_idx1 = best_arc_idx01 - best_arc_idx0x;
+  K2_EVAL(
+      context, num_arcs, lambda_set_arcs, (int32_t best_arc_idx01) {
+        int32_t fsas_idx0 = best_arc_indexes_row_ids1_data[best_arc_idx01];
+        int32_t best_arc_idx0x = best_arc_indexes_row_splits1_data[fsas_idx0];
+        int32_t best_arc_idx0x_next =
+            best_arc_indexes_row_splits1_data[fsas_idx0 + 1];
+        int32_t num_best_arcs = best_arc_idx0x_next - best_arc_idx0x;
+        int32_t best_arc_idx1 = best_arc_idx01 - best_arc_idx0x;
 
-    int32_t state_offset = states_shape_row_splits1_data[fsas_idx0];
+        int32_t state_offset = states_shape_row_splits1_data[fsas_idx0];
 
-    const Arc &arc = fsas_values_data[best_arc_indexes_data[best_arc_idx01]];
-    int32_t src_state = best_arc_idx1;
-    int32_t dest_state = src_state + 1;
-    int32_t label = arc.label;
-    float score = arc.score;
-    arcs_data[best_arc_idx01] = Arc(src_state, dest_state, label, score);
+        const Arc &arc =
+            fsas_values_data[best_arc_indexes_data[best_arc_idx01]];
+        int32_t src_state = best_arc_idx1;
+        int32_t dest_state = src_state + 1;
+        int32_t label = arc.label;
+        float score = arc.score;
+        arcs_data[best_arc_idx01] = Arc(src_state, dest_state, label, score);
 
-    int32_t state_idx01 = state_offset + src_state;
-    row_ids2_data[best_arc_idx01] = state_idx01;
-    row_splits2_data[state_idx01 + 1] = best_arc_idx01 + 1;
-    if (best_arc_idx01 == 0) row_splits2_data[0] = 0;
+        int32_t state_idx01 = state_offset + src_state;
+        row_ids2_data[best_arc_idx01] = state_idx01;
+        row_splits2_data[state_idx01 + 1] = best_arc_idx01 + 1;
+        if (best_arc_idx01 == 0) row_splits2_data[0] = 0;
 
-    if (best_arc_idx1 + 1 == num_best_arcs)
-      row_splits2_data[state_idx01 + 2] = best_arc_idx01 + 1;
-  };
-  Eval(context, num_arcs, lambda_set_arcs);
+        if (best_arc_idx1 + 1 == num_best_arcs)
+          row_splits2_data[state_idx01 + 2] = best_arc_idx01 + 1;
+      });
   RaggedShape shape =
       RaggedShape3(&states_shape.RowSplits(1), &states_shape.RowIds(1),
                    num_states, &row_splits2, &row_ids2, num_arcs);

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -785,13 +785,16 @@ Ragged<int32_t> GetStateBatches(FsaVec &fsas, bool transpose) {
         int32_t idx0 = ans_row_ids1_data[idx01],  // Fsa index
             idx0x = ans_row_splits1_data[idx0], idx1 = idx01 - idx0x,
                 fsas_idx0x =
-                    fsas_row_splits1_data[idx0],  // 1st state-idx (idx01)
+                    fsas_row_splits1_data[idx0];  // 1st state-idx (idx01)
                                                   // in fsas_, for this FSA
-            fsas_idx01 = fsas_idx0x + idx1,       // the idx1 is actually the
-                                                  // batch-index, this statement
-            // reflects the 'un-consolidated'
-            // format of `batch_starts`.
-            this_batch_start = batch_starts_data[fsas_idx01];
+
+        int32_t fsas_idx01 =
+            fsas_idx0x + idx1;  // the idx1 is actually the
+                                // batch-index, this statement
+                                // reflects the 'un-consolidated'
+                                // format of `batch_starts`.
+
+        int32_t this_batch_start = batch_starts_data[fsas_idx01];
         ans_row_splits2_data[idx01] = this_batch_start;
       });
 
@@ -1768,6 +1771,5 @@ FsaVec GetIncomingFsaVec(FsaVec &fsas) {
   Ragged<int32_t> arc_indexes = GetIncomingArcs(fsas, dest_states);
   return FsaVec(arc_indexes.shape, fsas.values[arc_indexes.values]);
 }
-
 
 }  // namespace k2

--- a/k2/csrc/host_shim.cu
+++ b/k2/csrc/host_shim.cu
@@ -322,15 +322,15 @@ Array1<FloatType> GetBackwardScores(
     K2_CHECK_EQ(tot_scores->Context()->GetDeviceType(), kCpu);
     K2_CHECK_EQ(tot_scores->Dim(), num_fsas);
     const FloatType *tot_scores_data = tot_scores->Data();
-    auto lambda_add_tot_scores = [=] __host__ __device__(int32_t state_idx01) {
-      int32_t fsa_idx0 = fsa_row_ids1[state_idx01];
-      if (tot_scores_data[fsa_idx0] != negative_infinity) {
-        state_scores_data[state_idx01] -= tot_scores_data[fsa_idx0];
-      } else {
-        state_scores_data[state_idx01] = negative_infinity;
-      }
-    };
-    Eval(c, num_states, lambda_add_tot_scores);
+    K2_EVAL(
+        c, num_states, lambda_add_tot_scores, (int32_t state_idx01) {
+          int32_t fsa_idx0 = fsa_row_ids1[state_idx01];
+          if (tot_scores_data[fsa_idx0] != negative_infinity) {
+            state_scores_data[state_idx01] -= tot_scores_data[fsa_idx0];
+          } else {
+            state_scores_data[state_idx01] = negative_infinity;
+          }
+        });
   }
 
   return state_scores.AsType<FloatType>();

--- a/k2/csrc/intersect.cu
+++ b/k2/csrc/intersect.cu
@@ -15,6 +15,7 @@
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/fsa_algo.h"
 #include "k2/csrc/fsa_utils.h"
+#include "k2/csrc/macros.h"
 #include "k2/csrc/ragged_ops.h"
 
 namespace k2 {
@@ -44,8 +45,6 @@ struct StateInfo {
   */
   float backward_loglike;
 };
-
-
 
 /*
 static std::ostream &operator<<(std::ostream &os, const StateInfo &s) {
@@ -100,12 +99,9 @@ class MultiGraphDenseIntersect {
                            not on a path within `output_beam` of the best path
                            will not be retained.
    */
-  MultiGraphDenseIntersect(FsaVec &a_fsas,
-                           DenseFsaVec &b_fsas,
+  MultiGraphDenseIntersect(FsaVec &a_fsas, DenseFsaVec &b_fsas,
                            float output_beam)
-      : a_fsas_(a_fsas),
-        b_fsas_(b_fsas),
-        output_beam_(output_beam) {
+      : a_fsas_(a_fsas), b_fsas_(b_fsas), output_beam_(output_beam) {
     NVTX_RANGE(__func__);
     c_ = GetContext(a_fsas.shape, b_fsas.shape);
 
@@ -125,44 +121,46 @@ class MultiGraphDenseIntersect {
     RaggedShape combined_shape;
     {
       int32_t axis = 1, num_srcs = 2;
-      RaggedShape *vec[2] = { &a_fsas_.shape, &incoming_arcs_.shape };
+      RaggedShape *vec[2] = {&a_fsas_.shape, &incoming_arcs_.shape};
       combined_shape = Append(axis, num_srcs, vec);
     }
 
     int32_t num_arcs = a_fsas_.NumElements();
     // arc_scores_ will be used for backward and forward computations
     // simultaneously.
-    arc_scores_ = Ragged<float>(combined_shape,
-                                Array1<float>(c_, num_arcs * 2));
+    arc_scores_ =
+        Ragged<float>(combined_shape, Array1<float>(c_, num_arcs * 2));
 
     // set up fsa_info_
     InitFsaInfo();
 
     int32_t num_seqs = b_fsas.shape.Dim0();
 
-    { // check that b_fsas are in order of decreasing length.
+    {  // check that b_fsas are in order of decreasing length.
       Array1<int32_t> r = b_fsas.shape.RowSplits(1).To(GetCpuContext());
       int32_t *r_data = r.Data();
       int32_t prev_t = r_data[1] - r_data[0];
       for (int32_t i = 1; i + 1 < r.Dim(); i++) {
-        int32_t this_t = r_data[i+1] - r_data[i];
+        int32_t this_t = r_data[i + 1] - r_data[i];
         if (this_t > prev_t)
           K2_LOG(FATAL) << "Sequences (DenseFsaVec) must be in sorted "
-              "order from greatest to least length.";
+                           "order from greatest to least length.";
         prev_t = this_t;
       }
       T_ = r_data[1] - r_data[0];  // longest first, so T_ is the length of the
                                    // longest sequence.
     }
 
-    // set up steps_, which contains a bunch of meta-information about the steps of the algorithm.
+    // set up steps_, which contains a bunch of meta-information about the steps
+    // of the algorithm.
     InitSteps();
 
     int32_t num_states = a_fsas_.TotSize(1);
     // this is the largest array size we'll be dealing with.
-    size_t product = ((size_t)(T_+1) * (size_t)num_states);
-    K2_CHECK_EQ((1+product), (size_t)(int32_t)(1+product)) <<
-        "Problem size is too large for this algorithm; try reducing minibatch size.";
+    size_t product = ((size_t)(T_ + 1) * (size_t)num_states);
+    K2_CHECK_EQ((1 + product), (size_t)(int32_t)(1 + product))
+        << "Problem size is too large for this algorithm; try reducing "
+           "minibatch size.";
   }
 
   /* Does the main work of intersection/composition, but doesn't produce any
@@ -170,24 +168,24 @@ class MultiGraphDenseIntersect {
   void Intersect() {
     NVTX_RANGE(__func__);
     DoStep0();
-    for (int32_t t = 1; t <= T_; t++)
-      DoStep(t);
+    for (int32_t t = 1; t <= T_; t++) DoStep(t);
   }
   /*
-    Does pruning and returns a ragged array indexed [fsa][state][arc], containing
-    the result of intersection.
+    Does pruning and returns a ragged array indexed [fsa][state][arc],
+    containing the result of intersection.
 
-         @param [out] arc_map_a_out  If non-NULL, the map from (arc-index of returned
-                                  FsaVec) to (arc-index in a_fsas_) will be written
-                                  to here.
-         @param [out] arc_map_b_out  If non-NULL, the map from (arc-index of returned
-                                     FsaVec) to (offset into b_fsas_.scores.Data())
+         @param [out] arc_map_a_out  If non-NULL, the map from (arc-index of
+                                     returned FsaVec) to (arc-index in a_fsas_)
                                      will be written to here.
-         @return  Returns a FsaVec that is the composed result.  Note: due to roundoff,
-                      it may possibly contain states and/or arcs that are not
-                      accessible or not co-accessible.  It will be top-sorted,
-                      and deterministic and arc-sorted if the input a_fsas_
-                      had those properties.
+         @param [out] arc_map_b_out  If non-NULL, the map from (arc-index of
+                                     FsaVec) to (offset into
+                                     b_fsas_.scores.Data()) will be written to
+                                     here.
+         @return  Returns a FsaVec that is the composed result.  Note: due to
+                  roundoff, it may possibly contain states and/or arcs that are
+                  not accessible or not co-accessible.  It will be top-sorted,
+                  and deterministic and arc-sorted if the input a_fsas_ had
+                  those properties.
    */
   FsaVec FormatOutput(Array1<int32_t> *arc_map_a_out,
                       Array1<int32_t> *arc_map_b_out) {
@@ -195,7 +193,7 @@ class MultiGraphDenseIntersect {
     Array1<float> score_cutoffs = GetScoreCutoffs();
     float *score_cutoffs_data = score_cutoffs.Data();
     int32_t num_states = a_fsas_.TotSize(1);
-    int32_t product = ((size_t)(T_+1) * (size_t)num_states);
+    int32_t product = ((size_t)(T_ + 1) * (size_t)num_states);
 
     // We'll do exclusive-sum on the following array, after setting its elements
     // to 1 if the corresponding state was not pruned away.  The order of
@@ -213,37 +211,38 @@ class MultiGraphDenseIntersect {
     FsaInfo *fsa_info_data = fsa_info_.Data();
     float **state_scores_data = state_scores_.Data();
 
-    // the following lambda will set elements within `keep_state_data` to 0 or 1.
-    auto lambda_set_keep = [=] __host__ __device__ (int32_t i) -> void {
-      // i is actually an idx012 of a state.
+    // the following lambda will set elements within `keep_state_data` to 0
+    // or 1.
+    K2_EVAL(
+        c_, product, lambda_set_keep, (int32_t i)->void {
+          // i is actually an idx012 of a state.
 
-      // the following works because each FSA has (its num-states * T_+1) states
-      // allocated to it.  However (i / (T_+1)) does not directly map to a state
-      // index.
-      int32_t fsa_idx0 = a_fsas_row_ids1_data[(i / (T+1))];
-      FsaInfo fsa_info = fsa_info_data[fsa_idx0];
-      float cutoff = score_cutoffs_data[fsa_idx0];
+          // the following works because each FSA has (its num-states * T_+1)
+          // states allocated to it.  However (i / (T_+1)) does not directly map
+          // to a state index.
+          int32_t fsa_idx0 = a_fsas_row_ids1_data[(i / (T + 1))];
+          FsaInfo fsa_info = fsa_info_data[fsa_idx0];
+          float cutoff = score_cutoffs_data[fsa_idx0];
 
-      int32_t idx_within_fsa = i - (T+1) * fsa_info.state_offset,
-                      t = idx_within_fsa / fsa_info.num_states,
-             state_idx1 = idx_within_fsa % fsa_info.num_states;
-      // In the state_scores arrays, there are 2 copies of each FSA's states,
-      // for backward and forward.
-      int32_t backward_state_idx = (2 * fsa_info.state_offset) + state_idx1,
-            forward_state_idx = backward_state_idx + fsa_info.num_states;
+          int32_t idx_within_fsa = i - (T + 1) * fsa_info.state_offset,
+                  t = idx_within_fsa / fsa_info.num_states,
+                  state_idx1 = idx_within_fsa % fsa_info.num_states;
+          // In the state_scores arrays, there are 2 copies of each FSA's
+          // states, for backward and forward.
+          int32_t backward_state_idx = (2 * fsa_info.state_offset) + state_idx1,
+                  forward_state_idx = backward_state_idx + fsa_info.num_states;
 
-      char keep = (char)0;
-      if (t <= fsa_info.T) {
-        // This time is within the bounds for this FSA..
-        float forward_score = state_scores_data[t][forward_state_idx],
-            backward_score = state_scores_data[fsa_info.T - t][backward_state_idx];
+          char keep = (char)0;
+          if (t <= fsa_info.T) {
+            // This time is within the bounds for this FSA..
+            float forward_score = state_scores_data[t][forward_state_idx],
+                  backward_score =
+                      state_scores_data[fsa_info.T - t][backward_state_idx];
 
-        if (forward_score + backward_score > cutoff)
-          keep = (char)1;
-      }
-      keep_state_data[i] = keep;
-    };
-    Eval(c_, product, lambda_set_keep);
+            if (forward_score + backward_score > cutoff) keep = (char)1;
+          }
+          keep_state_data[i] = keep;
+        });
 
     Array1<int32_t> &new2old = renumber_states.New2Old();
     const int32_t *new2old_data = new2old.Data();
@@ -256,20 +255,14 @@ class MultiGraphDenseIntersect {
     Array1<int32_t> t_per_fsa(c_, num_fsas_ + 1);
     int32_t *t_per_fsa_data = t_per_fsa.Data();
 
-    // lambda is too short, we may run into compiler bug, so use if/else.
-    if (c_->GetDeviceType() == kCpu) {
-      for (int32_t i = 0; i < num_fsas_; i++)
-        t_per_fsa_data[i] = fsa_info_data[i].T + 1;
-    } else {
-      auto lambda_set_t_per_fsa_etc = [=] __host__ __device__ (int32_t i) -> void {
-        t_per_fsa_data[i] = fsa_info_data[i].T + 1;
-      };
-      EvalDevice(c_, num_fsas_, lambda_set_t_per_fsa_etc);
-    }
+    K2_EVAL(
+        c_, num_fsas_, lambda_set_t_per_fsa_etc,
+        (int32_t i)->void { t_per_fsa_data[i] = fsa_info_data[i].T + 1; });
+
     ExclusiveSum(t_per_fsa, &t_per_fsa);
 
-    // now t_per_fsa is the row_splits1 of the shape indexed we'll be returning.  It allocates
-    // fsa_info_data[i].T + 1 time-indexes to the i'th fsa.
+    // now t_per_fsa is the row_splits1 of the shape indexed we'll be returning.
+    // It allocates fsa_info_data[i].T + 1 time-indexes to the i'th fsa.
     Array1<int32_t> &ans_row_splits1 = t_per_fsa;
     const int32_t *ans_row_splits1_data = ans_row_splits1.Data();
     Array1<int32_t> ans_row_ids1(c_, t_per_fsa.Back());
@@ -291,30 +284,33 @@ class MultiGraphDenseIntersect {
 
     // set ans_row_ids2_data, which contains an ans_idx01 that combines
     // FSA-index and time-index.
-    auto lambda_set_row_ids2 = [=] __host__ __device__ (int32_t ans_idx012) -> void {
-      // old_i is the same as the index `i` into lambda_set_keep.  It is also an idx012.
-      // The logic is the same as for lambda_set_keep, we keep the code but not the
-      // comments.
-      int32_t old_i = new2old_data[ans_idx012];
-      int32_t fsa_idx0 = a_fsas_row_ids1_data[(old_i / (T+1))];
-      FsaInfo fsa_info = fsa_info_data[fsa_idx0];
-      int32_t idx_within_fsa = old_i - (T+1) * fsa_info.state_offset,
-                           t = idx_within_fsa / fsa_info.num_states,
-           a_fsas_state_idx1 = idx_within_fsa % fsa_info.num_states;
-      int32_t a_fsas_state_idx01 = fsa_info.state_offset + a_fsas_state_idx1;
-      int32_t ans_fsa_idx0x = ans_row_splits1_data[fsa_idx0],
+    K2_EVAL(
+        c_, ans_tot_num_states, lambda_set_row_ids2,
+        (int32_t ans_idx012)->void {
+          // old_i is the same as the index `i` into lambda_set_keep.  It is
+          // also an idx012. The logic is the same as for lambda_set_keep, we
+          // keep the code but not the comments.
+          int32_t old_i = new2old_data[ans_idx012];
+          int32_t fsa_idx0 = a_fsas_row_ids1_data[(old_i / (T + 1))];
+          FsaInfo fsa_info = fsa_info_data[fsa_idx0];
+          int32_t idx_within_fsa = old_i - (T + 1) * fsa_info.state_offset,
+                  t = idx_within_fsa / fsa_info.num_states,
+                  a_fsas_state_idx1 = idx_within_fsa % fsa_info.num_states;
+          int32_t a_fsas_state_idx01 =
+              fsa_info.state_offset + a_fsas_state_idx1;
+          int32_t ans_fsa_idx0x = ans_row_splits1_data[fsa_idx0],
                   ans_idx01 = ans_fsa_idx0x + t;
-      ans_row_ids2_data[ans_idx012] = ans_idx01;
-      ans_state_idx01_data[ans_idx012] = a_fsas_state_idx01;
-      // note: fsa_info.state_offset == a_fsas_row_splits2_data[a_fsas_state_idx01];
-      int32_t num_arcs = a_fsas_row_splits2_data[a_fsas_state_idx01 + 1] -
-              a_fsas_row_splits2_data[a_fsas_state_idx01];
-      if (t == fsa_info.T)  // No arcs leave copies of states on the last frame
-                            // for each FSA.
-        num_arcs = 0;
-      ans_num_arcs_data[ans_idx012] = num_arcs;
-    };
-    Eval(c_, ans_tot_num_states, lambda_set_row_ids2);
+          ans_row_ids2_data[ans_idx012] = ans_idx01;
+          ans_state_idx01_data[ans_idx012] = a_fsas_state_idx01;
+          // note: fsa_info.state_offset ==
+          // a_fsas_row_splits2_data[a_fsas_state_idx01];
+          int32_t num_arcs = a_fsas_row_splits2_data[a_fsas_state_idx01 + 1] -
+                             a_fsas_row_splits2_data[a_fsas_state_idx01];
+          if (t == fsa_info.T)  // No arcs leave copies of states on the last
+                                // frame for each FSA.
+            num_arcs = 0;
+          ans_num_arcs_data[ans_idx012] = num_arcs;
+        });
 
     Array1<int32_t> &ans_row_splits3(ans_num_arcs);
     ExclusiveSum(ans_num_arcs, &ans_row_splits3);
@@ -323,15 +319,13 @@ class MultiGraphDenseIntersect {
     RowSplitsToRowIds(ans_row_splits3, &ans_row_ids3);
 
     // Actually we'll do one more pass of pruning on 'ans' before we return it.
-    Ragged<Arc> ans(
-        RaggedShape4(&ans_row_splits1, &ans_row_ids1, -1,
-                     nullptr, &ans_row_ids2, ans_tot_num_states,
-                     &ans_row_splits3, &ans_row_ids3, -1),
-        Array1<Arc>(c_, tot_arcs));
+    Ragged<Arc> ans(RaggedShape4(&ans_row_splits1, &ans_row_ids1, -1, nullptr,
+                                 &ans_row_ids2, ans_tot_num_states,
+                                 &ans_row_splits3, &ans_row_ids3, -1),
+                    Array1<Arc>(c_, tot_arcs));
     Arc *ans_arcs_data = ans.values.Data();
 
-    Array1<int32_t> arc_map_a(c_, tot_arcs),
-        arc_map_b(c_, tot_arcs);
+    Array1<int32_t> arc_map_a(c_, tot_arcs), arc_map_b(c_, tot_arcs);
     int32_t *arc_map_a_data = arc_map_a.Data(),
             *arc_map_b_data = arc_map_b.Data();
 
@@ -340,95 +334,102 @@ class MultiGraphDenseIntersect {
 
     const int32_t *ans_row_ids1_data = ans_row_ids1.Data(),
                   *ans_row_ids3_data = ans_row_ids3.Data(),
-               *ans_row_splits2_data = ans.shape.RowSplits(2).Data(),
-               *ans_row_splits3_data = ans_row_splits3.Data(),
-                *states_old2new_data = renumber_states.Old2New().Data();
+                  *ans_row_splits2_data = ans.shape.RowSplits(2).Data(),
+                  *ans_row_splits3_data = ans_row_splits3.Data(),
+                  *states_old2new_data = renumber_states.Old2New().Data();
     CompressedArc *carcs_data = carcs_.Data();
     int32_t scores_stride = b_fsas_.scores.ElemStride0();
     const float *scores_data = b_fsas_.scores.Data();
 
-    auto lambda_set_arcs_and_keep = [=] __host__ __device__ (int32_t arc_idx0123) -> void {
-      int32_t ans_state_idx012 = ans_row_ids3_data[arc_idx0123],
-                   ans_idx012x = ans_row_splits3_data[ans_state_idx012],
-                     ans_idx01 = ans_row_ids2_data[ans_state_idx012],
-                      fsa_idx0 = ans_row_ids1_data[ans_idx01],
-                     ans_idx0x = ans_row_splits1_data[fsa_idx0],
-                    ans_idx0xx = ans_row_splits2_data[ans_idx0x],
-                        t_idx1 = ans_idx01 - ans_idx0x,
-                      arc_idx3 = arc_idx0123 - ans_idx012x;
-      int32_t a_fsas_state_idx01 = ans_state_idx01_data[ans_state_idx012];
-      FsaInfo fsa_info = fsa_info_data[fsa_idx0];
-      float cutoff = score_cutoffs_data[fsa_idx0];
-      int32_t a_fsas_state_idx0x = fsa_info.state_offset,
-              a_fsas_state_idx1 = a_fsas_state_idx01 - a_fsas_state_idx0x;
-      int32_t a_fsas_arc_idx012 = a_fsas_row_splits2_data[a_fsas_state_idx01]
-                   + arc_idx3; //  arc_idx3 is an idx2 w.r.t. a_fsas.
-      CompressedArc carc = carcs_data[a_fsas_arc_idx012];
-      K2_CHECK_EQ(a_fsas_state_idx1, (int32_t)carc.src_state);
-      int32_t a_fsas_dest_state_idx1 = carc.dest_state;
-      arc_map_a_data[arc_idx0123] = a_fsas_arc_idx012;
-      int32_t scores_index = fsa_info.scores_offset + (scores_stride * t_idx1) +
-                       carc.label_plus_one;
-      arc_map_b_data[arc_idx0123] = scores_index;
+    K2_EVAL(
+        c_, tot_arcs, lambda_set_arcs_and_keep, (int32_t arc_idx0123)->void {
+          int32_t ans_state_idx012 = ans_row_ids3_data[arc_idx0123],
+                  ans_idx012x = ans_row_splits3_data[ans_state_idx012],
+                  ans_idx01 = ans_row_ids2_data[ans_state_idx012],
+                  fsa_idx0 = ans_row_ids1_data[ans_idx01],
+                  ans_idx0x = ans_row_splits1_data[fsa_idx0],
+                  ans_idx0xx = ans_row_splits2_data[ans_idx0x],
+                  t_idx1 = ans_idx01 - ans_idx0x,
+                  arc_idx3 = arc_idx0123 - ans_idx012x;
+          int32_t a_fsas_state_idx01 = ans_state_idx01_data[ans_state_idx012];
+          FsaInfo fsa_info = fsa_info_data[fsa_idx0];
+          float cutoff = score_cutoffs_data[fsa_idx0];
+          int32_t a_fsas_state_idx0x = fsa_info.state_offset,
+                  a_fsas_state_idx1 = a_fsas_state_idx01 - a_fsas_state_idx0x;
+          int32_t a_fsas_arc_idx012 =
+              a_fsas_row_splits2_data[a_fsas_state_idx01] +
+              arc_idx3;  //  arc_idx3 is an idx2 w.r.t. a_fsas.
+          CompressedArc carc = carcs_data[a_fsas_arc_idx012];
+          K2_CHECK_EQ(a_fsas_state_idx1, (int32_t)carc.src_state);
+          int32_t a_fsas_dest_state_idx1 = carc.dest_state;
+          arc_map_a_data[arc_idx0123] = a_fsas_arc_idx012;
+          int32_t scores_index = fsa_info.scores_offset +
+                                 (scores_stride * t_idx1) + carc.label_plus_one;
+          arc_map_b_data[arc_idx0123] = scores_index;
 
-      float arc_score = carc.score + scores_data[scores_index];
+          float arc_score = carc.score + scores_data[scores_index];
 
-      // unpruned_src_state_idx and unpruned_dest_state_idx are into
-      // `renumber_states.Keep()` or `renumber_states.Old2New()`
-      int32_t unpruned_src_state_idx = fsa_info.state_offset * (T+1) +
-           (t_idx1 * fsa_info.num_states) + a_fsas_state_idx1,
-         unpruned_dest_state_idx = fsa_info.state_offset * (T+1) +
-         ((t_idx1 + 1) * fsa_info.num_states) + a_fsas_dest_state_idx1;
-      K2_CHECK_EQ(states_old2new_data[unpruned_src_state_idx], ans_state_idx012);
-      K2_CHECK_LT(t_idx1, (int32_t)fsa_info.T);
+          // unpruned_src_state_idx and unpruned_dest_state_idx are into
+          // `renumber_states.Keep()` or `renumber_states.Old2New()`
+          int32_t unpruned_src_state_idx = fsa_info.state_offset * (T + 1) +
+                                           (t_idx1 * fsa_info.num_states) +
+                                           a_fsas_state_idx1,
+                  unpruned_dest_state_idx =
+                      fsa_info.state_offset * (T + 1) +
+                      ((t_idx1 + 1) * fsa_info.num_states) +
+                      a_fsas_dest_state_idx1;
+          K2_CHECK_EQ(states_old2new_data[unpruned_src_state_idx],
+                      ans_state_idx012);
+          K2_CHECK_LT(t_idx1, (int32_t)fsa_info.T);
 
-      int32_t ans_dest_state_idx012 = states_old2new_data[unpruned_dest_state_idx],
-         ans_dest_state_idx012_next = states_old2new_data[unpruned_dest_state_idx + 1];
-      char keep_this_arc = (char)0;
+          int32_t ans_dest_state_idx012 =
+                      states_old2new_data[unpruned_dest_state_idx],
+                  ans_dest_state_idx012_next =
+                      states_old2new_data[unpruned_dest_state_idx + 1];
+          char keep_this_arc = (char)0;
 
-      const float *forward_state_scores = state_scores_data[t_idx1];
-      // 'next_backward_state_scores' is the state_scores vector for the next
-      // frame (t_idx1 + 1); the backward scores are in the opposite order so we
-      // index as ((int32_t)fsa_info.T) - (t_idx1 + 1).
-      const float *next_backward_state_scores = state_scores_data[((int32_t)fsa_info.T) - (t_idx1 + 1)];
+          const float *forward_state_scores = state_scores_data[t_idx1];
+          // 'next_backward_state_scores' is the state_scores vector for the
+          // next frame (t_idx1 + 1); the backward scores are in the opposite
+          // order so we index as ((int32_t)fsa_info.T) - (t_idx1 + 1).
+          const float *next_backward_state_scores =
+              state_scores_data[((int32_t)fsa_info.T) - (t_idx1 + 1)];
 
-      if (ans_dest_state_idx012 < ans_dest_state_idx012_next) {
-        // The dest-state of this arc has a number (was not pruned away).
-        // below, backward_dest_state_idx and forward_src_state_idx are into the
-        // state_scores arrays.
-        int32_t backward_dest_state_idx = (2 * fsa_info.state_offset) +
-                                          a_fsas_dest_state_idx1,
-                  forward_src_state_idx = (2 * fsa_info.state_offset) +
-                                          fsa_info.num_states + a_fsas_state_idx1;
-        float arc_forward_backward_score = forward_state_scores[forward_src_state_idx] +
-                                           arc_score +
-                                           next_backward_state_scores[backward_dest_state_idx];
-        if (arc_forward_backward_score > cutoff) {
-          keep_this_arc = (char)1;
-          Arc arc;
-          arc.label = static_cast<int32_t>(carc.label_plus_one) - 1;
-          // the idx12 into `ans`, which includes the 't' and 'state' indexes,
-          // corresponds to the state-index in the FSA we will return (the 't' index
-          // will be removed).
-          int32_t src_state_idx12 = ans_state_idx012 - ans_idx0xx,
-                 dest_state_idx12 = ans_dest_state_idx012 - ans_idx0xx;
-          arc.src_state = src_state_idx12;
-          arc.dest_state = dest_state_idx12;
-          arc.score = arc_score;
-          ans_arcs_data[arc_idx0123] = arc;
-        }
-      }
-      keep_arc_data[arc_idx0123] = keep_this_arc;
-    };
-    Eval(c_, tot_arcs, lambda_set_arcs_and_keep);
+          if (ans_dest_state_idx012 < ans_dest_state_idx012_next) {
+            // The dest-state of this arc has a number (was not pruned away).
+            // below, backward_dest_state_idx and forward_src_state_idx are into
+            // the state_scores arrays.
+            int32_t backward_dest_state_idx =
+                        (2 * fsa_info.state_offset) + a_fsas_dest_state_idx1,
+                    forward_src_state_idx = (2 * fsa_info.state_offset) +
+                                            fsa_info.num_states +
+                                            a_fsas_state_idx1;
+            float arc_forward_backward_score =
+                forward_state_scores[forward_src_state_idx] + arc_score +
+                next_backward_state_scores[backward_dest_state_idx];
+            if (arc_forward_backward_score > cutoff) {
+              keep_this_arc = (char)1;
+              Arc arc;
+              arc.label = static_cast<int32_t>(carc.label_plus_one) - 1;
+              // the idx12 into `ans`, which includes the 't' and 'state'
+              // indexes, corresponds to the state-index in the FSA we will
+              // return (the 't' index will be removed).
+              int32_t src_state_idx12 = ans_state_idx012 - ans_idx0xx,
+                      dest_state_idx12 = ans_dest_state_idx012 - ans_idx0xx;
+              arc.src_state = src_state_idx12;
+              arc.dest_state = dest_state_idx12;
+              arc.score = arc_score;
+              ans_arcs_data[arc_idx0123] = arc;
+            }
+          }
+          keep_arc_data[arc_idx0123] = keep_this_arc;
+        });
 
-    if (arc_map_a_out)
-      *arc_map_a_out = arc_map_a[renumber_arcs.New2Old()];
-    if (arc_map_b_out)
-      *arc_map_b_out = arc_map_b[renumber_arcs.New2Old()];
+    if (arc_map_a_out) *arc_map_a_out = arc_map_a[renumber_arcs.New2Old()];
+    if (arc_map_b_out) *arc_map_b_out = arc_map_b[renumber_arcs.New2Old()];
     // subsample the output shape, removing arcs that weren't kept
-    RaggedShape ans_shape_subsampled = SubsampleRaggedShape(ans.shape,
-                                                            renumber_arcs);
+    RaggedShape ans_shape_subsampled =
+        SubsampleRaggedShape(ans.shape, renumber_arcs);
     // .. and remove the 't' axis
     return Ragged<Arc>(RemoveAxis(ans_shape_subsampled, 1),
                        ans.values[renumber_arcs.New2Old()]);
@@ -437,8 +438,7 @@ class MultiGraphDenseIntersect {
   // We can't actually make the rest private for reasons relating to use of
   // __host__ __device__ lambdas, but logically the rest would be private.
 
-  //private:
-
+  // private:
 
   void InitCompressedArcs() {
     NVTX_RANGE(__func__);
@@ -448,41 +448,44 @@ class MultiGraphDenseIntersect {
     const Arc *arcs_data = a_fsas_.values.Data();
     const int32_t *a_fsas_row_ids1 = a_fsas_.RowIds(1).Data(),
                   *a_fsas_row_ids2 = a_fsas_.RowIds(2).Data(),
-               *a_fsas_row_splits1 = a_fsas_.RowSplits(1).Data(),
-               *a_fsas_row_splits2 = a_fsas_.RowSplits(2).Data();
+                  *a_fsas_row_splits1 = a_fsas_.RowSplits(1).Data(),
+                  *a_fsas_row_splits2 = a_fsas_.RowSplits(2).Data();
 
-    // incoming_indexes maps from position in normally-arranged arcs (i.e. arc_idx012 in
-    // a_fsas_) to the position that that arc has in incoming_arcs_.
+    // incoming_indexes maps from position in normally-arranged arcs (i.e.
+    // arc_idx012 in a_fsas_) to the position that that arc has in
+    // incoming_arcs_.
     Array1<int32_t> incoming_indexes = InvertPermutation(incoming_arcs_.values);
     const int32_t *incoming_indexes_data = incoming_indexes.Data();
 
-    auto set_carcs_lambda = [=] __host__ __device__ (int32_t i) -> void {
-      Arc arc = arcs_data[i];
-      CompressedArc carc;
-      carc.src_state = uint16_t(arc.src_state);
-      carc.dest_state = uint16_t(arc.dest_state);
-      carc.label_plus_one = uint16_t(arc.label + 1);
-      carc.fsa_idx = a_fsas_row_ids1[a_fsas_row_ids2[i]];
-      carc.score = arc.score;
-      { // set carc.incoming_arc_idx012
-        int32_t this_fsa_first_arc = a_fsas_row_splits2[
-            a_fsas_row_splits1[carc.fsa_idx]],
-                next_fsa_first_arc = a_fsas_row_splits2[
-                    a_fsas_row_splits1[carc.fsa_idx + 1]],
-                 this_fsa_num_arcs = next_fsa_first_arc - this_fsa_first_arc;
-        int32_t incoming_arc_idx012 = incoming_indexes_data[i],
-                 incoming_arc_idx12 = incoming_arc_idx012 - this_fsa_first_arc;
-        // The arrangement of arcs in arc_scores_ (and Step::arc_scores) comes
-        // from appending a_fsas_.shape and incoming_arcs_.shape along axis 1.
-        // So (2 * this_fsa_first_arc) is the start of this FSA's data, and
-        // adding this_fsa_num_arcs means skipping over the arcs arranged
-        // as in a_fsas_.shape.
-        carc.incoming_arc_idx012 = 2 * this_fsa_first_arc + this_fsa_num_arcs +
-                                   incoming_arc_idx12;
-      }
-      carcs_data[i] = carc;
-    };
-    Eval(c_, tot_arcs, set_carcs_lambda);
+    K2_EVAL(
+        c_, tot_arcs, set_carcs_lambda, (int32_t i)->void {
+          Arc arc = arcs_data[i];
+          CompressedArc carc;
+          carc.src_state = uint16_t(arc.src_state);
+          carc.dest_state = uint16_t(arc.dest_state);
+          carc.label_plus_one = uint16_t(arc.label + 1);
+          carc.fsa_idx = a_fsas_row_ids1[a_fsas_row_ids2[i]];
+          carc.score = arc.score;
+          {  // set carc.incoming_arc_idx012
+            int32_t
+                this_fsa_first_arc =
+                    a_fsas_row_splits2[a_fsas_row_splits1[carc.fsa_idx]],
+                next_fsa_first_arc =
+                    a_fsas_row_splits2[a_fsas_row_splits1[carc.fsa_idx + 1]],
+                this_fsa_num_arcs = next_fsa_first_arc - this_fsa_first_arc;
+            int32_t incoming_arc_idx012 = incoming_indexes_data[i],
+                    incoming_arc_idx12 =
+                        incoming_arc_idx012 - this_fsa_first_arc;
+            // The arrangement of arcs in arc_scores_ (and Step::arc_scores)
+            // comes from appending a_fsas_.shape and incoming_arcs_.shape along
+            // axis 1. So (2 * this_fsa_first_arc) is the start of this FSA's
+            // data, and adding this_fsa_num_arcs means skipping over the arcs
+            // arranged as in a_fsas_.shape.
+            carc.incoming_arc_idx012 =
+                2 * this_fsa_first_arc + this_fsa_num_arcs + incoming_arc_idx12;
+          }
+          carcs_data[i] = carc;
+        });
   }
 
   void InitFsaInfo() {
@@ -495,21 +498,23 @@ class MultiGraphDenseIntersect {
     fsa_info_ = Array1<FsaInfo>(c_, num_fsas_ + 1);
     FsaInfo *fsa_info_data = fsa_info_.Data();
     int32_t num_fsas = num_fsas_;
-    auto lambda_set_fsa_info = [=] __host__ __device__ (int32_t i) -> void {
-      FsaInfo info;
-      if (i < num_fsas) {
-        info.T = uint16_t(b_fsas_row_splits1_data[i+1] - b_fsas_row_splits1_data[i]);
-        info.num_states = uint16_t(a_fsas_row_splits1_data[i+1] - a_fsas_row_splits1_data[i]);
-      } else {
-        info.T = 0;
-        info.num_states = 0;
-      }
-      info.scores_offset = b_fsas_row_splits1_data[i] * scores_stride;
-      info.state_offset = a_fsas_row_splits1_data[i];
-      info.arc_offset = a_fsas_row_splits2_data[info.state_offset];
-      fsa_info_data[i] = info;
-    };
-    Eval(c_, num_fsas_ + 1, lambda_set_fsa_info);
+    K2_EVAL(
+        c_, num_fsas_ + 1, lambda_set_fsa_info, (int32_t i)->void {
+          FsaInfo info;
+          if (i < num_fsas) {
+            info.T = uint16_t(b_fsas_row_splits1_data[i + 1] -
+                              b_fsas_row_splits1_data[i]);
+            info.num_states = uint16_t(a_fsas_row_splits1_data[i + 1] -
+                                       a_fsas_row_splits1_data[i]);
+          } else {
+            info.T = 0;
+            info.num_states = 0;
+          }
+          info.scores_offset = b_fsas_row_splits1_data[i] * scores_stride;
+          info.state_offset = a_fsas_row_splits1_data[i];
+          info.arc_offset = a_fsas_row_splits2_data[info.state_offset];
+          fsa_info_data[i] = info;
+        });
   }
 
   /*
@@ -519,23 +524,24 @@ class MultiGraphDenseIntersect {
   void InitSteps() {
     NVTX_RANGE(__func__);
     // This vector, of length num_fsas_, tells us how many copies of (the states
-    // of the i'th decoding graph) we have.  It equals (the length of the sequence
-    // of log-likes in b_fsas_) + 1.  It is monotonically decreasing (thanks to
-    // how we require the FSAs to be sorted).
+    // of the i'th decoding graph) we have.  It equals (the length of the
+    // sequence of log-likes in b_fsas_) + 1.  It is monotonically decreasing
+    // (thanks to how we require the FSAs to be sorted).
     Array1<int32_t> num_copies_per_fsa(c_, num_fsas_);
     const int32_t *b_row_splits_data = b_fsas_.shape.RowSplits(1).Data();
     int32_t *num_copies_per_fsa_data = num_copies_per_fsa.Data();
-    auto lambda_set_num_copies = [=]  __host__ __device__ (int32_t i) -> void {
-      num_copies_per_fsa_data[i] = 1 + b_row_splits_data[i + 1] - b_row_splits_data[i];
-    };
-    Eval(c_, num_fsas_, lambda_set_num_copies);
+
+    K2_EVAL(
+        c_, num_fsas_, lambda_set_num_copies, (int32_t i)->void {
+          num_copies_per_fsa_data[i] =
+              1 + b_row_splits_data[i + 1] - b_row_splits_data[i];
+        });
 
     std::vector<int32_t> range(num_fsas_);
     // fill with 1, 2, .. num_fsas_.
     std::iota(range.begin(), range.end(), 1);
-    std::vector<RaggedShape> arc_scores_prefixes = GetPrefixes(arc_scores_.shape,
-                                                               range);
-
+    std::vector<RaggedShape> arc_scores_prefixes =
+        GetPrefixes(arc_scores_.shape, range);
 
     ContextPtr c_cpu = GetCpuContext();
 
@@ -544,15 +550,14 @@ class MultiGraphDenseIntersect {
     // time-index.  It equals InvertMonotonicDecreasing(num_copies_per_fsa_)
     // and it is also the case that InvertMonotonicDecreasing(num_fsas_per_t_)
     // == num_copies_per_fsa_.
-    Array1<int32_t> num_fsas_per_t = InvertMonotonicDecreasing(
-        num_copies_per_fsa),
-                num_fsas_per_t_cpu = num_fsas_per_t.To(c_cpu);
+    Array1<int32_t> num_fsas_per_t =
+                        InvertMonotonicDecreasing(num_copies_per_fsa),
+                    num_fsas_per_t_cpu = num_fsas_per_t.To(c_cpu);
 
     Array1<int32_t> a_fsas_row_splits1_cpu = a_fsas_.RowSplits(1).To(c_cpu),
-                  a_fsas_row_splits12_cpu = a_fsas_.RowSplits(2)[
-                      a_fsas_.RowSplits(1)].To(c_cpu);
-    int32_t tot_arcs = a_fsas_.NumElements(),
-          tot_states = a_fsas_.TotSize(1);
+                    a_fsas_row_splits12_cpu =
+                        a_fsas_.RowSplits(2)[a_fsas_.RowSplits(1)].To(c_cpu);
+    int32_t tot_arcs = a_fsas_.NumElements(), tot_states = a_fsas_.TotSize(1);
 
     steps_.resize(T_ + 1);
 
@@ -564,8 +569,8 @@ class MultiGraphDenseIntersect {
       // the - 1 is because arc_scores_prefixes contains prefixes
       // of length 1, 2, .. (starts from 1 not 0).
       RaggedShape &shape = arc_scores_prefixes[step.num_fsas - 1];
-      step.arc_scores = Ragged<float>(shape,
-                                      arc_scores_.values.Arange(0, shape.NumElements()));
+      step.arc_scores = Ragged<float>(
+          shape, arc_scores_.values.Arange(0, shape.NumElements()));
 
       int32_t num_states = a_fsas_row_splits1_cpu[step.num_fsas];
       // * 2 because have both forward and backward.
@@ -575,88 +580,93 @@ class MultiGraphDenseIntersect {
 
   void DoStep0() {
     NVTX_RANGE(__func__);
-    // Run step zero of the computation: this initializes the forward probabilities on
-    // frame 0, and the backward probabilities on the last frame for each sequence.
+    // Run step zero of the computation: this initializes the forward
+    // probabilities on frame 0, and the backward probabilities on the last
+    // frame for each sequence.
 
     float *scores = steps_[0].state_scores.Data();
     int32_t *a_fsas_row_ids1 = a_fsas_.RowIds(1).Data();
     FsaInfo *fsa_info_data = fsa_info_.Data();
     const float minus_inf = -std::numeric_limits<float>::infinity();
-    auto lambda_init_state_scores = [=] __host__ __device__ (int32_t state_idx01) -> void {
-      int32_t fsa_idx0 = a_fsas_row_ids1[state_idx01];
-      FsaInfo this_info = fsa_info_data[fsa_idx0];
-      // we could also write:
-      // backward_state_idx = (2 * this_info.state_offset) + state_idx1,
-      // where state_idx1 = this_info.state_offset - state_idx01.
-      // Each FSA has (its states for backward, its states for forward).
-      int32_t backward_state_idx = this_info.state_offset + state_idx01,
-         forward_state_idx = backward_state_idx + this_info.num_states,
-         state_idx1 = state_idx01 - this_info.state_offset;
-
-      float start_loglike = (state_idx1 == 0 ? 0 : minus_inf),
-         end_loglike = (state_idx1 + 1 == this_info.num_states ? 0 :
-                        minus_inf);
-      scores[forward_state_idx] = start_loglike;
-      scores[backward_state_idx] = end_loglike;
-    };
     int32_t tot_states = a_fsas_.TotSize(1);
-    Eval(c_, tot_states, lambda_init_state_scores);
+    K2_EVAL(
+        c_, tot_states, lambda_init_state_scores, (int32_t state_idx01)->void {
+          int32_t fsa_idx0 = a_fsas_row_ids1[state_idx01];
+          FsaInfo this_info = fsa_info_data[fsa_idx0];
+          // we could also write:
+          // backward_state_idx = (2 * this_info.state_offset) + state_idx1,
+          // where state_idx1 = this_info.state_offset - state_idx01.
+          // Each FSA has (its states for backward, its states for forward).
+          int32_t backward_state_idx = this_info.state_offset + state_idx01,
+                  forward_state_idx = backward_state_idx + this_info.num_states,
+                  state_idx1 = state_idx01 - this_info.state_offset;
+
+          float start_loglike = (state_idx1 == 0 ? 0 : minus_inf),
+                end_loglike =
+                    (state_idx1 + 1 == this_info.num_states ? 0 : minus_inf);
+          scores[forward_state_idx] = start_loglike;
+          scores[backward_state_idx] = end_loglike;
+        });
   }
 
   /* Called for 1 <= t <= T_, does one step of propagation (does forward and
      backward simultaneously, for different time steps) */
   void DoStep(int32_t t) {
     NVTX_RANGE(__func__);
-    Step &step = steps_[t],
-          &prev_step = steps_[t-1];
+    Step &step = steps_[t], &prev_step = steps_[t - 1];
 
     // Divide by two because each arc is repeated twice in arc_scores (once for
-    // forward, once for backward).  The same kernel instance does both the forward
-    // and backward passes, so we can avoid reading the arc twice.
+    // forward, once for backward).  The same kernel instance does both the
+    // forward and backward passes, so we can avoid reading the arc twice.
     int32_t num_arcs = step.arc_scores.values.Dim() / 2;
 
     float *arc_scores_data = step.arc_scores.values.Data(),
-      *prev_state_scores_data = prev_step.state_scores.Data();
+          *prev_state_scores_data = prev_step.state_scores.Data();
 
     CompressedArc *carcs_data = carcs_.Data();
     FsaInfo *fsa_info_data = fsa_info_.Data();
     float *scores_data = b_fsas_.scores.Data();
     int32_t scores_stride = b_fsas_.scores.ElemStride0();
 
-    auto lambda_set_arc_scores = [=] __host__ __device__ (int32_t arc_idx012) -> void {
-      CompressedArc carc = carcs_data[arc_idx012];
-      int32_t fsa_idx = carc.fsa_idx;
-      FsaInfo fsa_info = fsa_info_data[fsa_idx];
-      // First, forward pass.  We read from the src_state of the arc
+    K2_EVAL(
+        c_, num_arcs, lambda_set_arc_scores, (int32_t arc_idx012)->void {
+          CompressedArc carc = carcs_data[arc_idx012];
+          int32_t fsa_idx = carc.fsa_idx;
+          FsaInfo fsa_info = fsa_info_data[fsa_idx];
+          // First, forward pass.  We read from the src_state of the arc
 
-      int32_t src_state_idx1 = carc.src_state,
-             dest_state_idx1 = carc.dest_state;
-      int32_t dest_state_scores_index_backward = 2 * fsa_info.state_offset +
-                                                 dest_state_idx1,
-               src_state_scores_index_forward = 2 * fsa_info.state_offset +
-                                   fsa_info.num_states + src_state_idx1;
+          int32_t src_state_idx1 = carc.src_state,
+                  dest_state_idx1 = carc.dest_state;
+          int32_t dest_state_scores_index_backward =
+                      2 * fsa_info.state_offset + dest_state_idx1,
+                  src_state_scores_index_forward = 2 * fsa_info.state_offset +
+                                                   fsa_info.num_states +
+                                                   src_state_idx1;
 
+          float forward_src_prob =
+                    prev_state_scores_data[src_state_scores_index_forward],
+                backward_dest_prob =
+                    prev_state_scores_data[dest_state_scores_index_backward];
 
-      float forward_src_prob = prev_state_scores_data[src_state_scores_index_forward],
-        backward_dest_prob = prev_state_scores_data[dest_state_scores_index_backward];
+          float b_score_forward = scores_data[fsa_info.scores_offset +
+                                              (scores_stride * (t - 1)) +
+                                              carc.label_plus_one],
+                b_score_backward =
+                    scores_data[fsa_info.scores_offset +
+                                (scores_stride * (fsa_info.T - t)) +
+                                carc.label_plus_one];
+          float forward_arc_end_prob =
+                    forward_src_prob + carc.score + b_score_forward,
+                backward_arc_begin_prob =
+                    backward_dest_prob + carc.score + b_score_backward;
 
-      float b_score_forward = scores_data[fsa_info.scores_offset +
-                                          (scores_stride * (t - 1)) +
-                                          carc.label_plus_one],
-         b_score_backward = scores_data[fsa_info.scores_offset +
-                                        (scores_stride * (fsa_info.T - t)) +
-                                        carc.label_plus_one];
-      float forward_arc_end_prob = forward_src_prob + carc.score + b_score_forward,
-         backward_arc_begin_prob = backward_dest_prob + carc.score + b_score_backward;
+          // These are indexes into step.arc_scores.values.Data().
+          int32_t arc_idx_for_backward = arc_idx012 + fsa_info.arc_offset,
+                  arc_idx_for_forward = carc.incoming_arc_idx012;
 
-      // These are indexes into step.arc_scores.values.Data().
-      int32_t arc_idx_for_backward = arc_idx012 + fsa_info.arc_offset,
-           arc_idx_for_forward = carc.incoming_arc_idx012;
-
-      arc_scores_data[arc_idx_for_forward] = forward_arc_end_prob;
-      arc_scores_data[arc_idx_for_backward] = backward_arc_begin_prob;
-    };
-    Eval(c_, num_arcs, lambda_set_arc_scores);
+          arc_scores_data[arc_idx_for_forward] = forward_arc_end_prob;
+          arc_scores_data[arc_idx_for_backward] = backward_arc_begin_prob;
+        });
     MaxPerSublist(step.arc_scores, -std::numeric_limits<float>::infinity(),
                   &step.state_scores);
   }
@@ -668,12 +678,12 @@ class MultiGraphDenseIntersect {
     pick a looser beam if there is significant roundoff).
    */
   Array1<float> GetScoreCutoffs() {
-    std::vector<float*> state_scores_vec(T_ + 1);
+    std::vector<float *> state_scores_vec(T_ + 1);
     int32_t tot_states = a_fsas_.TotSize(1);
     for (int32_t t = 0; t <= T_; t++) {
       state_scores_vec[t] = steps_[t].state_scores.Data();
     }
-    state_scores_ = Array1<float*>(c_, state_scores_vec);
+    state_scores_ = Array1<float *>(c_, state_scores_vec);
     float **state_scores_data = state_scores_.Data();
 
     FsaInfo *fsa_info_data = fsa_info_.Data();
@@ -681,46 +691,51 @@ class MultiGraphDenseIntersect {
     float *score_cutoffs_data = score_cutoffs.Data();
     float output_beam = output_beam_;
     const float minus_inf = -std::numeric_limits<float>::infinity();
-    auto lambda_set_cutoffs = [=] __host__ __device__ (int32_t fsa_idx0) -> void {
-      FsaInfo fsa_info = fsa_info_data[fsa_idx0];
-      // In the scores array, we have FSA 0 then FSA1 and so on; for each
-      // FSA we have (backward scores, arranged as in a_fsas_.shape),
-      // then (forward scores, arranged as in incoming_arcs_.shape).
-      // We are interested in the backward-prob at state 0 (start state)
-      // and the forward-prob in the final state.
-      int32_t backward_state_idx = (2 * fsa_info.state_offset),
-         forward_state_idx = backward_state_idx + (2 * fsa_info.num_states) - 1;
-      // We get the start and end scoreas after fsa_info.T steps of propagation,
-      // and the result is in the state_scores of the Step indexed fsa_info.T.
-      float *this_state_scores = state_scores_data[fsa_info.T];
-      // Take the worst of the state scores; this will reduce the chance of
-      // roundoff errors causing all states to be pruned away.
-      float tot_score_start = (fsa_info.num_states == 0 ? minus_inf :
-                               this_state_scores[backward_state_idx]),
-          tot_score_end = (fsa_info.num_states == 0 ? minus_inf :
-                           this_state_scores[forward_state_idx]),
-         tot_score_min = (tot_score_start < tot_score_end ?
-                          tot_score_start : tot_score_end);
-      K2_CHECK(tot_score_end == tot_score_start ||
-               fabs(tot_score_end - tot_score_start) < 1.0);  // TODO: remove this
-      score_cutoffs_data[fsa_idx0] = tot_score_min - output_beam;
-    };
-    Eval(c_, num_fsas_, lambda_set_cutoffs);
+    K2_EVAL(
+        c_, num_fsas_, lambda_set_cutoffs, (int32_t fsa_idx0)->void {
+          FsaInfo fsa_info = fsa_info_data[fsa_idx0];
+          // In the scores array, we have FSA 0 then FSA1 and so on; for each
+          // FSA we have (backward scores, arranged as in a_fsas_.shape),
+          // then (forward scores, arranged as in incoming_arcs_.shape).
+          // We are interested in the backward-prob at state 0 (start state)
+          // and the forward-prob in the final state.
+          int32_t backward_state_idx = (2 * fsa_info.state_offset),
+                  forward_state_idx =
+                      backward_state_idx + (2 * fsa_info.num_states) - 1;
+          // We get the start and end scoreas after fsa_info.T steps of
+          // propagation, and the result is in the state_scores of the Step
+          // indexed fsa_info.T.
+          float *this_state_scores = state_scores_data[fsa_info.T];
+          // Take the worst of the state scores; this will reduce the chance of
+          // roundoff errors causing all states to be pruned away.
+          float tot_score_start = (fsa_info.num_states == 0
+                                       ? minus_inf
+                                       : this_state_scores[backward_state_idx]),
+                tot_score_end = (fsa_info.num_states == 0
+                                     ? minus_inf
+                                     : this_state_scores[forward_state_idx]),
+                tot_score_min =
+                    (tot_score_start < tot_score_end ? tot_score_start
+                                                     : tot_score_end);
+          K2_CHECK(tot_score_end == tot_score_start ||
+                   fabs(tot_score_end - tot_score_start) <
+                       1.0);  // TODO: remove this
+          score_cutoffs_data[fsa_idx0] = tot_score_min - output_beam;
+        });
     return score_cutoffs;
   }
 
-
-
   ContextPtr c_;
-  FsaVec &a_fsas_;          // a_fsas_: decoding graphs, with same Dim0() as
-                            // b_fsas_. Note: a_fsas_ has 3 axes.
+  FsaVec &a_fsas_;  // a_fsas_: decoding graphs, with same Dim0() as
+                    // b_fsas_. Note: a_fsas_ has 3 axes.
 
   DenseFsaVec &b_fsas_;
 
   // num_fsas_ equals b_fsas_.shape.Dim0() == a_fsas_.Dim0().
   int32_t num_fsas_;
 
-  // This is just a copy of a_fsas_.arcs, with a couple extra pieces of information.
+  // This is just a copy of a_fsas_.arcs, with a couple extra pieces of
+  // information.
   struct CompressedArc {
     // src_state of Arc, as uint16 (an idx1)
     uint16_t src_state;
@@ -740,7 +755,8 @@ class MultiGraphDenseIntersect {
     int32_t incoming_arc_idx012;
     float score;
   };
-  // The arcs in a_fsas_.arcs, converted to int16_t's and with a little more information.
+  // The arcs in a_fsas_.arcs, converted to int16_t's and with a little more
+  // information.
   Array1<CompressedArc> carcs_;
 
   // incoming_arcs_.shape is a modified version of the shape a_fsas_.arcs.shape,
@@ -749,18 +765,18 @@ class MultiGraphDenseIntersect {
   // computation.
   Ragged<int32_t> incoming_arcs_;
 
-
-  // The shape of arc_scores_ the result of appending a_fsas_.shape and incoming_arcs_.shape
-  // along axis 1 (i.e. states).  arc_scores_ is used to take the max of the forward and
-  // backward probabilities in parallel on each frame.  Each FSA has twice
-  // the number of of states as in a_fsas_, and twice the number of arcs;
-  // and the order is (the arcs/states as in a_fsas_, for backward propagation),
-  // then (the arcs/states as in incoming_arcs_, for forward propagation).
+  // The shape of arc_scores_ the result of appending a_fsas_.shape and
+  // incoming_arcs_.shape along axis 1 (i.e. states).  arc_scores_ is used to
+  // take the max of the forward and backward probabilities in parallel on each
+  // frame.  Each FSA has twice the number of of states as in a_fsas_, and twice
+  // the number of arcs; and the order is (the arcs/states as in a_fsas_, for
+  // backward propagation), then (the arcs/states as in incoming_arcs_, for
+  // forward propagation).
   Ragged<float> arc_scores_;
 
   struct FsaInfo {
-    // T is the number of frames in b_fsas_.scores that we have for this FSA, i.e.
-    // `b_fsas_.shape.RowSplits(1)[i+1] -  b_fsas_.shape.RowSplits(1)[i].`
+    // T is the number of frames in b_fsas_.scores that we have for this FSA,
+    // i.e. `b_fsas_.shape.RowSplits(1)[i+1] -  b_fsas_.shape.RowSplits(1)[i].`
     // The number of copies of the states of a_fsas_ that we have in the total
     // state space equals T+1, i.e. we have copies of those states for times
     // 0 <= t <= T.
@@ -770,7 +786,8 @@ class MultiGraphDenseIntersect {
     // scores_offset is the offset of first location in b_fsas_.scores.Data()
     // that is for this FSA, i.e. b_fsas_.scores.Data()[scores_offset] is the
     // score for t=0, symbol=-1 of this FSA.
-    // scores_offset == b_fsas_.shape.RowSplits(1)[fsa_idx] * b_fsas_.scores.ElemStride0().
+    // scores_offset == b_fsas_.shape.RowSplits(1)[fsa_idx] *
+    // b_fsas_.scores.ElemStride0().
     int32_t scores_offset;
     // state_offset is the idx0x corresponding to this FSA in a_fsas_.
     int32_t state_offset;
@@ -784,15 +801,14 @@ class MultiGraphDenseIntersect {
   struct Step {
     // 0 <= t <= T_ is the time whose states we are writing to in the
     // forward pass on this step of the algorithm (we read from those on time
-    // t - 1).  For the backward pass on an FSA with `FsaInfo info`, we write to states
-    // with time `t = info.T - t`.
-    // (Note: t==0 is a special case where we just initialize the times, there is
-    // no propagation.  However we do create the Step struct.)  See DoStep0() for that.
+    // t - 1).  For the backward pass on an FSA with `FsaInfo info`, we write to
+    // states with time `t = info.T - t`. (Note: t==0 is a special case where we
+    // just initialize the times, there is no propagation.  However we do create
+    // the Step struct.)  See DoStep0() for that.
     int32_t t;
 
     // num_fsas is the number of FSAs that have states active on time t.
     int32_t num_fsas;
-
 
     // Ragged array where we will write the scores of arcs before reduction;
     // this is a sub-array of arc_scores_, consisting of the first
@@ -811,24 +827,21 @@ class MultiGraphDenseIntersect {
   // steps_[0] is "special", on that step we do initialization.
   std::vector<Step> steps_;
 
-  // Pointer to the Data() pointers of the state_scores elements of steps_[i] for
-  // 0 <= i <= T_.
-  Array1<float*> state_scores_;
+  // Pointer to the Data() pointers of the state_scores elements of steps_[i]
+  // for 0 <= i <= T_.
+  Array1<float *> state_scores_;
 
   float output_beam_;
 
   int32_t T_;  // == b_fsas_.MaxSize(1)
-
 };
 
 void IntersectDense(FsaVec &a_fsas, DenseFsaVec &b_fsas, float output_beam,
-                    FsaVec *out,
-                    Array1<int32_t> *arc_map_a,
+                    FsaVec *out, Array1<int32_t> *arc_map_a,
                     Array1<int32_t> *arc_map_b) {
   NVTX_RANGE("IntersectDense");
   FsaVec a_vec = FsaToFsaVec(a_fsas);
-  MultiGraphDenseIntersect intersector(a_vec, b_fsas,
-                                       output_beam);
+  MultiGraphDenseIntersect intersector(a_vec, b_fsas, output_beam);
 
   intersector.Intersect();
   FsaVec ret = intersector.FormatOutput(arc_map_a, arc_map_b);

--- a/k2/csrc/intersect.cu
+++ b/k2/csrc/intersect.cu
@@ -102,7 +102,7 @@ class MultiGraphDenseIntersect {
   MultiGraphDenseIntersect(FsaVec &a_fsas, DenseFsaVec &b_fsas,
                            float output_beam)
       : a_fsas_(a_fsas), b_fsas_(b_fsas), output_beam_(output_beam) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     c_ = GetContext(a_fsas.shape, b_fsas.shape);
 
     K2_CHECK(a_fsas_.Dim0() == b_fsas_.shape.Dim0());
@@ -166,7 +166,7 @@ class MultiGraphDenseIntersect {
   /* Does the main work of intersection/composition, but doesn't produce any
      output; the output is provided when you call FormatOutput(). */
   void Intersect() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     DoStep0();
     for (int32_t t = 1; t <= T_; t++) DoStep(t);
   }
@@ -189,7 +189,7 @@ class MultiGraphDenseIntersect {
    */
   FsaVec FormatOutput(Array1<int32_t> *arc_map_a_out,
                       Array1<int32_t> *arc_map_b_out) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Array1<float> score_cutoffs = GetScoreCutoffs();
     float *score_cutoffs_data = score_cutoffs.Data();
     int32_t num_states = a_fsas_.TotSize(1);
@@ -441,7 +441,7 @@ class MultiGraphDenseIntersect {
   // private:
 
   void InitCompressedArcs() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     int32_t tot_arcs = a_fsas_.NumElements();
     carcs_ = Array1<CompressedArc>(c_, tot_arcs);
     CompressedArc *carcs_data = carcs_.Data();
@@ -489,7 +489,7 @@ class MultiGraphDenseIntersect {
   }
 
   void InitFsaInfo() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     int32_t *b_fsas_row_splits1_data = b_fsas_.shape.RowSplits(1).Data(),
             *a_fsas_row_splits1_data = a_fsas_.shape.RowSplits(1).Data(),
             *a_fsas_row_splits2_data = a_fsas_.shape.RowSplits(2).Data();
@@ -522,7 +522,7 @@ class MultiGraphDenseIntersect {
     does not do any of the actual computation.
    */
   void InitSteps() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     // This vector, of length num_fsas_, tells us how many copies of (the states
     // of the i'th decoding graph) we have.  It equals (the length of the
     // sequence of log-likes in b_fsas_) + 1.  It is monotonically decreasing
@@ -579,7 +579,7 @@ class MultiGraphDenseIntersect {
   }
 
   void DoStep0() {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     // Run step zero of the computation: this initializes the forward
     // probabilities on frame 0, and the backward probabilities on the last
     // frame for each sequence.
@@ -612,7 +612,7 @@ class MultiGraphDenseIntersect {
   /* Called for 1 <= t <= T_, does one step of propagation (does forward and
      backward simultaneously, for different time steps) */
   void DoStep(int32_t t) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Step &step = steps_[t], &prev_step = steps_[t - 1];
 
     // Divide by two because each arc is repeated twice in arc_scores (once for

--- a/k2/csrc/intersect.cu
+++ b/k2/csrc/intersect.cu
@@ -232,14 +232,14 @@ class MultiGraphDenseIntersect {
           int32_t backward_state_idx = (2 * fsa_info.state_offset) + state_idx1,
                   forward_state_idx = backward_state_idx + fsa_info.num_states;
 
-          char keep = (char)0;
+          char keep = 0;
           if (t <= fsa_info.T) {
             // This time is within the bounds for this FSA..
             float forward_score = state_scores_data[t][forward_state_idx],
                   backward_score =
                       state_scores_data[fsa_info.T - t][backward_state_idx];
 
-            if (forward_score + backward_score > cutoff) keep = (char)1;
+            if (forward_score + backward_score > cutoff) keep = 1;
           }
           keep_state_data[i] = keep;
         });
@@ -386,7 +386,7 @@ class MultiGraphDenseIntersect {
                       states_old2new_data[unpruned_dest_state_idx],
                   ans_dest_state_idx012_next =
                       states_old2new_data[unpruned_dest_state_idx + 1];
-          char keep_this_arc = (char)0;
+          char keep_this_arc = 0;
 
           const float *forward_state_scores = state_scores_data[t_idx1];
           // 'next_backward_state_scores' is the state_scores vector for the
@@ -408,7 +408,7 @@ class MultiGraphDenseIntersect {
                 forward_state_scores[forward_src_state_idx] + arc_score +
                 next_backward_state_scores[backward_dest_state_idx];
             if (arc_forward_backward_score > cutoff) {
-              keep_this_arc = (char)1;
+              keep_this_arc = 1;
               Arc arc;
               arc.label = static_cast<int32_t>(carc.label_plus_one) - 1;
               // the idx12 into `ans`, which includes the 't' and 'state'

--- a/k2/csrc/intersect_pruned.cu
+++ b/k2/csrc/intersect_pruned.cu
@@ -133,7 +133,7 @@ class MultiGraphDenseIntersectPruned {
         min_active_(min_active),
         max_active_(max_active),
         dynamic_beams_(a_fsas.Context(), b_fsas.shape.Dim0(), search_beam) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     c_ = GetContext(a_fsas.shape, b_fsas.shape);
     K2_CHECK(b_fsas.scores.IsContiguous());
     K2_CHECK_GT(search_beam, 0);
@@ -187,7 +187,7 @@ class MultiGraphDenseIntersectPruned {
       1).  So the #states is 2 greater than the actual number of frames in the
       neural-net output.
     */
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     int32_t T = b_fsas_.shape.MaxSize(1), num_fsas = b_fsas_.shape.Dim0();
 
     std::ostringstream os;
@@ -436,7 +436,7 @@ class MultiGraphDenseIntersectPruned {
     min_active and max_active.
   */
   Array1<float> GetPruningCutoffs(Ragged<float> &arc_end_scores) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     int32_t num_fsas = arc_end_scores.shape.Dim0();
 
     // get the maximum score from each sub-list (i.e. each FSA, on this frame).
@@ -508,7 +508,7 @@ class MultiGraphDenseIntersectPruned {
                        'states' member is expected to be set up on entry.
    */
   Ragged<ArcInfo> GetArcs(int32_t t, FrameInfo *cur_frame) {
-    NVTX_RANGE(__func__);
+    NVTX_RANGE(K2_FUNC);
     Ragged<StateInfo> &states = cur_frame->states;
     const StateInfo *state_values = states.values.Data();
 

--- a/k2/csrc/intersect_pruned.cu
+++ b/k2/csrc/intersect_pruned.cu
@@ -432,8 +432,8 @@ class MultiGraphDenseIntersectPruned {
                     states).  The cutoffs will be of the form: the best score
                     for any arc, minus the dynamic beam.  See the code for how
                     the dynamic beam is adjusted; it will approach
-    'search_beam_' as long as the number of active states in each FSA is between
-    min_active and max_active.
+                    'search_beam_' as long as the number of active states in
+                    each FSA is between min_active and max_active.
   */
   Array1<float> GetPruningCutoffs(Ragged<float> &arc_end_scores) {
     NVTX_RANGE(K2_FUNC);
@@ -808,8 +808,8 @@ class MultiGraphDenseIntersectPruned {
             int32_t a_fsas_state_idx01 =
                         kept_states_data[state_idx01].a_fsas_state_idx01,
                     fsa_idx0 = next_states_row_ids1[state_idx01];
-            K2_CHECK_EQ(state_map_acc(fsa_idx0, a_fsas_state_idx01),
-                        state_idx01);
+            K2_DCHECK_EQ(state_map_acc(fsa_idx0, a_fsas_state_idx01),
+                         state_idx01);
             // We're resetting state_map to its original clean condition.
             state_map_acc(fsa_idx0, a_fsas_state_idx01) = -1;
           });

--- a/k2/csrc/intersect_test.cu
+++ b/k2/csrc/intersect_test.cu
@@ -18,8 +18,7 @@
 
 namespace k2 {
 
-bool IsRandEquivalentWrapper(
-    Fsa &a, Fsa &b, bool treat_epsilons_specially) {
+bool IsRandEquivalentWrapper(Fsa &a, Fsa &b, bool treat_epsilons_specially) {
   float beam = 10.0;
   bool log_semiring = false;  // actually the intersection algorithm is the same
   // between the semirings; the 2 implementations of
@@ -32,8 +31,6 @@ bool IsRandEquivalentWrapper(
   return IsRandEquivalent(a, b, log_semiring, beam, treat_epsilons_specially,
                           delta, npath);
 }
-
-
 
 TEST(Intersect, Simple) {
   // tests single FSA and also 2 copies of a single FSA.
@@ -58,21 +55,20 @@ TEST(Intersect, Simple) {
 
     if (i >= 2) {
       // Duplicate fsa and dfsavec, stacking 2 copies.
-      { // fsa
-        Fsa *fsa_vec [] = { &fsa, &fsa };
+      {  // fsa
+        Fsa *fsa_vec[] = {&fsa, &fsa};
         FsaVec temp = Stack(0, 2, fsa_vec);
         fsa = temp;
       }
-      { // dfsavec
+      {  // dfsavec
         int32_t nrows = dfsavec.scores.Dim0();
-        Array2<float> scores2(c, nrows * 2,
-                              dfsavec.scores.Dim1());
+        Array2<float> scores2(c, nrows * 2, dfsavec.scores.Dim1());
         Array2<float> scores2a = scores2.RowArange(0, nrows),
                       scores2b = scores2.RowArange(nrows, nrows * 2);
         Assign(dfsavec.scores, &scores2a);
         Assign(dfsavec.scores, &scores2b);
 
-        RaggedShape *dfsavec_shapes [] = { &dfsavec.shape, &dfsavec.shape };
+        RaggedShape *dfsavec_shapes[] = {&dfsavec.shape, &dfsavec.shape};
         RaggedShape stacked_shape = Append(0, 2, dfsavec_shapes);
         dfsavec = DenseFsaVec(stacked_shape, scores2);
       }
@@ -82,9 +78,8 @@ TEST(Intersect, Simple) {
 
     FsaVec out_fsas;
     Array1<int32_t> arc_map_a, arc_map_b;
-    IntersectDense(fsa, dfsavec, output_beam,
-                   &out_fsas,
-                   &arc_map_a, &arc_map_b);
+    IntersectDense(fsa, dfsavec, output_beam, &out_fsas, &arc_map_a,
+                   &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_a = " << arc_map_a
                  << ", arc_map_b = " << arc_map_b;
 
@@ -100,40 +95,41 @@ TEST(Intersect, Simple) {
     Intersect(fsa, fsas_b, treat_epsilons_specially, &out_fsas2, &arc_map_a2,
               &arc_map_b2);
 
-    K2_LOG(INFO) << "out_fsas device type is " << out_fsas.Context()->GetDeviceType();
+    K2_LOG(INFO) << "out_fsas device type is "
+                 << out_fsas.Context()->GetDeviceType();
     out_fsas = out_fsas.To(cpu);
     arc_map_a = arc_map_a.To(cpu);
     arc_map_b = arc_map_b.To(cpu);
 
-    { // check arc map for out_fsas, arc_map_a, arc_map_b
+    {  // check arc map for out_fsas, arc_map_a, arc_map_b
       DenseFsaVec dfsavec2 = dfsavec.To(cpu);
       int32_t num_arcs = out_fsas.NumElements();
       for (int32_t i = 0; i < num_arcs; i++) {
         int32_t arc_idx_a = arc_map_a[i], arc_idx_b = arc_map_b[i];
         float score_a = fsa.values[arc_idx_a].score,
               score_b = dfsavec2.scores.Data()[arc_idx_b],
-       score_composed = out_fsas.values[i].score;
+              score_composed = out_fsas.values[i].score;
         float margin = 1.0e-04 * (fabs(score_a) + fabs(score_b));
-        K2_CHECK( (score_a + score_b) == score_composed ||
-                  fabs(score_a + score_b - score_composed) < margin);
+        K2_CHECK((score_a + score_b) == score_composed ||
+                 fabs(score_a + score_b - score_composed) < margin);
       }
     }
 
-    { // check arc map for out_fsas2, arc_map_a2, arc_map_b2
+    {  // check arc map for out_fsas2, arc_map_a2, arc_map_b2
       int32_t num_arcs = out_fsas2.NumElements();
       for (int32_t i = 0; i < num_arcs; i++) {
         int32_t arc_idx_a = arc_map_a2[i], arc_idx_b = arc_map_b2[i];
         float score_a = fsa.values[arc_idx_a].score,
               score_b = fsas_b.values[arc_idx_b].score,
-       score_composed = out_fsas2.values[i].score;
+              score_composed = out_fsas2.values[i].score;
         float margin = 1.0e-04 * (fabs(score_a) + fabs(score_b));
-        K2_CHECK( (score_a + score_b) == score_composed ||
-                  fabs(score_a + score_b - score_composed) < margin);
+        K2_CHECK((score_a + score_b) == score_composed ||
+                 fabs(score_a + score_b - score_composed) < margin);
       }
     }
 
-    K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                     treat_epsilons_specially));
+    K2_CHECK(
+        IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
 
     K2_LOG(INFO) << "out_fsas2 = " << out_fsas2
                  << ", arc_map_a2 = " << arc_map_a2
@@ -149,7 +145,6 @@ TEST(Intersect, Simple) {
   }
 }
 
-
 TEST(Intersect, RandomSingle) {
   for (int32_t i = 0; i < 10; i++) {
     K2_LOG(INFO) << "Iteration of testing: i = " << i;
@@ -160,8 +155,8 @@ TEST(Intersect, RandomSingle) {
 
     int32_t num_fsas = 1;
 
-    int32_t min_frames = 0, max_frames = 10,
-        min_nsymbols = max_symbol + 1, max_nsymbols = max_symbol + 4;
+    int32_t min_frames = 0, max_frames = 10, min_nsymbols = max_symbol + 1,
+            max_nsymbols = max_symbol + 4;
     float scores_scale = 1.0;
     DenseFsaVec dfsavec =
         RandomDenseFsaVec(num_fsas, num_fsas, min_frames, max_frames,
@@ -187,8 +182,8 @@ TEST(Intersect, RandomSingle) {
 
     FsaVec out_fsas;
     float output_beam = 1000.0;
-    IntersectDense(fsa, dfsavec, output_beam,
-                   &out_fsas, &arc_map_a, &arc_map_b);
+    IntersectDense(fsa, dfsavec, output_beam, &out_fsas, &arc_map_a,
+                   &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_b = " << arc_map_b;
 
     FsaVec fsas_b = ConvertDenseToFsaVec(dfsavec);
@@ -206,11 +201,10 @@ TEST(Intersect, RandomSingle) {
     K2_LOG(INFO) << "out_fsas2 = " << out_fsas2
                  << ", arc_map_a2 = " << arc_map_a2
                  << ", arc_map_b2 = " << arc_map_b2;
-    K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                     treat_epsilons_specially));
+    K2_CHECK(
+        IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
   }
 }
-
 
 TEST(Intersect, RandomFsaVec) {
   for (int32_t i = 0; i < 10; i++) {
@@ -221,16 +215,15 @@ TEST(Intersect, RandomFsaVec) {
     int32_t max_symbol = 10, min_num_arcs = 0, max_num_arcs = 200;
     bool acyclic = false;
 
-    int32_t num_b_fsas = RandInt(1, 5),
-            num_a_fsas = num_b_fsas;
+    int32_t num_b_fsas = RandInt(1, 5), num_a_fsas = num_b_fsas;
 
-    Fsa fsavec = RandomFsaVec(num_a_fsas, num_a_fsas,
-                              acyclic, max_symbol,
-                              min_num_arcs, max_num_arcs).To(c);
+    Fsa fsavec = RandomFsaVec(num_a_fsas, num_a_fsas, acyclic, max_symbol,
+                              min_num_arcs, max_num_arcs)
+                     .To(c);
     ArcSort(&fsavec);
 
-    int32_t min_frames = 0, max_frames = 10,
-        min_nsymbols = max_symbol + 1, max_nsymbols = max_symbol + 4;
+    int32_t min_frames = 0, max_frames = 10, min_nsymbols = max_symbol + 1,
+            max_nsymbols = max_symbol + 4;
     float scores_scale = 1.0;
     DenseFsaVec dfsavec =
         RandomDenseFsaVec(num_b_fsas, num_b_fsas, min_frames, max_frames,
@@ -241,7 +234,6 @@ TEST(Intersect, RandomFsaVec) {
     K2_LOG(INFO) << "Dfsa-vec after reordering is " << dfsavec;
 
     if (true) {
-
       // trying to find bugs where the cutoffs might get mixed up between
       // FSAs
       auto dfsa_acc = dfsavec.scores.Accessor();
@@ -261,27 +253,26 @@ TEST(Intersect, RandomFsaVec) {
     Array1<int32_t> arc_map_a, arc_map_b;
 
     FsaVec out_fsas;
-    float output_beam = 100000.0; // TODO...
-    IntersectDense(fsavec, dfsavec, output_beam,
-                   &out_fsas, &arc_map_a, &arc_map_b);
+    float output_beam = 100000.0;  // TODO(Dan) ...
+    IntersectDense(fsavec, dfsavec, output_beam, &out_fsas, &arc_map_a,
+                   &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_b = " << arc_map_b;
-
 
     fsavec = fsavec.To(cpu);
     out_fsas = out_fsas.To(cpu);
     arc_map_a = arc_map_a.To(cpu);
     arc_map_b = arc_map_b.To(cpu);
-    { // check arc map for out_fsas, arc_map_a, arc_map_b
+    {  // check arc map for out_fsas, arc_map_a, arc_map_b
       DenseFsaVec dfsavec2 = dfsavec.To(cpu);
       int32_t num_arcs = out_fsas.NumElements();
       for (int32_t i = 0; i < num_arcs; i++) {
         int32_t arc_idx_a = arc_map_a[i], arc_idx_b = arc_map_b[i];
         float score_a = fsavec.values[arc_idx_a].score,
               score_b = dfsavec2.scores.Data()[arc_idx_b],
-       score_composed = out_fsas.values[i].score;
+              score_composed = out_fsas.values[i].score;
         float margin = 1.0e-04 * (fabs(score_a) + fabs(score_b));
-        K2_CHECK( (score_a + score_b) == score_composed ||
-                  fabs(score_a + score_b - score_composed) < margin);
+        K2_CHECK((score_a + score_b) == score_composed ||
+                 fabs(score_a + score_b - score_composed) < margin);
       }
     }
 
@@ -293,36 +284,31 @@ TEST(Intersect, RandomFsaVec) {
     // IntersectDensePruned() treats epsilons as normal symbols, so we need to
     // as well.
 
-    ArcSort(
-        &fsavec);  // CAUTION if you later test the arc_maps: we arc-sort here,
-                   // so the input `fsa` is not the same as before.
+    ArcSort(&fsavec);  // CAUTION if you later test the arc_maps: we arc-sort
+                       // here, so the input `fsa` is not the same as before.
     bool treat_epsilons_specially = false;
     Intersect(fsavec, fsas_b, treat_epsilons_specially, &out_fsas2, &arc_map_a2,
               &arc_map_b2);
     K2_LOG(INFO) << "out_fsas2 = " << out_fsas2
                  << ", arc_map_a2 = " << arc_map_a2
                  << ", arc_map_b2 = " << arc_map_b2;
-    K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                     treat_epsilons_specially));
+    K2_CHECK(
+        IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
 
-
-    { // check arc map for out_fsas2, arc_map_a2, arc_map_b2
+    {  // check arc map for out_fsas2, arc_map_a2, arc_map_b2
       int32_t num_arcs = out_fsas2.NumElements();
       for (int32_t i = 0; i < num_arcs; i++) {
         int32_t arc_idx_a = arc_map_a2[i], arc_idx_b = arc_map_b2[i];
         float score_a = fsavec.values[arc_idx_a].score,
               score_b = fsas_b.values[arc_idx_b].score,
-       score_composed = out_fsas2.values[i].score;
+              score_composed = out_fsas2.values[i].score;
         float margin = 1.0e-04 * (fabs(score_a) + fabs(score_b));
-        K2_CHECK( (score_a + score_b) == score_composed ||
-                  fabs(score_a + score_b - score_composed) < margin);
+        K2_CHECK((score_a + score_b) == score_composed ||
+                 fabs(score_a + score_b - score_composed) < margin);
       }
     }
-
-
   }
 }
-
 
 TEST(IntersectPruned, Simple) {
   for (int i = 0; i < 2; i++) {
@@ -348,9 +334,8 @@ TEST(IntersectPruned, Simple) {
 
     FsaVec out_fsas;
     Array1<int32_t> arc_map_a, arc_map_b;
-    IntersectDensePruned(fsa, dfsavec, beam, beam,
-                         min_active, max_active, &out_fsas,
-                         &arc_map_a, &arc_map_b);
+    IntersectDensePruned(fsa, dfsavec, beam, beam, min_active, max_active,
+                         &out_fsas, &arc_map_a, &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_a = " << arc_map_a
                  << ", arc_map_b = " << arc_map_b;
 
@@ -367,8 +352,8 @@ TEST(IntersectPruned, Simple) {
               &arc_map_b2);
 
     out_fsas = out_fsas.To(cpu);
-    K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                     treat_epsilons_specially));
+    K2_CHECK(
+        IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
 
     K2_LOG(INFO) << "out_fsas2 = " << out_fsas2
                  << ", arc_map_a2 = " << arc_map_a2
@@ -406,9 +391,8 @@ TEST(IntersectPruned, TwoDense) {
 
   FsaVec out_fsas;
   Array1<int32_t> arc_map_a, arc_map_b;
-  IntersectDensePruned(fsa, dfsavec, beam, beam,
-                       min_active, max_active,  &out_fsas,
-                       &arc_map_a, &arc_map_b);
+  IntersectDensePruned(fsa, dfsavec, beam, beam, min_active, max_active,
+                       &out_fsas, &arc_map_a, &arc_map_b);
   K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_a = " << arc_map_a
                << ", arc_map_b = " << arc_map_b;
 
@@ -420,8 +404,8 @@ TEST(IntersectPruned, TwoDense) {
   bool treat_epsilons_specially = false;
   Intersect(fsa, fsas_b, treat_epsilons_specially, &out_fsas2, &arc_map_a2,
             &arc_map_b2);
-  K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                   treat_epsilons_specially));
+  K2_CHECK(
+      IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
 
   K2_LOG(INFO) << "out_fsas2 = " << out_fsas2 << ", arc_map_a2 = " << arc_map_a2
                << ", arc_map_b2 = " << arc_map_b2;
@@ -433,7 +417,7 @@ TEST(IntersectPruned, TwoFsas) {
     2 3 -1 3.0
     3
   )",
-      s2 = R"(0 1 1 1.0
+              s2 = R"(0 1 1 1.0
     1 1 1 50.0
     1 2 2 2.0
     2 3 -1 3.0
@@ -456,8 +440,7 @@ TEST(IntersectPruned, TwoFsas) {
 
   FsaVec out_fsas;
   Array1<int32_t> arc_map_a, arc_map_b;
-  IntersectDensePruned(fsa_vec, dfsavec, beam, beam,
-                       min_active, max_active,
+  IntersectDensePruned(fsa_vec, dfsavec, beam, beam, min_active, max_active,
                        &out_fsas, &arc_map_a, &arc_map_b);
   K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_a = " << arc_map_a
                << ", arc_map_b = " << arc_map_b;
@@ -470,8 +453,8 @@ TEST(IntersectPruned, TwoFsas) {
   bool treat_epsilons_specially = false;
   Intersect(fsa_vec, fsas_b, treat_epsilons_specially, &out_fsas2, &arc_map_a2,
             &arc_map_b2);
-  K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                   treat_epsilons_specially));
+  K2_CHECK(
+      IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
 
   K2_LOG(INFO) << "out_fsas2 = " << out_fsas2 << ", arc_map_a2 = " << arc_map_a2
                << ", arc_map_b2 = " << arc_map_b2;
@@ -491,8 +474,8 @@ TEST(IntersectPruned, RandomSingle) {
       num_fsas = RandInt(2, 5);
     }
 
-    int32_t min_frames = 0, max_frames = 10,
-        min_nsymbols = max_symbol + 1, max_nsymbols = max_symbol + 4;
+    int32_t min_frames = 0, max_frames = 10, min_nsymbols = max_symbol + 1,
+            max_nsymbols = max_symbol + 4;
     float scores_scale = 1.0;
     DenseFsaVec dfsavec =
         RandomDenseFsaVec(num_fsas, num_fsas, min_frames, max_frames,
@@ -519,9 +502,8 @@ TEST(IntersectPruned, RandomSingle) {
     FsaVec out_fsas;
     float beam = 1000.0;
     int32_t max_active = 10000, min_active = 0;
-    IntersectDensePruned(fsa, dfsavec, beam, beam,
-                         min_active, max_active,  &out_fsas,
-                         &arc_map_a, &arc_map_b);
+    IntersectDensePruned(fsa, dfsavec, beam, beam, min_active, max_active,
+                         &out_fsas, &arc_map_a, &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_b = " << arc_map_b;
 
     FsaVec fsas_b = ConvertDenseToFsaVec(dfsavec);
@@ -539,11 +521,10 @@ TEST(IntersectPruned, RandomSingle) {
     K2_LOG(INFO) << "out_fsas2 = " << out_fsas2
                  << ", arc_map_a2 = " << arc_map_a2
                  << ", arc_map_b2 = " << arc_map_b2;
-    K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                     treat_epsilons_specially));
+    K2_CHECK(
+        IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
   }
 }
-
 
 TEST(IntersectPruned, RandomFsaVec) {
   for (int32_t i = 0; i < 10; i++) {
@@ -551,18 +532,18 @@ TEST(IntersectPruned, RandomFsaVec) {
     int32_t max_symbol = 10, min_num_arcs = 0, max_num_arcs = 200;
     bool acyclic = false;
     ContextPtr c = (i % 2 == 0 ? GetCpuContext() : GetCudaContext()),
-             cpu = GetCpuContext();
+               cpu = GetCpuContext();
 
     int32_t num_b_fsas = RandInt(1, 5),
-        num_a_fsas = (RandInt(0, 1) ? 1 : num_b_fsas);
+            num_a_fsas = (RandInt(0, 1) ? 1 : num_b_fsas);
 
-    Fsa fsavec = RandomFsaVec(num_a_fsas, num_a_fsas,
-                              acyclic, max_symbol,
-                              min_num_arcs, max_num_arcs).To(c);
+    Fsa fsavec = RandomFsaVec(num_a_fsas, num_a_fsas, acyclic, max_symbol,
+                              min_num_arcs, max_num_arcs)
+                     .To(c);
     ArcSort(&fsavec);
 
-    int32_t min_frames = 0, max_frames = 10,
-        min_nsymbols = max_symbol + 1, max_nsymbols = max_symbol + 4;
+    int32_t min_frames = 0, max_frames = 10, min_nsymbols = max_symbol + 1,
+            max_nsymbols = max_symbol + 4;
     float scores_scale = 1.0;
     DenseFsaVec dfsavec =
         RandomDenseFsaVec(num_b_fsas, num_b_fsas, min_frames, max_frames,
@@ -590,9 +571,8 @@ TEST(IntersectPruned, RandomFsaVec) {
     FsaVec out_fsas;
     float search_beam = 1000.0, output_beam = 1000.0;
     int32_t min_active = 0, max_active = 10;
-    IntersectDensePruned(fsavec, dfsavec, search_beam, output_beam,
-                         min_active, max_active,
-                         &out_fsas, &arc_map_a, &arc_map_b);
+    IntersectDensePruned(fsavec, dfsavec, search_beam, output_beam, min_active,
+                         max_active, &out_fsas, &arc_map_a, &arc_map_b);
     K2_LOG(INFO) << "out_fsas = " << out_fsas << ", arc_map_b = " << arc_map_b;
 
     out_fsas = out_fsas.To(cpu);
@@ -601,19 +581,18 @@ TEST(IntersectPruned, RandomFsaVec) {
     arc_map_a = arc_map_a.To(cpu);
     arc_map_b = arc_map_b.To(cpu);
 
-    { // check arc map for out_fsas, arc_map_a, arc_map_b
+    {  // check arc map for out_fsas, arc_map_a, arc_map_b
       int32_t num_arcs = out_fsas.NumElements();
       for (int32_t i = 0; i < num_arcs; i++) {
         int32_t arc_idx_a = arc_map_a[i], arc_idx_b = arc_map_b[i];
         float score_a = fsavec.values[arc_idx_a].score,
               score_b = dfsavec.scores.Data()[arc_idx_b],
-       score_composed = out_fsas.values[i].score;
+              score_composed = out_fsas.values[i].score;
         float margin = 1.0e-04 * (fabs(score_a) + fabs(score_b));
-        K2_CHECK( (score_a + score_b) == score_composed ||
-                  fabs(score_a + score_b - score_composed) < margin);
+        K2_CHECK((score_a + score_b) == score_composed ||
+                 fabs(score_a + score_b - score_composed) < margin);
       }
     }
-
 
     FsaVec fsas_b = ConvertDenseToFsaVec(dfsavec);
     K2_LOG(INFO) << "fsas_b = " << fsas_b;
@@ -622,19 +601,17 @@ TEST(IntersectPruned, RandomFsaVec) {
     // IntersectDensePruned() treats epsilons as normal symbols, so we need to
     // as well.
 
-    ArcSort(
-        &fsavec);  // CAUTION if you later test the arc_maps: we arc-sort here,
-                   // so the input `fsa` is not the same as before.
+    ArcSort(&fsavec);  // CAUTION if you later test the arc_maps: we arc-sort
+                       // here, so the input `fsa` is not the same as before.
     bool treat_epsilons_specially = false;
     Intersect(fsavec, fsas_b, treat_epsilons_specially, &out_fsas2, &arc_map_a2,
               &arc_map_b2);
     K2_LOG(INFO) << "out_fsas2 = " << out_fsas2
                  << ", arc_map_a2 = " << arc_map_a2
                  << ", arc_map_b2 = " << arc_map_b2;
-    K2_CHECK(IsRandEquivalentWrapper(out_fsas, out_fsas2,
-                                     treat_epsilons_specially));
+    K2_CHECK(
+        IsRandEquivalentWrapper(out_fsas, out_fsas2, treat_epsilons_specially));
   }
 }
-
 
 }  // namespace k2

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -21,4 +21,16 @@
 #define K2_FUNC __func__
 #endif
 
+#define K2_EVAL(context, dim, lambda_name, ...)           \
+  do {                                                    \
+    if (context->GetDeviceType() == kCpu) {               \
+      auto lambda_name = [=] __VA_ARGS__;                 \
+      int32_t _dim = dim;                                 \
+      for (int32_t i = 0; i != _dim; ++i) lambda_name(i); \
+    } else {                                              \
+      auto lambda_name = [=] __device__ __VA_ARGS__;      \
+      EvalDevice(context, dim, lambda_name);              \
+    }                                                     \
+  } while (0)
+
 #endif  // K2_CSRC_MACROS_H_

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -21,6 +21,36 @@
 #define K2_FUNC __func__
 #endif
 
+/*
+`K2_EVAL` simplifies the task of writing lambdas
+for CUDA as well as for CPU.
+
+Assume you have a lambda to increment the elements of an array:
+
+@code
+  Array1<int32_t> array = ...; // initialize it
+  int32_t *array_data = array.Data();
+  ContextPtr &context = array.Context();
+  if (context->GetDeviceType() == kCpu) {
+    for (int32_t i = 0; i != array.Dim(); ++i) array_data[i] += 1;
+  } else {
+    auto lambda_inc = [=] __device__ (int32_t i) {
+      array_data[i] += 1;
+    };
+    EvalDevice(context, array.Dim(); lambda_inc);
+  }
+@endcode
+
+You can replace the above code with `K2_EVAL` by the following code:
+
+@code
+  Array1<int32_t> array = ...; // initialize it
+  int32_t *array_data = array.Data();
+  K2_EVAL(
+      c, array.Dim(), inc, (int32_t i)->void { array_data[i] += 1; });
+@endcode
+ */
+
 #define K2_EVAL(context, dim, lambda_name, ...)           \
   do {                                                    \
     if (context->GetDeviceType() == kCpu) {               \
@@ -31,6 +61,57 @@
       auto lambda_name = [=] __device__ __VA_ARGS__;      \
       EvalDevice(context, dim, lambda_name);              \
     }                                                     \
+  } while (0)
+
+/*
+`K2_EVAL2` simplifies the task of writing lambdas
+for CUDA as well as for CPU.
+
+Assume you have a lambda to increment the elements of an array2:
+
+@code
+  Array2<int32_t> array = ...; // initialize it
+  int32_t *array_data = array.Data();
+  int32_t elem_stride0 = array.ElemStride0();
+  ContextPtr &context = array.Context();
+  if (context->GetDeviceType() == kCpu) {
+    for (int32_t i = 0; i != array.Dim0(); ++i)
+      for (int32_t j = 0; j != array.Dim1(); ++j)
+        array_data[i * elem_stride0 + j] += 1;
+  } else {
+    auto lambda_inc = [=] __device__ (int32_t i, j) {
+      array_data[i * elem_stride0 + j] += 1;
+    };
+    Eval2Device(context, array.Dim0(), array.Dim1(), lambda_inc);
+  }
+@endcode
+
+You can replace the above code with `K2_EVAL2` by the following code:
+
+@code
+  Array2<int32_t> array = ...; // initialize it
+  int32_t *array_data = array.Data();
+  int32_t elem_stride0 = array.ElemStride0();
+  ContextPtr &context = array.Context();
+  K2_EVAL2(
+      context, array.Dim0(), array.Dim1(), lambda_inc,
+      (int32_t i, int32_t j)->void {
+        array_data[i * elem_stride0 + j] += 1;
+      });
+@endcode
+ */
+#define K2_EVAL2(context, m, n, lambda_name, ...)            \
+  do {                                                       \
+    if (context->GetDeviceType() == kCpu) {                  \
+      auto lambda_name = [=] __VA_ARGS__;                    \
+      int32_t _m = m;                                        \
+      int32_t _n = n;                                        \
+      for (int32_t i = 0; i != _m; ++i)                      \
+        for (int32_t j = 0; j != _n; ++j) lambda_name(i, j); \
+    } else {                                                 \
+      auto lambda_name = [=] __device__ __VA_ARGS__;         \
+      Eval2Device(context, m, n, lambda_name);               \
+    }                                                        \
   } while (0)
 
 #endif  // K2_CSRC_MACROS_H_

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -51,16 +51,16 @@ You can replace the above code with `K2_EVAL` by the following code:
 @endcode
  */
 
-#define K2_EVAL(context, dim, lambda_name, ...)           \
-  do {                                                    \
-    if (context->GetDeviceType() == kCpu) {               \
-      auto lambda_name = [=] __VA_ARGS__;                 \
-      int32_t _dim = dim;                                 \
-      for (int32_t i = 0; i != _dim; ++i) lambda_name(i); \
-    } else {                                              \
-      auto lambda_name = [=] __device__ __VA_ARGS__;      \
-      EvalDevice(context, dim, lambda_name);              \
-    }                                                     \
+#define K2_EVAL(context, dim, lambda_name, ...)                        \
+  do {                                                                 \
+    if (context->GetDeviceType() == kCpu) {                            \
+      auto lambda_name = [=] __VA_ARGS__;                              \
+      int32_t lambda_name##_dim = dim;                                 \
+      for (int32_t i = 0; i != lambda_name##_dim; ++i) lambda_name(i); \
+    } else {                                                           \
+      auto lambda_name = [=] __device__ __VA_ARGS__;                   \
+      EvalDevice(context, dim, lambda_name);                           \
+    }                                                                  \
   } while (0)
 
 /*
@@ -100,18 +100,18 @@ You can replace the above code with `K2_EVAL2` by the following code:
       });
 @endcode
  */
-#define K2_EVAL2(context, m, n, lambda_name, ...)            \
-  do {                                                       \
-    if (context->GetDeviceType() == kCpu) {                  \
-      auto lambda_name = [=] __VA_ARGS__;                    \
-      int32_t _m = m;                                        \
-      int32_t _n = n;                                        \
-      for (int32_t i = 0; i != _m; ++i)                      \
-        for (int32_t j = 0; j != _n; ++j) lambda_name(i, j); \
-    } else {                                                 \
-      auto lambda_name = [=] __device__ __VA_ARGS__;         \
-      Eval2Device(context, m, n, lambda_name);               \
-    }                                                        \
+#define K2_EVAL2(context, m, n, lambda_name, ...)                         \
+  do {                                                                    \
+    if (context->GetDeviceType() == kCpu) {                               \
+      auto lambda_name = [=] __VA_ARGS__;                                 \
+      int32_t lambda_name##_m = m;                                        \
+      int32_t lambda_name##_n = n;                                        \
+      for (int32_t i = 0; i != lambda_name##_m; ++i)                      \
+        for (int32_t j = 0; j != lambda_name##_n; ++j) lambda_name(i, j); \
+    } else {                                                              \
+      auto lambda_name = [=] __device__ __VA_ARGS__;                      \
+      Eval2Device(context, m, n, lambda_name);                            \
+    }                                                                     \
   } while (0)
 
 #endif  // K2_CSRC_MACROS_H_

--- a/k2/csrc/macros_test.cu
+++ b/k2/csrc/macros_test.cu
@@ -1,0 +1,43 @@
+/**
+ * @brief Unittest for macros.
+ *
+ * @copyright
+ * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "k2/csrc/array.h"
+#include "k2/csrc/context.h"
+#include "k2/csrc/macros.h"
+#include "k2/csrc/test_utils.h"
+
+namespace k2 {
+
+static void TestEval() {
+  for (auto &c : {GetCpuContext(), GetCudaContext()}) {
+    Array1<int32_t> array = Range(c, 3, 0);
+    int32_t *array_data = array.Data();
+    K2_EVAL(
+        c, array.Dim(), inc, (int32_t i)->void { array_data[i] += 1; });
+    CheckArrayData(array, std::vector<int32_t>{1, 2, 3});
+
+    // with multiple lines
+    K2_EVAL(
+        c, array.Dim(), inc, (int32_t kk)->void {
+          array_data[kk] += 1;
+          array_data[kk] += 1;
+          array_data[kk] += 1;
+        });
+    CheckArrayData(array, std::vector<int32_t>{4, 5, 6});
+  }
+}
+
+TEST(Macros, Eval) { TestEval(); }
+
+}  // namespace k2

--- a/k2/csrc/macros_test.cu
+++ b/k2/csrc/macros_test.cu
@@ -38,6 +38,23 @@ static void TestEval() {
   }
 }
 
+static void TestEval2() {
+  for (auto &c : {GetCpuContext(), GetCudaContext()}) {
+    Array1<int32_t> array1 = Range(c, 6, 0);
+    Array2<int32_t> array(array1, 2, 3);
+    int32_t *array_data = array.Data();
+    int32_t elem_stride0 = array.ElemStride0();
+    ContextPtr &context = array.Context();
+    K2_EVAL2(
+        context, array.Dim0(), array.Dim1(), lambda_inc,
+        (int32_t i, int32_t j)->void {
+          array_data[i * elem_stride0 + j] += 1;
+        });
+    CheckArrayData(array.Flatten(), std::vector<int32_t>{1, 2, 3, 4, 5, 6});
+  }
+}
+
 TEST(Macros, Eval) { TestEval(); }
+TEST(Macros, Eval2) { TestEval2(); }
 
 }  // namespace k2

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -257,23 +257,22 @@ RaggedShape Unsqueeze(const RaggedShape &src, int32_t axis) {
     row_ids_dim = src.Dim0();  // e.g. [ 0 0 0 0 0 ]
     mem = Array1<int32_t>(c, row_splits_dim + row_ids_dim);
     int32_t *mem_data = mem.Data();
-    auto lambda_set_mem = [=] __host__ __device__(int32_t i) -> void {
-      if (i == 1)
-        mem_data[i] = row_ids_dim;
-      else
-        mem_data[i] = 0;
-    };
-    Eval(c, mem.Dim(), lambda_set_mem);
+    K2_EVAL(
+        c, mem.Dim(), lambda_set_mem, (int32_t i)->void {
+          if (i == 1)
+            mem_data[i] = row_ids_dim;
+          else
+            mem_data[i] = 0;
+        });
   } else {
     int32_t tot_size = src.TotSize(axis);
     row_splits_dim = tot_size + 1;
     row_ids_dim = tot_size;
     mem = Array1<int32_t>(c, row_splits_dim + row_ids_dim);
     int32_t *mem_data = mem.Data();
-    auto lambda_set_mem2 = [=] __host__ __device__(int32_t i) -> void {
-      mem_data[i] = i % (tot_size + 1);
-    };
-    Eval(c, mem.Dim(), lambda_set_mem2);
+    K2_EVAL(
+        c, mem.Dim(), lambda_set_mem2,
+        (int32_t i)->void { mem_data[i] = i % (tot_size + 1); });
   }
   axes_out[axis].row_splits = mem.Range(0, row_splits_dim);
   axes_out[axis].row_ids = mem.Range(row_splits_dim, row_ids_dim);
@@ -360,20 +359,20 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
        new_offsets_acc = new_offsets->Accessor();
   // Set old_offsets; and for now, set new_offsets to the corresponding
   // sizes of the output slices.
-  auto lambda_set_offsets = [=] __host__ __device__(int32_t i) {
-    // 0 <= i < ans_dim0
-    int32_t old_offset = new2old_data[i], old_offset_next = old_offset + 1;
-    for (int32_t axis = 0;; axis++) {
-      old_offsets_acc(axis, i) = old_offset;
-      // Below, 'new_offsets_acc' currently contains the size rather
-      // than the offset; we need to do exclusive-sum.
-      new_offsets_acc(axis, i) = old_offset_next - old_offset;
-      if (axis + 1 == num_axes) return;
-      old_offset = src_row_splits_ptrs_data[axis][old_offset];
-      old_offset_next = src_row_splits_ptrs_data[axis][old_offset_next];
-    }
-  };
-  Eval(c, ans_dim0, lambda_set_offsets);
+  K2_EVAL(
+      c, ans_dim0, lambda_set_offsets, (int32_t i) {
+        // 0 <= i < ans_dim0
+        int32_t old_offset = new2old_data[i], old_offset_next = old_offset + 1;
+        for (int32_t axis = 0;; axis++) {
+          old_offsets_acc(axis, i) = old_offset;
+          // Below, 'new_offsets_acc' currently contains the size rather
+          // than the offset; we need to do exclusive-sum.
+          new_offsets_acc(axis, i) = old_offset_next - old_offset;
+          if (axis + 1 == num_axes) return;
+          old_offset = src_row_splits_ptrs_data[axis][old_offset];
+          old_offset_next = src_row_splits_ptrs_data[axis][old_offset_next];
+        }
+      });
   ExclusiveSum(*new_offsets, new_offsets);
 }
 
@@ -788,10 +787,9 @@ RaggedShape MakeTransposable(RaggedShape &src) {
       axis1_shape.row_ids = Array1<int32_t>(c, ans_tot_size1);
       int32_t *row_ids1_data = axis1_shape.row_ids.Data();
       axis1_shape.cached_tot_size = ans_tot_size1;
-      auto lambda_set_row_ids1 = [=] __host__ __device__(int32_t i) {
-        row_ids1_data[i] = i / max_size;
-      };
-      Eval(c, ans_tot_size1, lambda_set_row_ids1);
+      K2_EVAL(
+          c, ans_tot_size1, lambda_set_row_ids1,
+          (int32_t i) { row_ids1_data[i] = i / max_size; });
     }
     if (num_axes > 2) {
       RaggedShapeDim &axis2_shape = axes_out[1];
@@ -802,22 +800,24 @@ RaggedShape MakeTransposable(RaggedShape &src) {
         axis2_shape.cached_tot_size = src.TotSize(2);
         axis2_shape.row_splits = Array1<int32_t>(c, ans_tot_size1 + 1);
         int32_t *ans_row_splits2_data = axis2_shape.row_splits.Data();
-        auto lambda_set_row_splits2 = [=] __host__ __device__(int32_t idx01) {
-          if (idx01 == ans_tot_size1) {
-            ans_row_splits2_data[idx01] = src_row_splits2_data[src_tot_size1];
-            return;
-          }
-          int32_t idx0 = idx01 / max_size, idx1 = idx01 % max_size;
-          int32_t idx0x = src_row_splits1_data[idx0],
-                  idx0x_next = src_row_splits1_data[idx0 + 1];
-          int32_t num_elems_this_row = idx0x_next - idx0x;
-          if (idx1 < num_elems_this_row)
-            ans_row_splits2_data[idx01] = src_row_splits2_data[idx0x + idx1];
-          else
-            ans_row_splits2_data[idx01] =
-                src_row_splits2_data[idx0x_next];  // append empty row
-        };
-        Eval(c, ans_tot_size1 + 1, lambda_set_row_splits2);
+        K2_EVAL(
+            c, ans_tot_size1 + 1, lambda_set_row_splits2, (int32_t idx01) {
+              if (idx01 == ans_tot_size1) {
+                ans_row_splits2_data[idx01] =
+                    src_row_splits2_data[src_tot_size1];
+                return;
+              }
+              int32_t idx0 = idx01 / max_size, idx1 = idx01 % max_size;
+              int32_t idx0x = src_row_splits1_data[idx0],
+                      idx0x_next = src_row_splits1_data[idx0 + 1];
+              int32_t num_elems_this_row = idx0x_next - idx0x;
+              if (idx1 < num_elems_this_row)
+                ans_row_splits2_data[idx01] =
+                    src_row_splits2_data[idx0x + idx1];
+              else
+                ans_row_splits2_data[idx01] =
+                    src_row_splits2_data[idx0x_next];  // append empty row
+            });
       }
       {
         // set ans.RowIds(2);
@@ -826,13 +826,13 @@ RaggedShape MakeTransposable(RaggedShape &src) {
         axis2_shape.row_ids = Array1<int32_t>(c, tot_size2);
         int32_t *ans_row_ids2_data = axis2_shape.row_ids.Data();
         const int32_t *src_row_ids2_data = src.RowIds(2).Data();
-        auto lambda_set_row_ids2 = [=] __host__ __device__(int32_t idx012) {
-          int32_t src_idx01 = src_row_ids2_data[idx012];
-          int32_t src_idx0 = src_row_ids1_data[src_idx01];
-          int32_t src_idx1 = src_idx01 - src_row_splits1_data[src_idx0];
-          ans_row_ids2_data[idx012] = (src_idx0 * max_size) + src_idx1;
-        };
-        Eval(c, tot_size2, lambda_set_row_ids2);
+        K2_EVAL(
+            c, tot_size2, lambda_set_row_ids2, (int32_t idx012) {
+              int32_t src_idx01 = src_row_ids2_data[idx012];
+              int32_t src_idx0 = src_row_ids1_data[src_idx01];
+              int32_t src_idx1 = src_idx01 - src_row_splits1_data[src_idx0];
+              ans_row_ids2_data[idx012] = (src_idx0 * max_size) + src_idx1;
+            });
       }
     }
   }
@@ -863,11 +863,11 @@ RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
   // to the first index into src_no_axis0.
   Array1<int32_t> renumbering(c, src_tot_size1);
   int32_t *renumbering_data = renumbering.Data();
-  auto lambda_set_renumbering = [=] __host__ __device__(int32_t i) {
-    int32_t j = i % src_dim0, k = i / src_dim0, i_old = j * src_dim1 + k;
-    renumbering_data[i] = i_old;
-  };
-  Eval(c, src_tot_size1, lambda_set_renumbering);
+  K2_EVAL(
+      c, src_tot_size1, lambda_set_renumbering, (int32_t i) {
+        int32_t j = i % src_dim0, k = i / src_dim0, i_old = j * src_dim1 + k;
+        renumbering_data[i] = i_old;
+      });
 
   RaggedShape src_no_axis0_renumbered =
       Index(src_no_axis0, renumbering, value_indexes);
@@ -877,20 +877,20 @@ RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
   std::vector<RaggedShapeDim> ans_axis0(1);
   Array1<int32_t> mem(c, row_splits_dim + row_ids_dim);
   int32_t *mem_data = mem.Data();
-  auto lambda_set_row_info = [=] __host__ __device__(int32_t i) {
-    int32_t val;
-    if (i >= row_splits_dim) {
-      // row_ids
-      int32_t elem_idx = i - row_splits_dim;
-      val = elem_idx / src_dim0;
-    } else {
-      // row_splits
-      int32_t row_idx = i;
-      val = row_idx * src_dim0;
-    }
-    mem_data[i] = val;
-  };
-  Eval(c, row_splits_dim + row_ids_dim, lambda_set_row_info);
+  K2_EVAL(
+      c, row_splits_dim + row_ids_dim, lambda_set_row_info, (int32_t i) {
+        int32_t val;
+        if (i >= row_splits_dim) {
+          // row_ids
+          int32_t elem_idx = i - row_splits_dim;
+          val = elem_idx / src_dim0;
+        } else {
+          // row_splits
+          int32_t row_idx = i;
+          val = row_idx * src_dim0;
+        }
+        mem_data[i] = val;
+      });
   ans_axis0[0].row_splits = mem.Range(0, row_splits_dim);
   ans_axis0[0].row_ids = mem.Range(row_splits_dim, row_ids_dim);
   ans_axis0[0].cached_tot_size = row_ids_dim;
@@ -936,10 +936,9 @@ RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1) {
   int32_t *row_splits_data = row_splits.Data();
   Array1<int32_t> row_ids(c, dim0 * dim1);
   int32_t *row_ids_data = row_ids.Data();
-  auto lambda_set_row_ids = [=] __host__ __device__(int32_t i, int32_t j) {
-    row_ids_data[i * dim1 + j] = i;
-  };
-  Eval2(c, dim0, dim1, lambda_set_row_ids);
+  K2_EVAL2(
+      c, dim0, dim1, lambda_set_row_ids,
+      (int32_t i, int32_t j) { row_ids_data[i * dim1 + j] = i; });
   return RaggedShape2(&row_splits, &row_ids, dim0 * dim1);
 }
 
@@ -1101,43 +1100,43 @@ RaggedShape ChangeSublistSize(RaggedShape &src, int32_t size_delta) {
     ParallelRunner pr(c);
     {
       With w(pr.NewStream());
-      auto lambda_set_row_splits =
-          [=] __host__ __device__(int32_t idx0) -> void {
-        row_splits_data[idx0] = src_row_splits_data[idx0] + size_delta * idx0;
-      };
-      Eval(c, num_rows + 1, lambda_set_row_splits);
+      K2_EVAL(
+          c, num_rows + 1, lambda_set_row_splits, (int32_t idx0)->void {
+            row_splits_data[idx0] =
+                src_row_splits_data[idx0] + size_delta * idx0;
+          });
     }
 
     {
       With w(pr.NewStream());
-      auto lambda_set_row_ids1 =
-          [=] __host__ __device__(int32_t src_idx01) -> void {
-        int32_t src_idx0 = src_row_ids_data[src_idx01],
-                src_idx0x = src_row_splits_data[src_idx0],
-                src_idx1 = src_idx01 - src_idx0x,
-                new_idx0x = row_splits_data[src_idx0],
-                new_idx0x_next = row_splits_data[src_idx0 + 1],
-                new_idx01 = new_idx0x + src_idx1;
-        // it's only necessary to guard the next statement with in 'if' because
-        // size_delta might be negative.
-        if (new_idx01 < new_idx0x_next) row_ids_data[new_idx01] = src_idx0;
-      };
-      Eval(c, src_num_elems, lambda_set_row_ids1);
+      K2_EVAL(
+          c, src_num_elems, lambda_set_row_ids1, (int32_t src_idx01)->void {
+            int32_t src_idx0 = src_row_ids_data[src_idx01],
+                    src_idx0x = src_row_splits_data[src_idx0],
+                    src_idx1 = src_idx01 - src_idx0x,
+                    new_idx0x = row_splits_data[src_idx0],
+                    new_idx0x_next = row_splits_data[src_idx0 + 1],
+                    new_idx01 = new_idx0x + src_idx1;
+            // it's only necessary to guard the next statement with in 'if'
+            // because size_delta might be negative.
+            if (new_idx01 < new_idx0x_next) row_ids_data[new_idx01] = src_idx0;
+          });
     }
     if (size_delta > 0) {
       // This sets the row-ids that are not set by lambda_set_row_ids1.
       With w(pr.NewStream());
-      auto lambda_set_row_ids2 = [=] __host__ __device__(int32_t i) -> void {
-        int32_t idx0 = i / size_delta, n = i % size_delta, next_idx0 = idx0 + 1;
-        // The following formula is the same as the one in
-        // lambda_set_row_splits; we want to compute the new value of
-        // row_splits_data[next_idx0] without waiting for that kernel to
-        // terminate.
-        int32_t next_idx0x =
-            src_row_splits_data[next_idx0] + size_delta * next_idx0;
-        row_ids_data[next_idx0x - 1 - n] = idx0;
-      };
-      Eval(c, num_rows * size_delta, lambda_set_row_ids2);
+      K2_EVAL(
+          c, num_rows * size_delta, lambda_set_row_ids2, (int32_t i)->void {
+            int32_t idx0 = i / size_delta, n = i % size_delta,
+                    next_idx0 = idx0 + 1;
+            // The following formula is the same as the one in
+            // lambda_set_row_splits; we want to compute the new value of
+            // row_splits_data[next_idx0] without waiting for that kernel to
+            // terminate.
+            int32_t next_idx0x =
+                src_row_splits_data[next_idx0] + size_delta * next_idx0;
+            row_ids_data[next_idx0x - 1 - n] = idx0;
+          });
     }
     // make the ParallelRunner go out of scope (should do this before any
     // validation code that gets invoked by the constructor of RaggedShape
@@ -1272,33 +1271,32 @@ RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &r_before_last,
   }
   {
     With w(pr.NewStream());
-    auto lambda_set_row_ids1_and_row_splits2 =
-        [=] __host__ __device__(int32_t new_idx01) -> void {
-      // row_ids1 maps from idx01 -> idx0.  Select subset of
-      // idx01's; the idx0 stays the same.
-      int32_t old_idx01 = idx01_new2old_data[new_idx01];
-      if (new_idx01 < new_tot_size1)
-        new_row_ids1_data[new_idx01] = old_row_ids1_data[old_idx01];
-      // row_splits2 maps from idx01 -> idx012.  Map both indexes.
-      // idx01's; the idx0 stays the same.
-      new_row_splits2_data[new_idx01] =
-          idx012_old2new_data[old_row_splits2_data[old_idx01]];
-    };
-    Eval(c, new_tot_size1 + 1, lambda_set_row_ids1_and_row_splits2);
+    K2_EVAL(
+        c, new_tot_size1 + 1, lambda_set_row_ids1_and_row_splits2,
+        (int32_t new_idx01)->void {
+          // row_ids1 maps from idx01 -> idx0.  Select subset of
+          // idx01's; the idx0 stays the same.
+          int32_t old_idx01 = idx01_new2old_data[new_idx01];
+          if (new_idx01 < new_tot_size1)
+            new_row_ids1_data[new_idx01] = old_row_ids1_data[old_idx01];
+          // row_splits2 maps from idx01 -> idx012.  Map both indexes.
+          // idx01's; the idx0 stays the same.
+          new_row_splits2_data[new_idx01] =
+              idx012_old2new_data[old_row_splits2_data[old_idx01]];
+        });
   }
 
   {
     With w(pr.NewStream());
-    auto lambda_set_row_ids2 =
-        [=] __host__ __device__(int32_t new_idx012) -> void {
-      // row_ids2 maps from idx012 -> idx01.  Both must be mapped.
+    K2_EVAL(
+        c, new_tot_size2, lambda_set_row_ids2, (int32_t new_idx012)->void {
+          // row_ids2 maps from idx012 -> idx01.  Both must be mapped.
 
-      int32_t old_idx012 = idx012_new2old_data[new_idx012];
-      int32_t old_idx01 = old_row_ids2_data[old_idx012],
-              new_idx01 = idx01_old2new_data[old_idx01];
-      new_row_ids2_data[new_idx012] = new_idx01;
-    };
-    Eval(c, new_tot_size2, lambda_set_row_ids2);
+          int32_t old_idx012 = idx012_new2old_data[new_idx012];
+          int32_t old_idx01 = old_row_ids2_data[old_idx012],
+                  new_idx01 = idx01_old2new_data[old_idx01];
+          new_row_ids2_data[new_idx012] = new_idx01;
+        });
   }
 
   before_last.row_ids = before_last_row_ids;

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -155,19 +155,18 @@ RaggedShape RaggedShape3(Array1<int32_t> *row_splits1,
 
   RaggedShape shape1 = RaggedShape2(row_splits1, row_ids1, cached_tot_size1);
 
-
   Array1<int32_t> temp_array;
   if (row_splits2 == nullptr) {
-    K2_CHECK_NE(row_ids2, nullptr) << "Either row-splits or row-ids must be defined";
+    K2_CHECK_NE(row_ids2, nullptr)
+        << "Either row-splits or row-ids must be defined";
     temp_array = Array1<int32_t>(row_ids2->Context(), shape1.NumElements() + 1);
     row_splits2 = &temp_array;
     RowIdsToRowSplits(*row_ids2, row_splits2);
   }
 
-  return ComposeRaggedShapes(shape1,
-                             RaggedShape2(row_splits2, row_ids2, cached_tot_size2));
+  return ComposeRaggedShapes(
+      shape1, RaggedShape2(row_splits2, row_ids2, cached_tot_size2));
 }
-
 
 RaggedShape RaggedShape4(Array1<int32_t> *row_splits1,
                          Array1<int32_t> *row_ids1, int32_t cached_tot_size1,
@@ -175,23 +174,22 @@ RaggedShape RaggedShape4(Array1<int32_t> *row_splits1,
                          Array1<int32_t> *row_ids2, int32_t cached_tot_size2,
                          Array1<int32_t> *row_splits3,
                          Array1<int32_t> *row_ids3, int32_t cached_tot_size3) {
-  NVTX_RANGE(__func__);
-
+  NVTX_RANGE(K2_FUNC);
 
   RaggedShape shape12 = RaggedShape3(row_splits1, row_ids1, cached_tot_size1,
                                      row_splits2, row_ids2, cached_tot_size2);
   Array1<int32_t> temp_array;
   if (row_splits3 == nullptr) {
-    K2_CHECK_NE(row_ids3, nullptr) << "Either row-splits or row-ids must be defined";
-    temp_array = Array1<int32_t>(row_ids3->Context(), shape12.NumElements() + 1);
+    K2_CHECK_NE(row_ids3, nullptr)
+        << "Either row-splits or row-ids must be defined";
+    temp_array =
+        Array1<int32_t>(row_ids3->Context(), shape12.NumElements() + 1);
     row_splits3 = &temp_array;
     RowIdsToRowSplits(*row_ids3, row_splits3);
   }
-  return ComposeRaggedShapes(shape12,
-                             RaggedShape2(row_splits3, row_ids3,
-                                          cached_tot_size3));
+  return ComposeRaggedShapes(
+      shape12, RaggedShape2(row_splits3, row_ids3, cached_tot_size3));
 }
-
 
 RaggedShape RaggedShapeFromTotSizes(ContextPtr c, int32_t num_axes,
                                     int32_t *tot_sizes) {
@@ -1016,10 +1014,10 @@ static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
   int32_t n = src.values.Dim();
   Array1<int32_t> ans = Range(context, n, 0);
   if (n == 0) return ans;
-  K2_CUDA_SAFE_CALL(mgpu::segmented_sort(ans.Data(),       // keys
-                                         ans.Dim(),        // count
-                                         segments.Data(),  // segments
-                                         segments.Dim() - 1, // num_segments
+  K2_CUDA_SAFE_CALL(mgpu::segmented_sort(ans.Data(),          // keys
+                                         ans.Dim(),           // count
+                                         segments.Data(),     // segments
+                                         segments.Dim() - 1,  // num_segments
                                          lambda_comp, *mgpu_context));
   return ans;
 }
@@ -1324,9 +1322,8 @@ Array1<int32_t> GetDecreasingSizeOrder(RaggedShape &shape) {
 
   Array1<int32_t> sizes = RowSplitsToSizes(shape.RowSplits(1));
   Array1<int32_t> index_map;
-  Sort<int32_t, GreaterThan<int32_t> > (&sizes, &index_map);
+  Sort<int32_t, GreaterThan<int32_t>>(&sizes, &index_map);
   return index_map;
 }
-
 
 }  // namespace k2

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -358,7 +358,7 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
   // Set old_offsets; and for now, set new_offsets to the corresponding
   // sizes of the output slices.
   K2_EVAL(
-      c, ans_dim0, lambda_set_offsets, (int32_t i) {
+      c, ans_dim0, lambda_set_offsets, (int32_t i)->void {
         // 0 <= i < ans_dim0
         int32_t old_offset = new2old_data[i], old_offset_next = old_offset + 1;
         for (int32_t axis = 0;; axis++) {
@@ -787,7 +787,7 @@ RaggedShape MakeTransposable(RaggedShape &src) {
       axis1_shape.cached_tot_size = ans_tot_size1;
       K2_EVAL(
           c, ans_tot_size1, lambda_set_row_ids1,
-          (int32_t i) { row_ids1_data[i] = i / max_size; });
+          (int32_t i)->void { row_ids1_data[i] = i / max_size; });
     }
     if (num_axes > 2) {
       RaggedShapeDim &axis2_shape = axes_out[1];
@@ -799,7 +799,8 @@ RaggedShape MakeTransposable(RaggedShape &src) {
         axis2_shape.row_splits = Array1<int32_t>(c, ans_tot_size1 + 1);
         int32_t *ans_row_splits2_data = axis2_shape.row_splits.Data();
         K2_EVAL(
-            c, ans_tot_size1 + 1, lambda_set_row_splits2, (int32_t idx01) {
+            c, ans_tot_size1 + 1, lambda_set_row_splits2,
+            (int32_t idx01)->void {
               if (idx01 == ans_tot_size1) {
                 ans_row_splits2_data[idx01] =
                     src_row_splits2_data[src_tot_size1];
@@ -825,7 +826,7 @@ RaggedShape MakeTransposable(RaggedShape &src) {
         int32_t *ans_row_ids2_data = axis2_shape.row_ids.Data();
         const int32_t *src_row_ids2_data = src.RowIds(2).Data();
         K2_EVAL(
-            c, tot_size2, lambda_set_row_ids2, (int32_t idx012) {
+            c, tot_size2, lambda_set_row_ids2, (int32_t idx012)->void {
               int32_t src_idx01 = src_row_ids2_data[idx012];
               int32_t src_idx0 = src_row_ids1_data[src_idx01];
               int32_t src_idx1 = src_idx01 - src_row_splits1_data[src_idx0];
@@ -862,7 +863,7 @@ RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
   Array1<int32_t> renumbering(c, src_tot_size1);
   int32_t *renumbering_data = renumbering.Data();
   K2_EVAL(
-      c, src_tot_size1, lambda_set_renumbering, (int32_t i) {
+      c, src_tot_size1, lambda_set_renumbering, (int32_t i)->void {
         int32_t j = i % src_dim0, k = i / src_dim0, i_old = j * src_dim1 + k;
         renumbering_data[i] = i_old;
       });
@@ -876,7 +877,7 @@ RaggedShape Transpose(RaggedShape &src, Array1<int32_t> *value_indexes) {
   Array1<int32_t> mem(c, row_splits_dim + row_ids_dim);
   int32_t *mem_data = mem.Data();
   K2_EVAL(
-      c, row_splits_dim + row_ids_dim, lambda_set_row_info, (int32_t i) {
+      c, row_splits_dim + row_ids_dim, lambda_set_row_info, (int32_t i)->void {
         int32_t val;
         if (i >= row_splits_dim) {
           // row_ids
@@ -936,7 +937,7 @@ RaggedShape RegularRaggedShape(ContextPtr &c, int32_t dim0, int32_t dim1) {
   int32_t *row_ids_data = row_ids.Data();
   K2_EVAL2(
       c, dim0, dim1, lambda_set_row_ids,
-      (int32_t i, int32_t j) { row_ids_data[i * dim1 + j] = i; });
+      (int32_t i, int32_t j)->void { row_ids_data[i * dim1 + j] = i; });
   return RaggedShape2(&row_splits, &row_ids, dim0 * dim1);
 }
 

--- a/k2/csrc/ragged_test.cu
+++ b/k2/csrc/ragged_test.cu
@@ -1288,7 +1288,7 @@ void CheckResultOfIndex(const ContextPtr &context, RaggedShape shape,
   int32_t **row_splits_ptrs_data = row_splits_ptrs.Data();
   // Set old_offsets
   K2_EVAL(
-      context, src_dim0 + 1, lambda_get_old_offsets, (int32_t i) {
+      context, src_dim0 + 1, lambda_get_old_offsets, (int32_t i)->void {
         // 0 <= i <= dim0
         int32_t cur_offset = i;
         for (int32_t axis = 0; axis < num_axes; axis++) {

--- a/k2/csrc/top_sort.cu
+++ b/k2/csrc/top_sort.cu
@@ -186,7 +186,7 @@ class TopSorter {
                   *fsas_row_splits2_data = fsas_.RowSplits(2).Data();
     K2_EVAL(
         c_, cur_states.NumElements(), lambda_set_arcs_per_state,
-        (int32_t states_idx01) {
+        (int32_t states_idx01)->void {
           int32_t fsas_idx01 = states_data[states_idx01],
                   num_arcs = fsas_row_splits2_data[fsas_idx01 + 1] -
                              fsas_row_splits2_data[fsas_idx01];
@@ -306,7 +306,7 @@ class TopSorter {
           // If the following fails, it likely means an input FSA was invalid
           // (e.g. had exactly one state, which is not allowed).  Either that,
           // or a code error.
-          K2_CHECK_GT(final_state, fsas_row_splits1_data[fsa_idx0]);
+          K2_DCHECK_GT(final_state, fsas_row_splits1_data[fsa_idx0]);
           ans_data[i] = final_state;
         });
     return ans;

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -151,10 +151,10 @@ void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
 
       K2_EVAL(
           c, num_elems + 1, lambda_init_minus_one,
-          (int32_t i) { row_ids[i] = -1; });
+          (int32_t i)->void { row_ids[i] = -1; });
 
       K2_EVAL(
-          c, num_elems + 1, lambda_phase_one, (int32_t i) {
+          c, num_elems + 1, lambda_phase_one, (int32_t i)->void {
             int32_t this_row_split = row_splits[i],
                     next_row_split =
                         (i < num_rows ? row_splits[i + 1] : this_row_split + 1);
@@ -185,7 +185,7 @@ void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
       // could do the next line for num_elems+1, but the element at `num_elems`
       // will already be set.
       K2_EVAL(
-          c, num_elems, lambda_phase_two, (int32_t j) {
+          c, num_elems, lambda_phase_two, (int32_t j)->void {
             int32_t row_index = row_ids[j];
             if (row_index != -1) return;
             int32_t power = 0, j2 = j;
@@ -273,7 +273,8 @@ void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
   // process corner case first
   if (num_elems == 0) {
     K2_EVAL(
-        c, num_rows + 1, lambda_set_values, (int32_t i) { row_splits[i] = 0; });
+        c, num_rows + 1, lambda_set_values,
+        (int32_t i)->void { row_splits[i] = 0; });
     return;
   }
   DeviceType d = c->GetDeviceType();

--- a/k2/python/tests/intersect_dense_test.py
+++ b/k2/python/tests/intersect_dense_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
-#                2020  Xiaomi Corp.       (authors: Daniel Povey)
+# Copyright (c)  2020  Xiaomi Corp.       (authors: Daniel Povey, Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
@@ -85,18 +84,18 @@ class TestIntersectDense(unittest.TestCase):
 
         # `expected` results are computed using gtn.
         # See https://bit.ly/3oYObeb
-        expected_scores_out_fsa = torch.tensor(
-            [1.2, 2.06, 3.0, 1.2, 50.5, 2.0, 3.0])
+        #  expected_scores_out_fsa = torch.tensor(
+        #      [1.2, 2.06, 3.0, 1.2, 50.5, 2.0, 3.0])
         expected_grad_fsa = torch.tensor([2.0, 1.0, 2.0, 2.0])
-        expected_grad_log_prob = torch.tensor([
-            0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0, 0, 0, 0.0, 1.0, 0.0, 0.0, 1.0,
-            0.0, 0.0, 0.0, 1.0
-        ]).reshape_as(log_prob)
+        #  expected_grad_log_prob = torch.tensor([
+        #      0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0, 0, 0, 0.0, 1.0, 0.0, 0.0, 1.0,
+        #      0.0, 0.0, 0.0, 1.0
+        #  ]).reshape_as(log_prob)
 
         # TODO(dan):: fix this..
-        #assert torch.allclose(out_fsa.scores, expected_scores_out_fsa)
+        # assert torch.allclose(out_fsa.scores, expected_scores_out_fsa)
         assert torch.allclose(expected_grad_fsa, fsa.scores.grad)
-        #gassert torch.allclose(expected_grad_log_prob, log_prob.grad)
+        # assert torch.allclose(expected_grad_log_prob, log_prob.grad)
 
     def test_two_fsas(self):
         s1 = '''
@@ -113,7 +112,6 @@ class TestIntersectDense(unittest.TestCase):
             2 3 -1 3.0
             3
         '''
-
 
         fsa1 = k2.Fsa.from_str(s1)
         fsa2 = k2.Fsa.from_str(s2)
@@ -144,23 +142,22 @@ class TestIntersectDense(unittest.TestCase):
 
         # `expected` results are computed using gtn.
         # See https://bit.ly/3oYObeb
-        expected_scores_out_fsa = torch.tensor(
-            [1.2, 2.06, 3.0, 1.2, 50.5, 2.0, 3.0])
-
+        #  expected_scores_out_fsa = torch.tensor(
+        #      [1.2, 2.06, 3.0, 1.2, 50.5, 2.0, 3.0])
 
         expected_grad_fsa1 = torch.tensor([1.0, 1.0, 1.0, 1.0])
         expected_grad_fsa2 = torch.tensor([1.0, 1.0, 1.0])
         print("fsa2 is ", fsa2.__str__())
         # TODO(dan):: fix this..
-        expected_grad_log_prob = torch.tensor([
-            0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0, 0, 0, 0.0, 1.0, 0.0, 0.0, 1.0,
-            0.0, 0.0, 0.0, 1.0
-        ]).reshape_as(log_prob)
+        #  expected_grad_log_prob = torch.tensor([
+        #      0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0, 0, 0, 0.0, 1.0, 0.0, 0.0, 1.0,
+        #      0.0, 0.0, 0.0, 1.0
+        #  ]).reshape_as(log_prob)
 
-        #assert torch.allclose(out_fsa.scores, expected_scores_out_fsa)
+        # assert torch.allclose(out_fsa.scores, expected_scores_out_fsa)
         assert torch.allclose(expected_grad_fsa1, fsa1.scores.grad)
         assert torch.allclose(expected_grad_fsa2, fsa2.scores.grad)
-        #assert torch.allclose(expected_grad_log_prob, log_prob.grad)
+        # assert torch.allclose(expected_grad_log_prob, log_prob.grad)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #430 

@danpovey 
Do we need to pass `lambda_name` as a macro aguement? I think it can be omitted and we can generate an unique name
inside the lambda.