### PR TITLE
Implement RowSplitsToRowIds with cub device scan.

### DIFF
--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -294,14 +294,17 @@ Array1<T> Times(Array1<T> &src1, Array1<T> &src2) {
     @param[in] c  Context for this array; note, this function will be slow
                   if this is not a CPU context
     @param [in] dim    Dimension, must be > 0
-    @param[in] min_value  Minimum value allowed in the array
-    @param[in] max_value  Maximum value allowed in the array;
+    @param [in] min_value  Minimum value allowed in the array
+    @param [in] max_value  Maximum value allowed in the array;
                            require max_value >= min_value.
+    @param [in] seed  The seed for the random generator. 0 to
+                      use the default seed. Set it to a non-zero
+                      value for reproducibility.
     @return    Returns the randomly generated array
  */
 template <typename T>
-Array1<T> RandUniformArray1(ContextPtr c, int32_t dim, T min_value,
-                            T max_value);
+Array1<T> RandUniformArray1(ContextPtr c, int32_t dim, T min_value, T max_value,
+                            int32_t seed = 0);
 
 /*
   Returns a random Array2, uniformly distributed betwen `min_value` and
@@ -333,10 +336,8 @@ Array2<T> RandUniformArray2(ContextPtr c, int32_t dim0, int32_t dim1,
 template <typename T = int32_t>
 Array1<T> Range(ContextPtr c, int32_t dim, T first_value, T inc = 1);
 
-
-template<typename T = int32_t>
+template <typename T = int32_t>
 Array1<T> Arange(ContextPtr c, T begin, T end, T inc = 1);
-
 
 /*
   This is a convenience wrapper for the function of the same name in utils.h.
@@ -359,7 +360,6 @@ void RowSplitsToRowIds(const Array1<int32_t> &row_splits,
  */
 Array1<int32_t> RowSplitsToSizes(const Array1<int32_t> &row_splits);
 
-
 /*
   This is a convenience wrapper for the function of the same name in utils.h.
    @param [in] row_ids     Input row_ids vector, of dimension num_elems
@@ -371,7 +371,6 @@ Array1<int32_t> RowSplitsToSizes(const Array1<int32_t> &row_splits);
  */
 void RowIdsToRowSplits(const Array1<int32_t> &row_ids,
                        Array1<int32_t> *row_splits);
-
 
 /*
   Creates a merge-map from a vector of sizes.  A merge-map is something we
@@ -399,7 +398,6 @@ void RowIdsToRowSplits(const Array1<int32_t> &row_ids,
  */
 Array1<uint32_t> SizesToMergeMap(ContextPtr c,
                                  const std::vector<int32_t> &sizes);
-
 
 /*
   Returns a new Array1<T> whose elements are this array's elements plus t.
@@ -432,7 +430,6 @@ bool IsMonotonic(const Array1<T> &a);
 template <typename T>
 bool IsMonotonicDecreasing(const Array1<T> &a);
 
-
 /*
   Generalized function inverse for an array viewed as a function which is
   monotonically decreasing.
@@ -458,7 +455,6 @@ bool IsMonotonicDecreasing(const Array1<T> &a);
  */
 Array1<int32_t> InvertMonotonicDecreasing(const Array1<int32_t> &src);
 
-
 /*
   Assuming `src` is a permutation of Range(0, src.Dim()), returns the inverse of
   that permutation, such that ans[src[i]] = i.  It is an error, and may cause a
@@ -466,7 +462,6 @@ Array1<int32_t> InvertMonotonicDecreasing(const Array1<int32_t> &src);
   src.Dim()).
  */
 Array1<int32_t> InvertPermutation(const Array1<int32_t> &src);
-
 
 /*
    Validate a row_ids vector; this just makes sure its elements are nonnegative
@@ -614,7 +609,6 @@ Array2<T> IndexRows(const Array2<T> &src, const Array1<int32_t> &indexes,
 template <typename T, typename Compare = LessThan<T>>
 void Sort(Array1<T> *array, Array1<int32_t> *index_map = nullptr);
 
-
 /*
   Assign elements from `src` to `dest`; they must have the same shape.  For now
   this only supports cross-device copy if the data is contiguous.
@@ -622,27 +616,26 @@ void Sort(Array1<T> *array, Array1<int32_t> *index_map = nullptr);
 template <typename T>
 void Assign(Array2<T> &src, Array2<T> *dest);
 
-
 /*
   Merge an array of Array1<T> with a `merge_map` which indicates which items
   to get from which positions (doesn't do any checking of the merge_map values!)
 
-    @param [in] merge_map   Array which is required to have the same dimension as
-                        the sum of src[i]->Dim().  If merge_map[i] == m, it indicates
-                        that the i'th position in the answer should come from element
-                        `m / num_srcs` within `*src[m % num_srcs]`.
-    @param [in] num_srcs   Number of Array1's in the source array
-    @param [in] src       Array of sources; total Dim() must equal merge_map.Dim()
-    @return               Returns array with elements combined from those in `src`.
+    @param [in] merge_map   Array which is required to have the same dimension
+                            as the sum of src[i]->Dim().
+                            If merge_map[i] == m, it indicates that the i'th
+                            position in the answer should come from
+                            element `m / num_srcs` within `*src[m % num_srcs]`.
+    @param [in] num_srcs  Number of Array1's in the source array
+    @param [in] src       Array of sources; total Dim() must equal
+                          merge_map.Dim()
+    @return               Returns array with elements combined from those in
+                          `src`.
 
    CAUTION: may segfault if merge_map contains invalid values.
  */
 template <typename T>
-Array1<T> MergeWithMap(const Array1<uint32_t> &merge_map,
-                       int32_t num_srcs, const Array1<T> **src);
-
-
-
+Array1<T> MergeWithMap(const Array1<uint32_t> &merge_map, int32_t num_srcs,
+                       const Array1<T> **src);
 
 }  // namespace k2
 

--- a/k2/csrc/benchmark/README.md
+++ b/k2/csrc/benchmark/README.md
@@ -1,0 +1,18 @@
+
+# Environment variables
+
+There are several environment variables that can
+affect running benchmarks.
+
+## `K2_BENCHMARK_FILTER`
+
+It specifies a regular expression. Benchmark names
+that do not match the pattern will be excluded. Only
+benchmarks with name matching the pattern will be run.
+
+## `K2_SEED`
+
+It specifies the seed for the random generator. If
+it is non-zero, then the results are reproducible.
+If it is not set or its value is 0, then every time
+the benchmark runs, it uses a different sets of data.

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -27,7 +27,7 @@ static BenchmarkStat BenchmarkExclusiveSum(int32_t dim,
   }
 
   int32_t num_iter = std::min(500, 1000000 / dim);
-  Array1<T> src = RandUniformArray1<T>(context, dim, -1000, 1000);
+  Array1<T> src = RandUniformArray1<T>(context, dim, -1000, 1000, GetSeed());
 
   BenchmarkStat stat;
   stat.op_name = "ExclusiveSum";
@@ -55,7 +55,8 @@ static BenchmarkStat BenchmarkRowSplitsToRowIds(int32_t dim,
   }
 
   int32_t num_iter = std::min(500, 1000000 / dim);
-  Array1<int32_t> sizes = RandUniformArray1<int32_t>(context, dim, 0, 1000);
+  Array1<int32_t> sizes =
+      RandUniformArray1<int32_t>(context, dim, 0, 1000, GetSeed());
   Array1<int32_t> row_splits = ExclusiveSum(sizes);
   Array1<int32_t> row_ids(context, row_splits.Back());
 

--- a/k2/csrc/benchmark/benchmark.cu
+++ b/k2/csrc/benchmark/benchmark.cu
@@ -154,4 +154,11 @@ std::string GetCurrentDateTime() {
   return std::string(kPrefix) + std::ctime(&t);
 }
 
+int32_t GetSeed() {
+  static const char *seed = std::getenv("K2_SEED");
+  if (seed == nullptr) return 0;
+
+  return atoi(seed);  // 0 is returned if K2_SEED is not a numeric string.
+}
+
 }  // namespace k2

--- a/k2/csrc/benchmark/benchmark.h
+++ b/k2/csrc/benchmark/benchmark.h
@@ -160,6 +160,9 @@ std::string GenerateBenchmarkName(const std::string &base_name,
 // for debugging only
 void PrintRegisteredBenchmarks();
 
+// Return the seed that can be used for random generators.
+int32_t GetSeed();
+
 }  // namespace k2
 
 #endif  // K2_CSRC_BENCHMARK_BENCHMARK_H_


### PR DESCRIPTION
Repost the result before the change from #484 

```
op_name,dtype,device,problem_size,number_of_iterations,elapsed_us_per_iteration
ExclusiveSum,int32,kCpu,100,500,0.430107
ExclusiveSum,int32,kCpu,500,500,0.652313
ExclusiveSum,int32,kCpu,1000,500,0.862122
ExclusiveSum,int32,kCpu,2000,500,1.428127
ExclusiveSum,int32,kCpu,5000,200,2.830029
ExclusiveSum,int32,kCpu,10000,100,5.679131
ExclusiveSum,int32,kCpu,100000,10,57.196617
ExclusiveSum,int32,kCuda,100,500,15.522688
ExclusiveSum,int32,kCuda,500,500,13.503168
ExclusiveSum,int32,kCuda,1000,500,12.769920
ExclusiveSum,int32,kCuda,2000,500,12.796735
ExclusiveSum,int32,kCuda,5000,200,13.019680
ExclusiveSum,int32,kCuda,10000,100,10.883519
ExclusiveSum,int32,kCuda,100000,10,13.872001
RowSplitsToRowIds,int32,kCpu,100,500,6.326199
RowSplitsToRowIds,int32,kCpu,500,500,39.864063
RowSplitsToRowIds,int32,kCpu,1000,500,107.650284
RowSplitsToRowIds,int32,kCpu,2000,500,185.015686
RowSplitsToRowIds,int32,kCpu,5000,200,536.605164
RowSplitsToRowIds,int32,kCpu,10000,100,1650.300049
RowSplitsToRowIds,int32,kCpu,100000,10,51252.414062
RowSplitsToRowIds,int32,kCuda,100,500,27.510401
RowSplitsToRowIds,int32,kCuda,500,500,47.054462
RowSplitsToRowIds,int32,kCuda,1000,500,121.602242
RowSplitsToRowIds,int32,kCuda,2000,500,115.474808
RowSplitsToRowIds,int32,kCuda,5000,200,240.739502
RowSplitsToRowIds,int32,kCuda,10000,100,453.319977
RowSplitsToRowIds,int32,kCuda,100000,10,4515.548828
```

---

The result of this pullrequest is (which is **FASTER** than before):

```
ExclusiveSum,int32,kCpu,100,500,0.388145
ExclusiveSum,int32,kCpu,500,500,0.594139
ExclusiveSum,int32,kCpu,1000,500,0.837803
ExclusiveSum,int32,kCpu,2000,500,1.332283
ExclusiveSum,int32,kCpu,5000,200,2.809763
ExclusiveSum,int32,kCpu,10000,100,5.249977
ExclusiveSum,int32,kCpu,100000,10,54.407120
ExclusiveSum,int32,kCuda,100,500,11.023936
ExclusiveSum,int32,kCuda,500,500,10.980480
ExclusiveSum,int32,kCuda,1000,500,11.052992
ExclusiveSum,int32,kCuda,2000,500,11.074368
ExclusiveSum,int32,kCuda,5000,200,11.086880
ExclusiveSum,int32,kCuda,10000,100,11.106239
ExclusiveSum,int32,kCuda,100000,10,11.392000
RowSplitsToRowIds,int32,kCpu,100,500,6.937981
RowSplitsToRowIds,int32,kCpu,500,500,38.788319
RowSplitsToRowIds,int32,kCpu,1000,500,91.593742
RowSplitsToRowIds,int32,kCpu,2000,500,187.736038
RowSplitsToRowIds,int32,kCpu,5000,200,458.455078
RowSplitsToRowIds,int32,kCpu,10000,100,1096.999634
RowSplitsToRowIds,int32,kCpu,100000,10,19828.986328
RowSplitsToRowIds,int32,kCuda,100,500,32.389694
RowSplitsToRowIds,int32,kCuda,500,500,39.937984
RowSplitsToRowIds,int32,kCuda,1000,500,39.807549
RowSplitsToRowIds,int32,kCuda,2000,500,39.866879
RowSplitsToRowIds,int32,kCuda,5000,200,73.464645
RowSplitsToRowIds,int32,kCuda,10000,100,118.126404
RowSplitsToRowIds,int32,kCuda,100000,10,933.507141
```