### PR TITLE
Fix a build error on CentOS/Red Hat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ execute_process(COMMAND
   OUTPUT_VARIABLE K2_OS
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+string(REGEX REPLACE "^\"+|\"+$" "" K2_OS "${K2_OS}")
 message(STATUS "K2_OS: ${K2_OS}")
 
 find_package(Git REQUIRED)


### PR DESCRIPTION
On my CentOS machine, lsb_release -sd will get double quoted string:
"CentOS Linux release 7.6.1810 (Core) "
so does Red Hat machine:
"Red Hat Enterprise Linux Server release 6.6 (Santiago)"
which cause a syntax error in build/k2/csrc/version.h:
`// The operating system that is used to build k2, e.g., Ubuntu 16.04 LTS`
`static constexpr const char *kOS = ""CentOS Linux release 7.6.1810 (Core) "";`
when make, reported as:
`[ 93%] Building CUDA object k2/python/csrc/CMakeFiles/_k2.dir/version.cu.o`
`/search/odin/wangjiawen/k2/build/k2/csrc/version.h(50): warning: a user-provided literal suffix must begin with "_"`
`/search/odin/wangjiawen/k2/build/k2/csrc/version.h(50): error: user-defined literal operator not found`
`/search/odin/wangjiawen/k2/build/k2/csrc/version.h(50): error: expected a ";"`
`/search/odin/wangjiawen/k2/build/k2/csrc/version.h(50): error: extra text after expected end of number`
`3 errors detected in the compilation of "/tmp/tmpxft_00003892_00000000-11_version.compute_75.cpp1.ii".`
`make[2]: *** [k2/python/csrc/CMakeFiles/_k2.dir/build.make:108: k2/python/csrc/CMakeFiles/_k2.dir/version.cu.o] Error 1`
`make[1]: *** [CMakeFiles/Makefile2:1692: k2/python/csrc/CMakeFiles/_k2.dir/all] Error 2`
`make: *** [Makefile:114: all] Error 2`