### PR TITLE
implement GPU invert with ExpandArcs

### DIFF
--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -418,6 +418,45 @@ Fsa Closure(Fsa &fsa, Array1<int32_t> *arc_map = nullptr);
 FsaOrVec ExpandArcs(FsaOrVec &fsas, RaggedShape &labels_shape,
                     Array1<int32_t> *fsas_arc_map = nullptr,
                     Array1<int32_t> *labels_arc_map = nullptr);
+/*
+  Invert an FST, swapping the labels in the FSA with the auxiliary labels.
+  (e.g. swap input and output symbols in FST, but you decide which is which).
+  Because each arc may have more than one auxiliary label, in general
+  the output FSA may have more states than the input FSA.
+
+    @param [in] src             Input Fsa or FsaVec.
+    @param [in] src_aux_labels  aux_labels of `src`, must have NumAxes() == 2
+                                and Dim0() == src.NumElements(). Each row in it
+                                is the aux_labels for each arc in `src`.
+                                Noted for final-arcs (arcs entering the final
+                                state), only the last aux_label can be -1, i.e.
+                                the aux_labels for final-arcs should be
+                                [x1,x2,...xn, -1] where xi != -1 for i from 1
+                                to n (which also implies that aux_labels for
+                                final-arc must at least contain -1).
+                                For other arcs that are not final-arcs,
+                                the corresponding aux_labels must contain no
+                                -1.
+    @param [out] dest   Output Fsa or FsaVec, it's the inverted Fsa. At exit
+                        dest.NumAxes() == src.NumAxes() and num-states of it
+                        >= num_states in src. labels in `dest` will correspond
+                        to those in `src_aux_labels`.
+                        If `src` is top-sorted, then `dest` will be top-sorted
+                        as well.
+    @param [out] dest_aux_labels aux_labels of dest, will be the same as labels
+                        in `src`.
+    @param [out] arc_map  If not nullptr, will be set to to a new array of
+                         size `ans.NumElements()`, whose i'th element
+                         is the arc-index into `fsas.values` where the score
+                         of this arc came from, or -1 if the score was set to
+                         zero (because it was not the first arc of a chain).
+                         Noted arc_map follows the *score*, not label, see
+                         `fsas_arc_map` in above function `expand_arcs` for
+                         details.
+ */
+void Invert(FsaOrVec &src, Ragged<int32_t> &src_aux_labels, FsaOrVec *dest,
+            Ragged<int32_t> *dest_aux_labels,
+            Array1<int32_t> *arc_map = nullptr);
 
 /*
   Invert an FST, swapping the labels in the FSA with the auxiliary labels.
@@ -430,6 +469,15 @@ FsaOrVec ExpandArcs(FsaOrVec &fsas, RaggedShape &labels_shape,
     @param [in] src_aux_labels  aux_labels of `src`, must have NumAxes() == 2
                                 and Dim0() == src.NumElements(). Each row in it
                                 is the aux_labels for each arc in `src`.
+                                Noted for final-arcs (arcs entering the final
+                                state), only the last aux_label can be -1, i.e.
+                                the aux_labels for final-arcs should be
+                                [x1,x2,...xn, -1] where xi != -1 for i from 1
+                                to n (which also implies that aux_labels for
+                                final-arc must at least contain -1).
+                                For other arcs that are not final-arcs,
+                                the corresponding aux_labels must contain no
+                                -1.
     @param [out] dest   Output Fsa or FsaVec, it's the inverted Fsa. At exit
                         dest.NumAxes() == src.NumAxes() and num-states of it
                         >= num_states in src. labels in `dest` will correspond

--- a/k2/csrc/host/aux_labels_test.cc
+++ b/k2/csrc/host/aux_labels_test.cc
@@ -263,17 +263,18 @@ TEST(AuxLabels, InvertFst) {
                                                     5, 6, 7, 7, 8));
   }
   {
-    // non-top-sorted input FSA and there are arcs entering the start state
+    // non-top-sorted input FSA and there are arcs entering the start state and
+    // there are multiple olables for the final-arc
     std::vector<Arc> arcs = {{0, 1, 1, 0},  {0, 1, 0, 0}, {0, 3, 2, 0},
                              {1, 2, 3, 0},  {1, 0, 4, 0}, {2, 0, 5, 0},
                              {2, 5, -1, 0}, {3, 1, 6, 0}, {4, 5, -1, 0}};
     FsaCreator fsa_in_creator(arcs, 5);
     const auto &fsa_in = fsa_in_creator.GetFsa();
     EXPECT_FALSE(IsTopSorted(fsa_in));
-    std::vector<int32_t> start_pos = {0, 2, 3, 3, 6, 8, 11, 12, 14, 15};
+    std::vector<int32_t> start_pos = {0, 2, 3, 3, 6, 8, 11, 13, 15, 18};
     EXPECT_EQ(start_pos.size(), fsa_in.size2 + 1);
-    std::vector<int32_t> labels = {1,  2,  3,  5,  6,  7,  8, 9,
-                                   10, 11, 12, -1, 13, 14, -1};
+    std::vector<int32_t> labels = {1,  2,  3,  5,  6,  7,  8,  9,  10,
+                                   11, 12, 13, -1, 14, 15, 16, 17, -1};
     AuxLabels labels_in(static_cast<int32_t>(start_pos.size()) - 1,
                         static_cast<int32_t>(labels.size()), start_pos.data(),
                         labels.data());
@@ -289,29 +290,32 @@ TEST(AuxLabels, InvertFst) {
 
     EXPECT_FALSE(IsTopSorted(fsa_out));
     std::vector<Arc> arcs_out = {
-        {0, 4, 1, 0},  {0, 6, 3, 0},   {0, 10, 0, 0},  {1, 0, 9, 0},
-        {2, 3, 11, 0}, {3, 0, 12, 0},  {4, 6, 2, 0},   {5, 6, 14, 0},
-        {6, 7, 5, 0},  {6, 1, 8, 0},   {7, 8, 6, 0},   {8, 9, 7, 0},
-        {9, 2, 10, 0}, {9, 12, -1, 0}, {10, 5, 13, 0}, {11, 12, -1, 0}};
+        {0, 4, 1, 0},    {0, 6, 3, 0},    {0, 10, 0, 0},  {1, 0, 9, 0},
+        {2, 3, 11, 0},   {3, 0, 12, 0},   {4, 6, 2, 0},   {5, 6, 15, 0},
+        {6, 7, 5, 0},    {6, 1, 8, 0},    {7, 8, 6, 0},   {8, 9, 7, 0},
+        {9, 2, 10, 0},   {9, 12, 13, 0},  {10, 5, 14, 0}, {11, 13, 16, 0},
+        {12, 15, -1, 0}, {13, 14, 17, 0}, {14, 15, -1, 0}};
     ASSERT_EQ(fsa_out.size2, arcs_out.size());
     for (auto i = 0; i != arcs_out.size(); ++i) {
       EXPECT_EQ(fsa_out.data[i], arcs_out[i]);
     }
-    ASSERT_EQ(fsa_out.size1, 13);
+    ASSERT_EQ(fsa_out.size1, 16);
     std::vector<int32_t> arc_indexes(fsa_out.indexes,
                                      fsa_out.indexes + fsa_out.size1 + 1);
-    EXPECT_THAT(arc_indexes, ::testing::ElementsAre(0, 3, 4, 5, 6, 7, 8, 10, 11,
-                                                    12, 14, 15, 16, 16));
+    EXPECT_THAT(arc_indexes,
+                ::testing::ElementsAre(0, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15,
+                                       16, 17, 18, 19, 19));
 
-    ASSERT_EQ(labels_out.size1, 16);
+    ASSERT_EQ(labels_out.size1, 19);
     ASSERT_EQ(labels_out.size2, 8);
     std::vector<int32_t> out_indexes(labels_out.indexes,
                                      labels_out.indexes + labels_out.size1 + 1);
     std::vector<int32_t> out_data(labels_out.data,
                                   labels_out.data + labels_out.size2);
     EXPECT_THAT(out_data, ::testing::ElementsAre(2, 4, 5, 1, 6, 3, -1, -1));
-    EXPECT_THAT(out_indexes, ::testing::ElementsAre(0, 0, 0, 1, 2, 2, 3, 4, 5,
-                                                    5, 5, 5, 6, 6, 7, 7, 8));
+    EXPECT_THAT(out_indexes,
+                ::testing::ElementsAre(0, 0, 0, 1, 2, 2, 3, 4, 5, 5, 5, 5, 6, 6,
+                                       6, 6, 6, 7, 7, 8));
   }
 }
 

--- a/k2/csrc/host/fsa_util.cc
+++ b/k2/csrc/host/fsa_util.cc
@@ -207,17 +207,16 @@ void ReorderArcs(const std::vector<Arc> &arcs, Fsa *fsa,
 
   using ArcWithIndex = std::pair<Arc, int32_t>;
   int32_t arc_id = 0;
-  std::vector<std::vector<ArcWithIndex>> vec;
+  std::size_t num_states = fsa->size1;
+  std::vector<std::vector<ArcWithIndex>> vec(num_states);
   for (const auto &arc : arcs) {
     auto src_state = arc.src_state;
     auto dest_state = arc.dest_state;
-    auto new_size = std::max(src_state, dest_state);
-    if (new_size >= vec.size()) vec.resize(new_size + 1);
+    K2_CHECK_LT(src_state, num_states);
+    K2_CHECK_LT(dest_state, num_states);
     vec[src_state].push_back({arc, arc_id++});
   }
 
-  std::size_t num_states = vec.size();
-  K2_CHECK_EQ(num_states, fsa->size1);
   std::vector<int32_t> arc_map_out;
   arc_map_out.reserve(arcs.size());
 

--- a/k2/python/csrc/torch/fsa_algo.cu
+++ b/k2/python/csrc/torch/fsa_algo.cu
@@ -317,14 +317,20 @@ static void PybindClosure(py::module &m) {
 static void PybindInvert(py::module &m) {
   m.def(
       "invert",
-      [](FsaOrVec &src, Ragged<int32_t> &src_aux_labels)
-          -> std::pair<FsaOrVec, Ragged<int32_t>> {
+      [](FsaOrVec &src, Ragged<int32_t> &src_aux_labels,
+         bool need_arc_map =
+             true) -> std::tuple<FsaOrVec, Ragged<int32_t>,
+                                 torch::optional<torch::Tensor>> {
         FsaOrVec dest;
         Ragged<int32_t> dest_aux_labels;
-        InvertHost(src, src_aux_labels, &dest, &dest_aux_labels);
-        return std::make_pair(dest, dest_aux_labels);
+        Array1<int32_t> arc_map;
+        Invert(src, src_aux_labels, &dest, &dest_aux_labels,
+               need_arc_map ? &arc_map : nullptr);
+        torch::optional<torch::Tensor> arc_map_tensor;
+        if (need_arc_map) arc_map_tensor = ToTensor(arc_map);
+        return std::make_tuple(dest, dest_aux_labels, arc_map_tensor);
       },
-      py::arg("src"), py::arg("src_aux_labels"));
+      py::arg("src"), py::arg("src_aux_labels"), py::arg("need_arc_map"));
 }
 
 }  // namespace k2

--- a/k2/python/k2/fsa_algo.py
+++ b/k2/python/k2/fsa_algo.py
@@ -527,9 +527,6 @@ def closure(fsa: Fsa) -> Fsa:
 def invert(fsa: Fsa) -> Fsa:
     '''Invert an FST, swapping the labels in the FSA with the auxiliary labels.
 
-    Caution:
-      It only works on CPU and doesn't support autograd.
-
     Args:
       fsa:
         The input FSA. It can be either a single FSA or an FsaVec.
@@ -542,5 +539,7 @@ def invert(fsa: Fsa) -> Fsa:
         return fsa.invert()
     else:
         assert isinstance(fsa.aux_labels, _k2.RaggedInt)
-        ragged_arc, aux_labels = _k2.invert(fsa.arcs, fsa.aux_labels)
+        need_arc_map = False
+        ragged_arc, aux_labels, _ = _k2.invert(fsa.arcs, fsa.aux_labels,
+                                               need_arc_map)
         return Fsa(ragged_arc, aux_labels)

--- a/k2/python/tests/invert_test.py
+++ b/k2/python/tests/invert_test.py
@@ -57,25 +57,6 @@ class TestInvert(unittest.TestCase):
         fsa.aux_labels = k2.RaggedInt(aux_shape, aux_values)
         dest = k2.invert(fsa)
         print(dest)  # will print aux_labels as well
-        expected_fsa_str = '''
-            0 1 1 0
-            0 3 3 0
-            0 7 0 0
-            1 3 2 0
-            2 3 10 0
-            3 4 5 0
-            3 7 0 0
-            4 5 6 0
-            5 6 7 0
-            6 3 8 0
-            6 9 -1 0
-            7 2 9 0
-            8 9 -1 0
-            9
-        '''
-        expected_fsa = k2.Fsa.from_str(expected_fsa_str)
-        print(dest.arcs)
-        print(expected_fsa.arcs)
         # TODO(haowen): wrap C++ code to check equality for Ragged?
 
 


### PR DESCRIPTION
Have made host version consistent with GPU version (i.e. final-arcs now can have multiple aux_labels), though the state_id of the output Fsa from those two functions may be different, but we can test theire equivalence with `IsRandEquivalent`.