### PR TITLE
Fix PYTHONPATH for testing.

### DIFF
--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ function(k2_add_py_test source)
   get_filename_component(k2_path ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
 
   set_property(TEST ${name}
-    PROPERTY ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:_k2>:${k2_path}:$ENV{PYTHONPATH}"
+    PROPERTY ENVIRONMENT "PYTHONPATH=${k2_path}:$<TARGET_FILE_DIR:_k2>:$ENV{PYTHONPATH}"
   )
 endfunction()
 

--- a/scripts/build_pip.sh
+++ b/scripts/build_pip.sh
@@ -75,3 +75,4 @@ mv $build_dir/.lib-bak/*.so $build_dir/lib/
 mv .temp_lib/lib*test*.so $build_dir/lib/
 
 rm -rfv $build_dir/.lib-bak
+rm -rf $build_dir/lib/k2


### PR DESCRIPTION

`./scripts/build_pip_package.sh` will copy `k2` from the source tree to `build/lib` but does not remove it. CMake
is not aware of this process.

This causes problems for `make test`. If you change k2 in the source tree, `make test` still uses the one in `build/lib`
because `build/lib` comes first in PYTHONPATH than the source tree.

This pullrequest avoids the above problem in two ways:
(1) Remove `build/lib/k2` after building pip packages
(2) Set the path of k2 in the source tree to the beginning of PYTHONPATH so that the one from the source tree
is found first even if there exists `build/lib/k2`.