### PR TITLE
Add quality-of-life improvements to SymbolTable

### DIFF
--- a/k2/python/k2/symbol_table.py
+++ b/k2/python/k2/symbol_table.py
@@ -2,7 +2,7 @@
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Optional
 from typing import Generic
 from typing import TypeVar
@@ -22,11 +22,11 @@ class SymbolTable(Generic[Symbol]):
     The SymbolTable can only be read to/written from disk if the
     symbols are strings.
     '''
-    _id2sym: Dict[int, Symbol]
+    _id2sym: Dict[int, Symbol] = field(default_factory=dict)
     '''Map an integer to a symbol.
     '''
 
-    _sym2id: Dict[Symbol, int]
+    _sym2id: Dict[Symbol, int] = field(default_factory=dict)
     '''Map a symbol to an integer.
     '''
 

--- a/k2/python/k2/symbol_table.py
+++ b/k2/python/k2/symbol_table.py
@@ -168,10 +168,8 @@ class SymbolTable(Generic[Symbol]):
         '''
         if isinstance(k, int):
             return self._id2sym[k]
-        elif isinstance(k, str):
-            return self._sym2id[k]
         else:
-            raise ValueError(f'Unsupported type {type(k)}.')
+            return self._sym2id[k]
 
     def merge(self, other: 'SymbolTable') -> 'SymbolTable':
         '''Create a union of two SymbolTables.


### PR DESCRIPTION
I'm proposing a couple of changes for the `SymbolTable`:
- standard Python magic methods (len(st), st[], x in st)
- mutability (it is useful to construct them programatically)
- limited support for generic symbol type (can be anything that is hashable and immutable)
- merging symbol tables (without conflicting ids)

If these are OK to go I'll add the tests.