### PR TITLE
fix a issue of host invertion

### DIFF
--- a/k2/csrc/host/aux_labels.cc
+++ b/k2/csrc/host/aux_labels.cc
@@ -61,12 +61,14 @@ static void CountExtraStates(const k2host::Fsa &fsa_in,
                                `state_map[i]` in the output FSA.
                                At exit, it will be
                                state_map[0] = 0,
-                               state_map[i] = state_map[i-1]
+                               state_map[i] = num_extra_states[0]
+                                            + state_map[i-1]
                                             + num_extra_states[i]
                                             + 1, for any i >=1
   @param [out] state_ids       At exit, it will be
                                state_ids[0] = 0,
-                               state_ids[i] = state_map[i-1], for any i >= 1.
+                               state_ids[1] = num_extra_states[0],
+                               state_ids[i] = state_map[i-1], for any i > 1.
 */
 static void MapStates(const std::vector<int32_t> &num_extra_states,
                       std::vector<int32_t> *state_map,
@@ -76,15 +78,12 @@ static void MapStates(const std::vector<int32_t> &num_extra_states,
   K2_CHECK_EQ(state_ids->size(), num_extra_states.size());
   auto &s_map = *state_map;
   auto &s_ids = *state_ids;
-  // we suppose there's no arcs entering the start state (i.e. state id of the
-  // start state in output FSA will be 0), otherwise we may need to create a new
-  // state as the real start state.
-  K2_CHECK_EQ(num_extra_states[0], 0);
+
   auto num_states_in = num_extra_states.size();
   // process from the second state
   s_map[0] = 0;
   s_ids[0] = 0;
-  int32_t num_states_out = 0;
+  int32_t num_states_out = num_extra_states[0];
   for (auto i = 1; i != num_states_in; ++i) {
     s_ids[i] = num_states_out;
     // `+1` as we did not count state `i` itself in `num_extra_states`

--- a/k2/csrc/host/aux_labels_test.cc
+++ b/k2/csrc/host/aux_labels_test.cc
@@ -262,6 +262,57 @@ TEST(AuxLabels, InvertFst) {
     EXPECT_THAT(out_indexes, ::testing::ElementsAre(0, 0, 0, 1, 2, 3, 3, 4, 4,
                                                     5, 6, 7, 7, 8));
   }
+  {
+    // non-top-sorted input FSA and there are arcs entering the start state
+    std::vector<Arc> arcs = {{0, 1, 1, 0},  {0, 1, 0, 0}, {0, 3, 2, 0},
+                             {1, 2, 3, 0},  {1, 0, 4, 0}, {2, 0, 5, 0},
+                             {2, 5, -1, 0}, {3, 1, 6, 0}, {4, 5, -1, 0}};
+    FsaCreator fsa_in_creator(arcs, 5);
+    const auto &fsa_in = fsa_in_creator.GetFsa();
+    EXPECT_FALSE(IsTopSorted(fsa_in));
+    std::vector<int32_t> start_pos = {0, 2, 3, 3, 6, 8, 11, 12, 14, 15};
+    EXPECT_EQ(start_pos.size(), fsa_in.size2 + 1);
+    std::vector<int32_t> labels = {1,  2,  3,  5,  6,  7,  8, 9,
+                                   10, 11, 12, -1, 13, 14, -1};
+    AuxLabels labels_in(static_cast<int32_t>(start_pos.size()) - 1,
+                        static_cast<int32_t>(labels.size()), start_pos.data(),
+                        labels.data());
+
+    FstInverter fst_inverter(fsa_in, labels_in);
+    Array2Size<int32_t> fsa_size, aux_size;
+    fst_inverter.GetSizes(&fsa_size, &aux_size);
+    Array2Storage<int32_t *, int32_t> aux_storage(aux_size, 1);
+    auto labels_out = aux_storage.GetArray2();
+    FsaCreator fsa_creator(fsa_size);
+    auto &fsa_out = fsa_creator.GetFsa();
+    fst_inverter.GetOutput(&fsa_out, &labels_out);
+
+    EXPECT_FALSE(IsTopSorted(fsa_out));
+    std::vector<Arc> arcs_out = {
+        {0, 4, 1, 0},  {0, 6, 3, 0},   {0, 10, 0, 0},  {1, 0, 9, 0},
+        {2, 3, 11, 0}, {3, 0, 12, 0},  {4, 6, 2, 0},   {5, 6, 14, 0},
+        {6, 7, 5, 0},  {6, 1, 8, 0},   {7, 8, 6, 0},   {8, 9, 7, 0},
+        {9, 2, 10, 0}, {9, 12, -1, 0}, {10, 5, 13, 0}, {11, 12, -1, 0}};
+    ASSERT_EQ(fsa_out.size2, arcs_out.size());
+    for (auto i = 0; i != arcs_out.size(); ++i) {
+      EXPECT_EQ(fsa_out.data[i], arcs_out[i]);
+    }
+    ASSERT_EQ(fsa_out.size1, 13);
+    std::vector<int32_t> arc_indexes(fsa_out.indexes,
+                                     fsa_out.indexes + fsa_out.size1 + 1);
+    EXPECT_THAT(arc_indexes, ::testing::ElementsAre(0, 3, 4, 5, 6, 7, 8, 10, 11,
+                                                    12, 14, 15, 16, 16));
+
+    ASSERT_EQ(labels_out.size1, 16);
+    ASSERT_EQ(labels_out.size2, 8);
+    std::vector<int32_t> out_indexes(labels_out.indexes,
+                                     labels_out.indexes + labels_out.size1 + 1);
+    std::vector<int32_t> out_data(labels_out.data,
+                                  labels_out.data + labels_out.size2);
+    EXPECT_THAT(out_data, ::testing::ElementsAre(2, 4, 5, 1, 6, 3, -1, -1));
+    EXPECT_THAT(out_indexes, ::testing::ElementsAre(0, 0, 0, 1, 2, 2, 3, 4, 5,
+                                                    5, 5, 5, 6, 6, 7, 7, 8));
+  }
 }
 
 }  // namespace k2host


### PR DESCRIPTION
@freewym I have removed the limitation of `no arcs entering start state`. Noted we still have the limitation that aux_labels for final-arcs must be -1. I'll do it tomorrow.