### PR TITLE
create Fsa from vector of arcs (maybe cyclic)

### DIFF
--- a/k2/csrc/host/determinize_pruned.cc
+++ b/k2/csrc/host/determinize_pruned.cc
@@ -89,7 +89,7 @@ float DeterminizerPruned<TracebackState>::GetOutput(
   std::vector<int32_t> arc_map;
   // output fsa
   K2_CHECK_EQ(arcs_.size(), fsa_out->size2);
-  CreateFsa(arcs_, fsa_out, &arc_map);
+  CreateTopSortedFsa(arcs_, fsa_out, &arc_map);
   K2_CHECK_EQ(arcs_.size(), arc_map.size());
 
   // output arc derivative information

--- a/k2/csrc/host/fsa_util.cc
+++ b/k2/csrc/host/fsa_util.cc
@@ -416,8 +416,8 @@ void RandFsaGenerator::GetOutput(Fsa *fsa_out) {
   std::copy(fsa.data, fsa.data + fsa.size2, fsa_out->data);
 }
 
-void CreateFsa(const std::vector<Arc> &arcs, Fsa *fsa,
-               std::vector<int32_t> *arc_map /*=null_ptr*/) {
+void CreateTopSortedFsa(const std::vector<Arc> &arcs, Fsa *fsa,
+                        std::vector<int32_t> *arc_map /*=null_ptr*/) {
   using dfs::DfsState;
   using dfs::kNotVisited;
   using dfs::kVisited;
@@ -503,6 +503,65 @@ void CreateFsa(const std::vector<Arc> &arcs, Fsa *fsa,
       arc_map_out.push_back(arc_with_index.second);
     }
   }
+  fsa->indexes[num_states] = num_arcs;
+  if (arc_map != nullptr) arc_map->swap(arc_map_out);
+}
+
+void CreateFsa(const std::vector<Arc> &arcs, Fsa *fsa,
+               std::vector<int32_t> *arc_map /*=null_ptr*/) {
+  K2_CHECK_NE(fsa, nullptr);
+  if (arcs.empty()) return;
+
+  int32_t old_final_state = -1;
+  using ArcWithIndex = std::pair<Arc, int32_t>;
+  int32_t arc_id = 0;
+  std::vector<std::vector<ArcWithIndex>> state_to_arcs;  // indexed by states
+  for (const auto &arc : arcs) {
+    if (arc.label == -1) {
+      // if old_final_state != -1, there must be arc.dest_state ==
+      // old_final_state, as we suppose there is only one final state.
+      K2_CHECK(old_final_state == -1 || arc.dest_state == old_final_state);
+      old_final_state = arc.dest_state;
+    }
+    int32_t src_state = arc.src_state;
+    int32_t dest_state = arc.dest_state;
+    int32_t new_size = std::max(src_state, dest_state);
+    if (new_size >= state_to_arcs.size()) state_to_arcs.resize(new_size + 1);
+    state_to_arcs[src_state].push_back({arc, arc_id++});
+  }
+
+  int32_t num_states = static_cast<int32_t>(state_to_arcs.size());
+  K2_CHECK_EQ(fsa->size1, num_states);
+  K2_CHECK_EQ(fsa->size2, arcs.size());
+  // there's no leaving arc from final state
+  K2_CHECK_EQ(state_to_arcs[old_final_state].size(), 0);
+
+  int32_t final_state = num_states - 1;
+  std::vector<int32_t> new_to_old(num_states);
+  // we move old_final_state to the end so that final state will be
+  // the largest state.
+  for (int32_t i = 0; i < old_final_state; ++i) new_to_old[i] = i;
+  for (int32_t i = old_final_state; i < final_state; ++i) new_to_old[i] = i + 1;
+  new_to_old[final_state] = old_final_state;
+  std::vector<int32_t> old_to_new(num_states);
+  for (int32_t i = 0; i != num_states; ++i) old_to_new[new_to_old[i]] = i;
+
+  std::vector<int32_t> arc_map_out;
+  arc_map_out.reserve(arcs.size());
+
+  int32_t num_arcs = 0;
+  for (int32_t i = 0; i != num_states; ++i) {
+    int32_t old_state = new_to_old[i];
+    fsa->indexes[i] = num_arcs;
+    for (auto arc_with_index : state_to_arcs[old_state]) {
+      auto &arc = arc_with_index.first;
+      arc.src_state = i;
+      arc.dest_state = old_to_new[arc.dest_state];
+      fsa->data[num_arcs++] = arc;
+      arc_map_out.push_back(arc_with_index.second);
+    }
+  }
+
   fsa->indexes[num_states] = num_arcs;
   if (arc_map != nullptr) arc_map->swap(arc_map_out);
 }

--- a/k2/csrc/host/fsa_util.h
+++ b/k2/csrc/host/fsa_util.h
@@ -217,13 +217,34 @@ class FsaCreator {
   std::vector<Arc> arcs_;
 };
 
-/* Create an acyclic FSA from a list of arcs.
+/* Create an acyclic FSA from a list of arcs. The returned Fsa is top-sorted and
+   acyclic.
 
    Arcs do not need to be pre-sorted by src_state.
    If there is a cycle, it aborts.
 
    The start state MUST be 0. The final state will be automatically determined
    by topological sort.
+
+   @param [in] arcs  A list of arcs.
+   @param [out] fsa  Output fsa which is top-sorted. Must be initialized;
+                     search for 'initialized definition' in class Array2
+                     in array.h for meaning.
+   @param [out] arc_map   If non-NULL, this function will
+                            output a map from the arc-index in `fsa` to
+                            the corresponding arc-index in input `arcs`.
+*/
+void CreateTopSortedFsa(const std::vector<Arc> &arcs, Fsa *fsa,
+                        std::vector<int32_t> *arc_map = nullptr);
+
+/* Create an FSA from a list of arcs.
+
+   Arcs do not need to be pre-sorted by src_state.
+
+   The start state MUST be 0. There must be only one state whose all entering
+   arcs have label -1 and there's no arc leaving this state, this state will
+   be the final state; otherwise, if we cannot find such a state,
+   the program will abort with an error.
 
    @param [in] arcs  A list of arcs.
    @param [out] fsa  Output fsa. Must be initialized; search for 'initialized

--- a/k2/csrc/host/fsa_util_test.cc
+++ b/k2/csrc/host/fsa_util_test.cc
@@ -259,7 +259,7 @@ TEST(FsaUtil, FsaCreator) {
   }
 }
 
-TEST(FsaAlgo, CreateFsa) {
+TEST(FsaAlgo, CreateTopSortedFsa) {
   {
     // clang-format off
     std::vector<Arc> arcs = {
@@ -283,11 +283,37 @@ TEST(FsaAlgo, CreateFsa) {
     FsaCreator fsa_creator(fsa_size);
     auto &fsa_out = fsa_creator.GetFsa();
     std::vector<int32_t> arc_map;
-    CreateFsa(arcs, &fsa_out, &arc_map);
+    CreateTopSortedFsa(arcs, &fsa_out, &arc_map);
+    EXPECT_TRUE(IsTopSortedAndAcyclic(fsa_out));
 
     EXPECT_EQ(arc_map.size(), arcs.size());
     EXPECT_THAT(arc_map,
                 ::testing::ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+  }
+}
+
+TEST(FsaAlgo, CreateFsa) {
+  {
+    // clang-format off
+    std::vector<Arc> arcs = {
+      {0, 3, 3, 0},
+      {1, 3, 2, 0},
+      {3, 1, 1, 0},
+      {1, 4, 4, 0},
+      {1, 2, -1, 0},
+      {4, 2, -1, 0},
+    };
+    // clang-format on
+    Array2Size<int32_t> fsa_size;
+    fsa_size.size1 = 5;            // num_states
+    fsa_size.size2 = arcs.size();  // num_arcs
+    FsaCreator fsa_creator(fsa_size);
+    auto &fsa_out = fsa_creator.GetFsa();
+    std::vector<int32_t> arc_map;
+    CreateFsa(arcs, &fsa_out, &arc_map);
+
+    EXPECT_EQ(arc_map.size(), arcs.size());
+    EXPECT_THAT(arc_map, ::testing::ElementsAre(0, 1, 3, 4, 2, 5));
   }
 }
 }  // namespace k2host


### PR DESCRIPTION
The original `CreateFsa` (host version) requires the input arcs are acyclic, I add a version by removing this requirement
 I need this in un-pruned version of `determinize` as usually the output is cyclic, e.g. for L*G. The original version is renamed to `CreateTopSortedFsa`