### PR TITLE
Use load balancing search from moderngpu for RowSplitsToRowIds

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
   setup.py,
   build,
   k2/python/host,
-  k2/docs
+  docs
 
 ignore =
   # E127 continuation line over-indented for visual indent

--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -559,7 +559,7 @@ Array1<int32_t> GetCounts(const Array1<int32_t> &src, int32_t n);
     @param [in] c  Context of `src_data`.
     @param [in] src_data  The source array.
     @param [in] src_dim   The dimension of the src array.
-    @param  [in] n         Number of counts; we require `0 <= src_date[i] < n`.
+    @param [in] n         Number of counts; we require `0 <= src_data[i] < n`.
 
     See also GetCounts above.
  */

--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -554,6 +554,18 @@ void MonotonicDecreasingUpperBound(const Array1<S> &src, Array1<T> *dest);
 */
 Array1<int32_t> GetCounts(const Array1<int32_t> &src, int32_t n);
 
+/* Returns counts of numbers in the array.
+
+    @param [in] c  Context of `src_data`.
+    @param [in] src_data  The source array.
+    @param [in] src_dim   The dimension of the src array.
+    @param  [in] n         Number of counts; we require `0 <= src_date[i] < n`.
+
+    See also GetCounts above.
+ */
+Array1<int32_t> GetCounts(ContextPtr c, const int32_t *src_data,
+                          int32_t src_dim, int32_t n);
+
 template <typename T>
 Array2<T> ToContiguous(const Array2<T> &src);
 

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -61,7 +61,7 @@ static BenchmarkStat BenchmarkRowSplitsToRowIds(int32_t dim,
   Array1<int32_t> row_ids(context, row_splits.Back());
 
   BenchmarkStat stat;
-  stat.op_name = "RowSplitsToRowIds";
+  stat.op_name = "RowSplitsToRowIds_" + std::to_string(row_ids.Dim());
   stat.num_iter = num_iter;
   stat.problem_size = dim;
   stat.dtype_name = TraitsOf(DtypeOf<int32_t>::dtype).Name();

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -78,6 +78,41 @@ static BenchmarkStat BenchmarkRowSplitsToRowIds(int32_t dim,
   return stat;
 }
 
+static BenchmarkStat BenchmarkRowIdsToRowSplits(int32_t dim,
+                                                DeviceType device_type) {
+  ContextPtr context;
+  if (device_type == kCpu) {
+    context = GetCpuContext();
+  } else {
+    K2_CHECK_EQ(device_type, kCuda);
+    context = GetCudaContext();
+  }
+
+  int32_t num_iter = std::min(500, 1000000 / dim);
+  Array1<int32_t> sizes =
+      RandUniformArray1<int32_t>(context, dim, 0, 1000, GetSeed());
+  Array1<int32_t> row_splits = ExclusiveSum(sizes);
+  Array1<int32_t> row_ids(context, row_splits.Back());
+  RowSplitsToRowIds(row_splits, &row_ids);
+
+  BenchmarkStat stat;
+  stat.op_name = "RowIdsToRowSplits";
+  stat.num_iter = num_iter;
+  stat.problem_size = dim;
+  stat.dtype_name = TraitsOf(DtypeOf<int32_t>::dtype).Name();
+  stat.device_type = device_type;
+
+  // there are overloads of RowIdsToRowSplits,
+  // so we use an explicit conversion here.
+  stat.eplased_per_iter =
+      BenchmarkOp(num_iter, context,
+                  (void (*)(const Array1<int32_t> &, Array1<int32_t> *))(
+                      &RowIdsToRowSplits),
+                  row_ids, &row_splits);
+  stat.eplased_per_iter *= 1e6;  // from seconds to microseconds
+  return stat;
+}
+
 template <typename T>
 static void RegisterBenchmarkExclusiveSum(DeviceType device_type) {
   std::vector<int32_t> problems_sizes = {100,  500,   1000,  2000,
@@ -104,6 +139,19 @@ static void RegisterBenchmarkRowSplitsToRowIds(DeviceType device_type) {
   }
 }
 
+static void RegisterBenchmarkRowIdsToRowSplits(DeviceType device_type) {
+  std::vector<int32_t> problems_sizes = {100,  500,   1000,  2000,
+                                         5000, 10000, 100000};
+  for (auto s : problems_sizes) {
+    std::string name =
+        GenerateBenchmarkName<int32_t>("RowIdsToRowSplits", device_type) + "_" +
+        std::to_string(s);
+    RegisterBenchmark(name, [s, device_type]() -> BenchmarkStat {
+      return BenchmarkRowIdsToRowSplits(s, device_type);
+    });
+  }
+}
+
 static void RunArrayOpsBenchmark() {
   std::cout << GetCurrentDateTime() << "\n";
   std::cout << GetDeviceInfo() << "\n";
@@ -113,6 +161,9 @@ static void RunArrayOpsBenchmark() {
 
   RegisterBenchmarkRowSplitsToRowIds(kCpu);
   RegisterBenchmarkRowSplitsToRowIds(kCuda);
+
+  RegisterBenchmarkRowIdsToRowSplits(kCpu);
+  RegisterBenchmarkRowIdsToRowSplits(kCuda);
 
   // Users can set a regular expression via environment
   // variable `K2_BENCHMARK_FILTER` such that only benchmarks

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -12,6 +12,7 @@
 #include <algorithm>
 
 #include "cub/cub.cuh"
+#include "k2/csrc/array_ops.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/moderngpu_allocator.h"
@@ -323,6 +324,10 @@ void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
     }
   } else {
     K2_CHECK_EQ(d, kCuda);
+#if 1
+    Array1<int32_t> counts = GetCounts(c, row_ids, num_elems, num_rows + 1);
+    ExclusiveSum(c, num_rows + 1, counts.Data(), row_splits);
+#else
     if (no_empty_rows) {
       auto lambda_simple = [=] __device__(int32_t i) {
         int32_t this_row = row_ids[i], prev_row;
@@ -356,6 +361,7 @@ void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
                                                   c->GetCudaStream()>>>(
           num_elems, threads_per_elem, row_ids, num_rows, row_splits));
     }
+#endif
   }
 }
 

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -11,12 +11,13 @@
 
 #include <algorithm>
 
-
 #include "cub/cub.cuh"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
+#include "k2/csrc/moderngpu_allocator.h"
 #include "k2/csrc/nvtx.h"
 #include "k2/csrc/utils.h"
+#include "moderngpu/kernel_load_balance.hxx"
 
 namespace k2 {
 
@@ -132,6 +133,10 @@ void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
     K2_CHECK_EQ(d, kCuda);
     if (1) {
 #if 1
+      mgpu::context_t *mgpu_allocator = GetModernGpuAllocator(c);
+      mgpu::load_balance_search(num_elems, row_splits, num_rows, row_ids,
+                                *mgpu_allocator);
+#elif 0
       auto lambda_set_minus_1 = [=] __device__(int32_t i) -> void {
         row_ids[i] = -1;
       };

--- a/k2/csrc/utils.h
+++ b/k2/csrc/utils.h
@@ -383,11 +383,11 @@ __global__ void eval_lambda_redirect(int32_t num_jobs, TaskRedirect *redirect,
   lambda(task_id, num_threads_this_task, thread_idx_of_task);
 }
 
-
 template <typename LambdaT>
-__global__ void eval_lambda_redirect_large(int32_t num_jobs, TaskRedirect *redirect,
-                                         int32_t num_threads_per_job,
-                                         LambdaT lambda) {
+__global__ void eval_lambda_redirect_large(int32_t num_jobs,
+                                           TaskRedirect *redirect,
+                                           int32_t num_threads_per_job,
+                                           LambdaT lambda) {
   int32_t thread_idx = (blockIdx.y * gridDim.x + blockIdx.x) * blockDim.x
                        + threadIdx.x,
           num_threads = gridDim.x * gridDim.y * blockDim.x,
@@ -404,7 +404,6 @@ __global__ void eval_lambda_redirect_large(int32_t num_jobs, TaskRedirect *redir
       redirect[job_id].job_id_this_task * num_threads_per_job + thread_this_job;
   lambda(task_id, num_threads_this_task, thread_idx_of_task);
 }
-
 
 /*
   EvalWithRedirect() is like Eval() but for when the task have variable
@@ -490,7 +489,6 @@ void EvalWithRedirect(cudaStream_t stream, int32_t num_jobs,
       K2_CUDA_SAFE_CALL(eval_lambda_redirect_large<LambdaT>
                         <<<grid_dim, block_dim, 0, stream>>>(
                             num_jobs, redirect, num_threads_per_job, lambda));
-
     }
   }
 }

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -477,7 +477,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name = 'forward_scores_tropical' + ('double'
                                             if use_double_scores else 'float')
@@ -505,7 +506,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name = 'forward_scores_log' + ('double'
                                        if use_double_scores else 'float')
@@ -533,7 +535,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name = 'tot_scores_tropical_' + ('double'
                                          if use_double_scores else 'false')
@@ -557,7 +560,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name = 'tot_scores_log_' + ('double' if use_double_scores else 'float')
         cache = self._cache
@@ -577,7 +581,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name = 'backward_scores_tropical_' + ('double' if use_double_scores
                                               else 'float')
@@ -607,7 +612,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name = 'backward_scores_log_' + ('double'
                                          if use_double_scores else 'float')
@@ -634,7 +640,8 @@ class Fsa(object):
 
         Args:
           use_double_scores:
-            True to use `double precision` floating point. False to use `single precision`.
+            True to use `double precision` floating point.
+            False to use `single precision`.
         '''
         name, cache = 'entering_arcs', self._cache
         if name not in cache:

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -525,15 +525,13 @@ class TestFsa(unittest.TestCase):
         assert fsa.symbols.get('a') == 1
         assert fsa.symbols.get(1) == 'a'
 
-
-
     def test_fsa_vec_as_dict_ragged(self):
         r = k2.RaggedInt(k2.RaggedShape('[ [ x x ] [x] [ x x ] [x]]'),
-                         torch.tensor([ 3, 4, 5, 6, 7, 8], dtype=torch.int32))
+                         torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.int32))
         g = k2.Fsa.from_str('0  1  3  0.0\n  1 2 -1 0.0\n  2')
-        h = k2.create_fsa_vec([g,g])
+        h = k2.create_fsa_vec([g, g])
         h.aux_labels = r
-        assert(h[0].aux_labels.dim0() == h[0].labels.shape[0])
+        assert (h[0].aux_labels.dim0() == h[0].labels.shape[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Benchmark results of load balancing search:

```
op_name,dtype,device,problem_size,number_of_iterations,elapsed_us_per_iteration
ExclusiveSum,int32,kCpu,100,500,0.741959
ExclusiveSum,int32,kCpu,500,500,1.077652
ExclusiveSum,int32,kCpu,1000,500,1.495838
ExclusiveSum,int32,kCpu,2000,500,2.334118
ExclusiveSum,int32,kCpu,5000,200,4.814863
ExclusiveSum,int32,kCpu,10000,100,9.050369
ExclusiveSum,int32,kCpu,100000,10,95.701218
ExclusiveSum,int32,kCuda,100,500,13.094592
ExclusiveSum,int32,kCuda,500,500,13.116672
ExclusiveSum,int32,kCuda,1000,500,13.119424
ExclusiveSum,int32,kCuda,2000,500,13.278720
ExclusiveSum,int32,kCuda,5000,200,13.156799
ExclusiveSum,int32,kCuda,10000,100,13.206080
ExclusiveSum,int32,kCuda,100000,10,14.076800
RowSplitsToRowIds_48549,int32,kCpu,100,500,6.597996
RowSplitsToRowIds_241752,int32,kCpu,500,500,36.424160
RowSplitsToRowIds_497635,int32,kCpu,1000,500,98.988060
RowSplitsToRowIds_985875,int32,kCpu,2000,500,244.418137
RowSplitsToRowIds_2510591,int32,kCpu,5000,200,491.620270
RowSplitsToRowIds_5005413,int32,kCpu,10000,100,1527.450073
RowSplitsToRowIds_49917013,int32,kCpu,100000,10,23030.996094
RowSplitsToRowIds_48549,int32,kCuda,100,500,25.711679
RowSplitsToRowIds_241752,int32,kCuda,500,500,28.892801
RowSplitsToRowIds_497635,int32,kCuda,1000,500,31.538115
RowSplitsToRowIds_985875,int32,kCuda,2000,500,31.851713
RowSplitsToRowIds_2510591,int32,kCuda,5000,200,47.378403
RowSplitsToRowIds_5005413,int32,kCuda,10000,100,63.828163
RowSplitsToRowIds_49917013,int32,kCuda,100000,10,377.737610
```

It is faster than the one reported in https://github.com/k2-fsa/k2/pull/503#issuecomment-744426330