### PR TITLE
Implement normalize scores for ragged tensors

### DIFF
--- a/docs/source/python_tutorials/index.rst
+++ b/docs/source/python_tutorials/index.rst
@@ -1,5 +1,5 @@
 
-Python Tutorials
+Python tutorials
 ================
 
 .. toctree::

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1052,7 +1052,7 @@ Array1<FloatType> GetForwardScores(FsaVec &fsas, Ragged<int32_t> &state_batches,
           num_arcs = fsas.TotSize(2);
   int32_t num_batches = state_batches.Dim0();
   // just using DCHECK below to save time in production code
-  K2_DCHECK(state_batches.TotSize(1) == num_fsas * num_batches);
+  K2_DCHECK_EQ(state_batches.TotSize(1), num_fsas * num_batches);
   K2_DCHECK_EQ(state_batches.NumElements(), num_states);
   K2_DCHECK_EQ(entering_arc_batches.Dim0(), num_batches);
   K2_DCHECK_EQ(entering_arc_batches.TotSize(1), state_batches.TotSize(1));

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1797,7 +1797,7 @@ void FixNumStates(FsaVec *fsas) {
 
   Array1<int32_t> changed(c, 1, 0);
   Renumbering renumber_states(c, num_states);
-  renumber_states.Keep() = (char)1;  // by default keep all states..
+  renumber_states.Keep() = static_cast<char>(1);  // by default keep all states.
 
   int32_t *changed_data = changed.Data();
   char *keep_data = renumber_states.Keep().Data();

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -32,7 +32,7 @@ namespace k2 {
 
      @param [in] src            Input ragged array; must have src.NumAxes()
                                 >= 2. src.values is allowed to be empty.
-     @param [in] default_value  Value to initialize the reduction with;
+     @param [in] initial_value  Value to initialize the reduction with;
      @param [out] dst           Array to which the reduction values will be
                                 written. Must satisfy
                                 dst->Dim() == rows along the last axis in src,
@@ -40,15 +40,15 @@ namespace k2 {
 */
 
 template <typename T, typename Op>
-void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst);
+void ApplyOpPerSublist(Ragged<T> &src, T initial_value, Array1<T> *dst);
 /*
   Output to an array `max_values` the maximum of each sub-list along the last
-  axis of `src` i.e. the max taken over the last axis), or `default_value`,
+  axis of `src` i.e. the max taken over the last axis), or `initial_value`,
   whichever was larger.
 
      @param [in] src            Input ragged array; must have src.NumAxes()
                                 >= 2. src.values is allowed to be empty.
-     @param [in] default_value  Value to use for maximum operation as a default
+     @param [in] initial_value  Value to use for maximum operation as a default
                                 so max is taken over this and the elements
                                 of sub-lists in `src`.
      @param [out] max_values    Array to which the maximum values will be
@@ -58,28 +58,28 @@ void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst);
                                 src.RowSplits(src.NumAxes() - 1).Dim() - 1.
  */
 template <typename T>
-void MaxPerSublist(Ragged<T> &src, T default_value, Array1<T> *max_values) {
-  ApplyOpPerSublist<T, MaxOp<T>>(src, default_value, max_values);
+void MaxPerSublist(Ragged<T> &src, T initial_value, Array1<T> *max_values) {
+  ApplyOpPerSublist<T, MaxOp<T>>(src, initial_value, max_values);
 }
 
 // Same with `MaxPerSubList`, but output the `min_value` in each sub-list.
 template <typename T>
-void MinPerSublist(Ragged<T> &src, T default_value, Array1<T> *min_values) {
-  ApplyOpPerSublist<T, MinOp<T>>(src, default_value, min_values);
+void MinPerSublist(Ragged<T> &src, T initial_value, Array1<T> *min_values) {
+  ApplyOpPerSublist<T, MinOp<T>>(src, initial_value, min_values);
 }
 
 // Same with `MaxPerSubList`, but output the sum of values in each sub-list.
 template <typename T>
-void SumPerSublist(Ragged<T> &src, T default_value, Array1<T> *sum_values) {
-  ApplyOpPerSublist<T, PlusOp<T>>(src, default_value, sum_values);
+void SumPerSublist(Ragged<T> &src, T initial_value, Array1<T> *sum_values) {
+  ApplyOpPerSublist<T, PlusOp<T>>(src, initial_value, sum_values);
 }
 
 // Same with `MaxPerSubList`, but with Op as `LogAdd`.
 template <typename T>
-void LogSumPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst_values) {
+void LogSumPerSublist(Ragged<T> &src, T initial_value, Array1<T> *dst_values) {
   K2_STATIC_ASSERT(
       (std::is_same<float, T>::value || std::is_same<double, T>::value));
-  ApplyOpPerSublist<T, LogAdd<T>>(src, default_value, dst_values);
+  ApplyOpPerSublist<T, LogAdd<T>>(src, initial_value, dst_values);
 }
 
 /*
@@ -88,7 +88,7 @@ void LogSumPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst_values) {
 
      @param [in] src            Input ragged array; must have src.NumAxes()
                                 >= 2. src.values is allowed to be empty.
-     @param [in] default_value  Value to initialize the reduction with; should
+     @param [in] initial_value  Value to initialize the reduction with; should
                                 probably be all-ones.
      @param [out] and_values    Array to which the bitwise-and values will be
                                 written. Must satisfy
@@ -96,14 +96,14 @@ void LogSumPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst_values) {
   2), i.e. the total size on the second-to-last axis of `src`.
 */
 template <typename T>
-void AndPerSublist(Ragged<T> &src, T default_value, Array1<T> *and_values) {
-  ApplyOpPerSublist<T, BitAndOp<T>>(src, default_value, and_values);
+void AndPerSublist(Ragged<T> &src, T initial_value, Array1<T> *and_values) {
+  ApplyOpPerSublist<T, BitAndOp<T>>(src, initial_value, and_values);
 }
 
 // bitwise or
 template <typename T>
-void OrPerSublist(Ragged<T> &src, T default_value, Array1<T> *or_values) {
-  ApplyOpPerSublist<T, BitOrOp<T>>(src, default_value, or_values);
+void OrPerSublist(Ragged<T> &src, T initial_value, Array1<T> *or_values) {
+  ApplyOpPerSublist<T, BitOrOp<T>>(src, initial_value, or_values);
 }
 
 /*
@@ -332,7 +332,6 @@ Ragged<T> RemoveAxis(Ragged<T> &src, int32_t axis) {
  */
 RaggedShape GetLayer(const RaggedShape &src, int32_t layer);
 
-
 /*
   This is the inverse of ComposeRaggedShapes(); it splits up a RaggedShape
   into two pieces such that `top->NumElements() == bottom->Dim0()`.
@@ -347,8 +346,7 @@ RaggedShape GetLayer(const RaggedShape &src, int32_t layer);
                         `top->NumElements() == bottom->Dim0()` and
                         `Equal(src, ComposeRaggedShapes(*top, *bottom))`
  */
-void DecomposeRaggedShape(const RaggedShape &src,
-                          int32_t axis,
+void DecomposeRaggedShape(const RaggedShape &src, int32_t axis,
                           RaggedShape *top, RaggedShape *bottom);
 
 /*
@@ -530,9 +528,7 @@ RaggedShape RandomRaggedShape(bool set_row_ids = false,
 
   Notice the other version of this function below.
  */
-RaggedShape SubsampleRaggedShape(RaggedShape &src,
-                                 Renumbering &renumbering);
-
+RaggedShape SubsampleRaggedShape(RaggedShape &src, Renumbering &renumbering);
 
 /*
   Return ragged shape with only a subset of the elements on the last
@@ -558,13 +554,13 @@ RaggedShape SubsampleRaggedShape(RaggedShape &src,
                          between old and new indexes on axis `axis` (e.g. if
                          `axis == 0` would map between idx0's and idx0's; if
                          `axis == 1`, would map between idx01's and idx01's).
-     @return             Returns modified shape with ans.NumAxes() == src_shape.NumAxes().
-                         ans.TotSize(axis) may differ from src_shape.TotSize(axis),
-                         but other TotSize() values, and the numbering on other axes,
-                         will remain the same.
+     @return             Returns modified shape with
+                         ans.NumAxes() == src_shape.NumAxes().
+                         ans.TotSize(axis) may differ from
+                         src_shape.TotSize(axis), but other TotSize() values,
+                         and the numbering on other axes, will remain the same.
  */
-RaggedShape RemoveEmptyLists(RaggedShape &src_shape,
-                             int32_t axis,
+RaggedShape RemoveEmptyLists(RaggedShape &src_shape, int32_t axis,
                              Renumbering *renumbering = nullptr);
 
 /*
@@ -581,15 +577,14 @@ RaggedShape RemoveEmptyLists(RaggedShape &src_shape,
                          `axis == 1`, would map between idx01's and idx01's).
                          It is assumed that this renumbering preserves
                          all lists that are nonempty.
-     @return             Returns modified shape with ans.NumAxes() == src_shape.NumAxes().
-                         ans.TotSize(axis) may differ from src_shape.TotSize(axis),
-                         but other TotSize() values, and the numbering on other axes,
-                         will remain the same.
+     @return             Returns modified shape with
+                         ans.NumAxes() == src_shape.NumAxes().
+                         ans.TotSize(axis) may differ from
+                         src_shape.TotSize(axis), but other TotSize() values,
+                         and the numbering on other axes, will remain the same.
  */
-RaggedShape RemoveSomeEmptyLists(RaggedShape &src_shape,
-                                 int32_t axis,
+RaggedShape RemoveSomeEmptyLists(RaggedShape &src_shape, int32_t axis,
                                  Renumbering &renumbering);
-
 
 /*
   Removes empty lists on axis 0 of a RaggedShape, returning the modified shape
@@ -600,9 +595,11 @@ RaggedShape RemoveSomeEmptyLists(RaggedShape &src_shape,
      @param [out] renumbering  If not nullptr, a renumbering object that maps
                          between old and new indexes on axis 0, i.e. between
                          old and new idx0's.
-     @return             Returns modified shape with ans.NumAxes() == src_shape.NumAxes().
-                         ans.Dim0() may differ from src_shape.Dim0(), but for axis > 0,
-                         we have `ans.TotSize(axis) == src.TotSize(axis)`.
+     @return             Returns modified shape with
+                         ans.NumAxes() == src_shape.NumAxes().
+                         ans.Dim0() may differ from src_shape.Dim0(),
+                         but for axis > 0, we have
+                         `ans.TotSize(axis) == src.TotSize(axis)`.
 */
 RaggedShape RemoveEmptyListsAxis0(RaggedShape &src_shape,
                                   Renumbering *renumbering = nullptr);
@@ -619,14 +616,14 @@ RaggedShape RemoveEmptyListsAxis0(RaggedShape &src_shape,
                          between old and new indexes on axis 0, i.e. between
                          old and new idx0's.  The removed lists must be empty.
 
-     @return             Returns modified shape with ans.NumAxes() == src_shape.NumAxes().
-                         ans.Dim0() may differ from src_shape.Dim0(), but for axis > 0,
-                         we have `ans.TotSize(axis) == src.TotSize(axis)`.
+     @return             Returns modified shape with
+                         ans.NumAxes() == src_shape.NumAxes().
+                         ans.Dim0() may differ from src_shape.Dim0(),
+                         but for axis > 0, we have
+                         `ans.TotSize(axis) == src.TotSize(axis)`.
  */
 RaggedShape RenumberAxis0Simple(RaggedShape &src_shape,
                                 Renumbering &renumbering);
-
-
 
 /*
   Return ragged array with only a subset of the bottom-level elements kept.

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -82,6 +82,20 @@ void LogSumPerSublist(Ragged<T> &src, T initial_value, Array1<T> *dst_values) {
   ApplyOpPerSublist<T, LogAdd<T>>(src, initial_value, dst_values);
 }
 
+/* Normalize per sublist.
+
+   The normalization per sublist is done as follows:
+
+      1. Compute the log sum using LogSumPerSublist
+      2. Subtract the log sum from the sublist
+      3. Return the resulting sublist
+   @param [in] src  The source ragged tensor. The normalization
+                    is done on the last axis.
+   @return The normalized ragged tensor.
+ */
+template <typename T>
+Ragged<T> NormalizePerSublist(Ragged<T> &src);
+
 /*
   Output to an array `and_values` the result of reducing each sub-list along
   the last axis of `src` with operator &, i.e. bit-wise and.

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -40,7 +40,7 @@ void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst) {
   K2_CHECK(IsCompatible(src.shape, *dst));
 
   int32_t last_axis = src.NumAxes() - 1;
-  const Array1<int32_t> &row_splits_array = src.shape.RowSplits(last_axis);
+  const Array1<int32_t> &row_splits_array = src.RowSplits(last_axis);
   int32_t num_rows = row_splits_array.Dim() - 1;
   K2_CHECK_EQ(num_rows, dst->Dim());
 
@@ -62,7 +62,7 @@ void ApplyOpPerSublist(Ragged<T> &src, T default_value, Array1<T> *dst) {
       output_data[i] = val;
     }
   } else {
-    K2_CHECK(c->GetDeviceType() == kCuda);
+    K2_CHECK_EQ(c->GetDeviceType(), kCuda);
 
     // This code is based on the example here:
     // https://nvlabs.github.io/cub/structcub_1_1_device_segmented_reduce.html

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -93,8 +93,7 @@ Ragged<T> NormalizePerSublist(Ragged<T> &src) {
   LogSumPerSublist(src, negative_infinity, &values);
 
   const T *values_data = values.Data();
-  int32_t num_rows = values.Dim();
-  const int32_t *row_splits_data = src.RowSplits(num_axes - 1).Data();
+  const int32_t *row_ids_data = src.RowIds(num_axes - 1).Data();
 
   Array1<T> ans_values(context, src.values.Dim());
   Ragged<T> ans(src.shape, ans_values);
@@ -103,14 +102,11 @@ Ragged<T> NormalizePerSublist(Ragged<T> &src) {
   const T *src_data = src.values.Data();
 
   K2_EVAL(
-      context, num_rows, lambda_do_normalization, (int32_t i)->void {
-        int32_t begin = row_splits_data[i];
-        int32_t end = row_splits_data[i + 1];
-        T normalizer = values_data[i];
+      context, ans_values.Dim(), lambda_do_normalization, (int32_t i)->void {
+        int32_t row = row_ids_data[i];
+        T normalizer = values_data[row];
 
-        // it also handles the case when the sublist is empty
-        for (int32_t k = begin; k != end; ++k)
-          ans_data[k] = src_data[k] - normalizer;
+        ans_data[i] = src_data[i] - normalizer;
       });
   return ans;
 }

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -83,6 +83,7 @@ void ApplyOpPerSublist(Ragged<T> &src, T initial_value, Array1<T> *dst) {
 
 template <typename T>
 Ragged<T> NormalizePerSublist(Ragged<T> &src) {
+  NVTX_RANGE(K2_FUNC);
   K2_STATIC_ASSERT(
       (std::is_same<float, T>::value || std::is_same<double, T>::value));
   T negative_infinity = -std::numeric_limits<T>::infinity();

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -22,6 +22,7 @@
 #endif
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <vector>

--- a/k2/csrc/ragged_utils.cu
+++ b/k2/csrc/ragged_utils.cu
@@ -91,7 +91,7 @@ RaggedShape IntersperseRaggedLayer(int32_t layer,
   int32_t num_axes = src[0]->NumAxes(),
           num_rows = src[0]->TotSize(layer),
        tot_elems = 0;
-  for (int32_t i = 0; i < num_srcs; i++) {
+  for (int32_t i = 0; i < num_srcs; ++i) {
     if (i > 0) {
       K2_CHECK_EQ(src[i]->NumAxes(), num_axes);
       K2_CHECK_EQ(src[i]->TotSize(layer), num_rows);
@@ -100,7 +100,7 @@ RaggedShape IntersperseRaggedLayer(int32_t layer,
     tot_elems += src[i]->TotSize(layer + 1);
     row_splits_ptrs_vec[i] = row_splits.Data();
   }
-  ContextPtr c = src[0]->Context();
+  ContextPtr &c = src[0]->Context();
 
   int32_t new_num_rows = num_rows * num_srcs;
   Array1<int32_t> row_ids(c, tot_elems),
@@ -160,8 +160,8 @@ RaggedShape IntersperseRaggedLayer(int32_t layer,
 
     K2_EVAL(c, tot_elems, lambda_set_merge_map, (int32_t idx01) -> void {
         int32_t idx0 = row_ids_data[idx01],
-               idx1x = row_splits_data[idx0],
-                idx1 = idx01 - idx1x,
+               idx0x = row_splits_data[idx0],
+                idx1 = idx01 - idx0x,
                  src = idx0 % num_srcs,
             src_idx0 = idx0 / num_srcs,
            src_idx0x = row_splits_ptrs_data[src][src_idx0],

--- a/k2/csrc/ragged_utils.h
+++ b/k2/csrc/ragged_utils.h
@@ -114,7 +114,7 @@ RaggedShape AppendRaggedLayer(int32_t axis,
                              element within its source.
 
       @return               Return a RaggedShape with `NumAxes() == 2`, i.e. one layer,
-                            that is the result of appending th
+                            that is the result of appending the
                             sources together; its
                             TotSize(0) will be the sum of src[i]->TotSize(layer),
                             i.e. `num_srcs times src[0]->TotSize(layer)` since they

--- a/k2/python/csrc/torch/ragged.cu
+++ b/k2/python/csrc/torch/ragged.cu
@@ -72,9 +72,7 @@ static void PybindRaggedTpl(py::module &m, const char *name) {
 
   pyclass.def("num_elements", &PyClass::NumElements);
 
-  pyclass.def("shape", [](PyClass &self) -> RaggedShape {
-      return self.shape;
-    });
+  pyclass.def("shape", [](PyClass &self) -> RaggedShape { return self.shape; });
 
   pyclass.def(
       "row_splits",
@@ -111,15 +109,12 @@ static void PybindRaggedTpl(py::module &m, const char *name) {
     return os.str();
   });
 
-  pyclass.def(
-      "tot_sizes",
-      [](const PyClass &self) -> py::list {
-        int32_t num_axes = self.NumAxes();
-        py::list ans(num_axes);
-        for (int32_t i = 0; i < self.NumAxes(); i++)
-          ans[i] = self.TotSize(i);
-        return ans;
-      });
+  pyclass.def("tot_sizes", [](const PyClass &self) -> py::list {
+    int32_t num_axes = self.NumAxes();
+    py::list ans(num_axes);
+    for (int32_t i = 0; i < self.NumAxes(); i++) ans[i] = self.TotSize(i);
+    return ans;
+  });
 
   pyclass.def(py::pickle(
       [](const PyClass &obj) {
@@ -176,6 +171,7 @@ static void PybindRaggedTpl(py::module &m, const char *name) {
 static void PybindRaggedImpl(py::module &m) {
   PybindRaggedTpl<Arc>(m, "RaggedArc");
   PybindRaggedTpl<int32_t>(m, "RaggedInt");
+  PybindRaggedTpl<float>(m, "RaggedFloat");
 
   m.def(
       "index_tensor_with_ragged_int",
@@ -220,16 +216,12 @@ static void PybindRaggedShape(py::module &m) {
       },
       py::arg("axis"));
 
-  pyclass.def(
-      "tot_sizes",
-      [](const PyClass &self) -> py::list {
-        int32_t num_axes = self.NumAxes();
-        py::list ans(num_axes);
-        for (int32_t i = 0; i < self.NumAxes(); i++)
-          ans[i] = self.TotSize(i);
-        return ans;
-      });
-
+  pyclass.def("tot_sizes", [](const PyClass &self) -> py::list {
+    int32_t num_axes = self.NumAxes();
+    py::list ans(num_axes);
+    for (int32_t i = 0; i < self.NumAxes(); i++) ans[i] = self.TotSize(i);
+    return ans;
+  });
 
   pyclass.def("__str__", [](const PyClass &self) -> std::string {
     std::ostringstream os;
@@ -262,17 +254,16 @@ static void PybindRaggedShapeUtils(py::module &m) {
       },
       py::arg("row_splits"), py::arg("row_ids"),
       py::arg("cached_tot_size") = -1);
+  m.def("compose_ragged_shapes", ComposeRaggedShapes, py::arg("a"),
+        py::arg("b"));
+
   m.def(
-      "compose_ragged_shapes", ComposeRaggedShapes,
-      py::arg("a"), py::arg("b"));
-
-  m.def("ragged_shape_remove_axis",  [](RaggedShape &src, int32_t axis) -> RaggedShape {
-      return RemoveAxis(src, axis);
-    }, py::arg("src"), py::arg("axis"));
-
+      "ragged_shape_remove_axis",
+      [](RaggedShape &src, int32_t axis) -> RaggedShape {
+        return RemoveAxis(src, axis);
+      },
+      py::arg("src"), py::arg("axis"));
 }
-
-
 
 }  // namespace k2
 

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -117,7 +117,8 @@ static void PybindNormalizePerSublistBackward(py::module &m, const char *name) {
               });
         }
         return ToTensor(ans_grad_array);
-      });
+      },
+      py::arg("out"), py::arg("out_grad"));
 }
 
 }  // namespace k2

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -10,15 +10,14 @@
 
 #include "k2/csrc/ragged_ops.h"
 #include "k2/python/csrc/torch/ragged_ops.h"
+#include "k2/python/csrc/torch/torch_util.h"
 
 namespace k2 {
-
 
 template <typename T>
 static void PybindRaggedRemoveAxis(py::module &m, const char *name) {
   m.def(name, &RemoveAxis<T>, py::arg("src"), py::arg("axis"));
 }
-
 
 template <typename T>
 static void PybindRemoveValuesLeq(py::module &m, const char *name) {
@@ -30,27 +29,26 @@ static void PybindRemoveValuesEq(py::module &m, const char *name) {
   m.def(name, &RemoveValuesEq<T>, py::arg("src"), py::arg("target"));
 }
 
-
 // Recursive implementation function used inside PybindToLists().
 // Returns a list containing elements `begin` through `end-1` on
 // axis `axis` of `r`, with 0 <= axis < r.NumAxes(), and
 // 0 <= begin <= end <= r.TotSize(axis).
-py::list RaggedInt32ToList(Ragged<int32_t> &r, int32_t axis,
-                           int32_t begin, int32_t end) {
-  K2_CHECK_LT(static_cast<uint32_t>(axis),
-              static_cast<uint32_t>(r.NumAxes()));
+static py::list RaggedInt32ToList(Ragged<int32_t> &r, int32_t axis,
+                                  int32_t begin, int32_t end) {
+  K2_CHECK_LT(static_cast<uint32_t>(axis), static_cast<uint32_t>(r.NumAxes()));
   K2_CHECK_LE(end, r.TotSize(axis));
   py::list ans(end - begin);
   int32_t num_axes = r.NumAxes();
   int32_t *data;
-  if (axis == num_axes - 1) data = r.values.Data();
-  else data = r.RowSplits(axis + 1).Data();
+  if (axis == num_axes - 1)
+    data = r.values.Data();
+  else
+    data = r.RowSplits(axis + 1).Data();
   for (int32_t i = begin; i < end; i++) {
     if (axis == num_axes - 1) {
       ans[i - begin] = data[i];
     } else {
-      int32_t row_begin = data[i],
-                row_end = data[i + 1];
+      int32_t row_begin = data[i], row_end = data[i + 1];
       ans[i - begin] = RaggedInt32ToList(r, axis + 1, row_begin, row_end);
     }
   }
@@ -58,20 +56,34 @@ py::list RaggedInt32ToList(Ragged<int32_t> &r, int32_t axis,
 };
 
 static void PybindRaggedIntToList(py::module &m, const char *name) {
-  m.def(name, [](Ragged<int32_t> &src) -> py::list {
-      Ragged<int32_t> r = src.To(GetCpuContext());
-      return RaggedInt32ToList(r, 0, 0, r.Dim0());
-    }, py::arg("src"));
+  m.def(
+      name,
+      [](Ragged<int32_t> &src) -> py::list {
+        Ragged<int32_t> r = src.To(GetCpuContext());
+        return RaggedInt32ToList(r, 0, 0, r.Dim0());
+      },
+      py::arg("src"));
 }
 
+template <typename T>
+static void PybindMaxPerSublist(py::module &m, const char *name) {
+  m.def(
+      name,
+      [](Ragged<T> &src, T default_value) -> torch::Tensor {
+        Array1<T> max_values(src.Context(), src.TotSize(src.NumAxes() - 2));
+        MaxPerSublist(src, default_value, &max_values);
+        return ToTensor(max_values);
+      },
+      py::arg("src"), py::arg("default_value"));
+}
 
 }  // namespace k2
 
 void PybindRaggedOps(py::module &m) {
-  using namespace k2;
+  using namespace k2;  // NOLINT
   PybindRaggedRemoveAxis<int32_t>(m, "ragged_int_remove_axis");
   PybindRemoveValuesLeq<int32_t>(m, "ragged_int_remove_values_leq");
   PybindRemoveValuesEq<int32_t>(m, "ragged_int_remove_values_eq");
   PybindRaggedIntToList(m, "ragged_int_to_list");
-
+  PybindMaxPerSublist<float>(m, "max_per_sublist");
 }

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -1,6 +1,5 @@
 import torch  # noqa
-from _k2 import RaggedFloat
-from _k2 import RaggedInt
+from _k2 import RaggedInt  # TODO(fangjun): move it to k2.ragged
 from _k2 import simple_ragged_index_select
 
 from . import autograd

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -1,4 +1,5 @@
 import torch  # noqa
+from _k2 import RaggedFloat
 from _k2 import RaggedInt
 from _k2 import simple_ragged_index_select
 

--- a/k2/python/k2/ragged/__init__.py
+++ b/k2/python/k2/ragged/__init__.py
@@ -1,10 +1,12 @@
 # please sort imported functions alphabetically
 from .ops import (
     index,
+    log_sum_per_sublist,
     max_per_sublist,
     remove_axis,
     remove_values_eq,
     remove_values_leq,
+    sum_per_sublist,
     to_list,
 )
 from .ragged_shape import (
@@ -16,10 +18,12 @@ from .ragged_shape import (
 
 __all__ = [
     'index',
+    'log_sum_per_sublist',
     'max_per_sublist',
     'remove_axis',
     'remove_values_eq',
     'remove_values_leq',
+    'sum_per_sublist',
     'to_list',
     #
     'RaggedShape'

--- a/k2/python/k2/ragged/__init__.py
+++ b/k2/python/k2/ragged/__init__.py
@@ -1,33 +1,26 @@
 # please sort imported functions alphabetically
-from .ops import (
-    index,
-    log_sum_per_sublist,
-    max_per_sublist,
-    remove_axis,
-    remove_values_eq,
-    remove_values_leq,
-    sum_per_sublist,
-    to_list,
-)
-from .ragged_shape import (
-    RaggedShape,
-    compose_ragged_shapes,
-    create_ragged_shape2,
-    random_ragged_shape,
-)
+from .autograd import normalize_scores
+from .ops import index
+from .ops import remove_axis
+from .ops import remove_values_eq
+from .ops import remove_values_leq
+from .ops import to_list
+from .ragged_shape import RaggedShape
+from .ragged_shape import compose_ragged_shapes
+from .ragged_shape import create_ragged_shape2
+from .ragged_shape import random_ragged_shape
+from .tensor import RaggedFloat
 
 __all__ = [
-    'index',
-    'log_sum_per_sublist',
-    'max_per_sublist',
-    'remove_axis',
-    'remove_values_eq',
-    'remove_values_leq',
-    'sum_per_sublist',
-    'to_list',
-    #
+    'RaggedFloat'
     'RaggedShape'
     'compose_ragged_shapes',
     'create_ragged_shape2',
+    'index',
+    'normalize_scores',
     'random_ragged_shape',
+    'remove_axis',
+    'remove_values_eq',
+    'remove_values_leq',
+    'to_list',
 ]

--- a/k2/python/k2/ragged/__init__.py
+++ b/k2/python/k2/ragged/__init__.py
@@ -1,25 +1,29 @@
+# please sort imported functions alphabetically
 from .ops import (
     index,
+    max_per_sublist,
+    remove_axis,
     remove_values_eq,
     remove_values_leq,
-    remove_axis,
     to_list,
 )
 from .ragged_shape import (
+    RaggedShape,
     compose_ragged_shapes,
     create_ragged_shape2,
-    RaggedShape,
     random_ragged_shape,
 )
 
 __all__ = [
     'index',
-    'compose_ragged_shapes',
-    'create_ragged_shape2',
-    'RaggedShape'
-    'random_ragged_shape',
+    'max_per_sublist',
+    'remove_axis',
     'remove_values_eq',
     'remove_values_leq',
-    'remove_axis',
     'to_list',
+    #
+    'RaggedShape'
+    'compose_ragged_shapes',
+    'create_ragged_shape2',
+    'random_ragged_shape',
 ]

--- a/k2/python/k2/ragged/autograd.py
+++ b/k2/python/k2/ragged/autograd.py
@@ -1,0 +1,80 @@
+# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# See ../../../../LICENSE for clarification regarding multiple authors
+
+from typing import List, Tuple
+
+import torch
+import _k2
+
+from .tensor import RaggedFloat
+
+
+class _NormalizeScores(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, src: RaggedFloat, out: List[RaggedFloat],
+                unused_scores: torch.Tensor) -> torch.Tensor:
+        '''Normalize a ragged tensor of scores.
+
+        The normalization per sublist is done as follows:
+
+            1. Compute the log sum per sublist
+            2. Subtract the log sum computed above from the sublist and return
+            it
+
+        Note:
+          If a sublist contains 3 elements `[a, b, c]`, then the log sum
+          is defined as::
+
+            s = log(exp(a) + exp(b) + exp(c))
+
+          The resulting sublist looks like::
+
+            [a - s, b - s, c - s]
+
+        Args:
+          src:
+            The source ragged tensor.
+          out:
+            The output ragged tensor is put in this list. It is returned
+            in the list since this function can only return values of type
+            `torch.Tensor`. On input, we check that `len(out) == 1`.
+          unused_scores:
+            Its sole purpose is for autograd. It equals to `src.scores`.
+        Returns:
+          Returns a tensor that equals to `out.scores`. Callers should
+          discard the return value.
+        '''
+        assert len(out) == 1
+        ans_ragged = _k2.normalize_per_sublist(src.ragged)
+        out[0] = RaggedFloat(ans_ragged)
+        ctx.out = out[0]  # save for backward
+        return out[0].scores
+
+    @staticmethod
+    def backward(ctx,
+                 out_grad: torch.Tensor) -> Tuple[None, None, torch.Tensor]:
+        out = ctx.out
+
+        # TODO(fangjun): remove clone
+        #
+        # we use clone here since out_grad.stride may be 0, which
+        # cannot be converted to k2::Array<T>
+        if out_grad.stride()[0] == 0:
+            out_grad = out_grad.clone()
+
+        ans_grad = _k2.normalize_per_sublist_backward(out.ragged, out_grad)
+        return (
+            None,  # src
+            None,  # out
+            ans_grad)
+
+
+def normalize_scores(src: RaggedFloat) -> RaggedFloat:
+    out = [None]  # placeholder
+
+    # the return value is discarded for the following call
+    # as it equals to out[0].scores
+    _NormalizeScores.apply(src, out, src.scores)
+
+    return out[0]

--- a/k2/python/k2/ragged/autograd.py
+++ b/k2/python/k2/ragged/autograd.py
@@ -55,14 +55,6 @@ class _NormalizeScores(torch.autograd.Function):
     def backward(ctx,
                  out_grad: torch.Tensor) -> Tuple[None, None, torch.Tensor]:
         out = ctx.out
-
-        # TODO(fangjun): remove clone
-        #
-        # we use clone here since out_grad.stride may be 0, which
-        # cannot be converted to k2::Array<T>
-        if out_grad.stride()[0] == 0:
-            out_grad = out_grad.clone()
-
         ans_grad = _k2.normalize_per_sublist_backward(out.ragged, out_grad)
         return (
             None,  # src

--- a/k2/python/k2/ragged/autograd.py
+++ b/k2/python/k2/ragged/autograd.py
@@ -71,6 +71,30 @@ class _NormalizeScores(torch.autograd.Function):
 
 
 def normalize_scores(src: RaggedFloat) -> RaggedFloat:
+    '''Normalize a ragged tensor of scores.
+
+    The normalization per sublist is done as follows:
+
+        1. Compute the log sum per sublist
+        2. Subtract the log sum computed above from the sublist and return
+        it
+
+    Note:
+      If a sublist contains 3 elements `[a, b, c]`, then the log sum
+      is defined as::
+
+        s = log(exp(a) + exp(b) + exp(c))
+
+      The resulting sublist looks like::
+
+        [a - s, b - s, c - s]
+
+    Args:
+      src:
+        The source ragged tensor.
+    Returns:
+      The normalized ragged tensor.
+    '''
     out = [None]  # placeholder
 
     # the return value is discarded for the following call

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -1,4 +1,7 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang
+#                                                   Daniel Povey
+#                                                   Haowen Qiu)
+#
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 
@@ -110,3 +113,16 @@ def to_list(src: _k2.RaggedInt) -> List:
        as `src`.
     '''
     return _k2.ragged_int_to_list(src)
+
+
+def max_per_sublist(src: _k2.RaggedFloat,
+                    default_value: float) -> torch.Tensor:
+    '''Return the max value per sublist.
+
+    Args:
+      src:
+        The source ragged tensor.
+      default_value:
+        The initial value for computing max.
+    '''
+    return _k2.max_per_sublist(src, default_value)

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -2,7 +2,6 @@
 #                                                   Daniel Povey
 #                                                   Haowen Qiu)
 #
-#
 # See ../../../../LICENSE for clarification regarding multiple authors
 
 from typing import Optional, List, Tuple, Union
@@ -114,52 +113,3 @@ def to_list(src: _k2.RaggedInt) -> List:
        as `src`.
     '''
     return _k2.ragged_int_to_list(src)
-
-
-def max_per_sublist(src: _k2.RaggedFloat,
-                    initial_value: Optional[float] = -np.inf) -> torch.Tensor:
-    '''Return the max value per sublist.
-
-    Note:
-      max is taken over the last axis.
-
-    Args:
-      src:
-        The source ragged tensor.
-      initial_value:
-        The initial value for computing max.
-    '''
-    return _k2.max_per_sublist(src, initial_value)
-
-
-def sum_per_sublist(src: _k2.RaggedFloat,
-                    initial_value: Optional[float] = 0) -> torch.Tensor:
-    '''Return the sum per sublist.
-
-    Note:
-      sum is taken over the last axis.
-
-    Args:
-      src:
-        The source ragged tensor.
-      initial_value:
-        The initial value for computing sum.
-    '''
-    return _k2.sum_per_sublist(src, initial_value)
-
-
-def log_sum_per_sublist(src: _k2.RaggedFloat,
-                        initial_value: Optional[float] = -np.inf
-                       ) -> torch.Tensor:
-    '''Return the `log-add` sum per sublist.
-
-    Note:
-      log-add sum is taken over the last axis.
-
-    Args:
-      src:
-        The source ragged tensor.
-      initial_value:
-        The initial value for computing log-add sum.
-    '''
-    return _k2.log_sum_per_sublist(src, initial_value)

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -4,10 +4,14 @@
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 
-from typing import Optional, List, Tuple, Union
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import numpy as np
 import torch
+
 import _k2
 
 

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -5,8 +5,9 @@
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 
-from typing import Tuple, Optional, List
-from typing import Union
+from typing import Optional, List, Tuple, Union
+
+import numpy as np
 import torch
 import _k2
 
@@ -116,13 +117,49 @@ def to_list(src: _k2.RaggedInt) -> List:
 
 
 def max_per_sublist(src: _k2.RaggedFloat,
-                    default_value: float) -> torch.Tensor:
+                    initial_value: Optional[float] = -np.inf) -> torch.Tensor:
     '''Return the max value per sublist.
+
+    Note:
+      max is taken over the last axis.
 
     Args:
       src:
         The source ragged tensor.
-      default_value:
+      initial_value:
         The initial value for computing max.
     '''
-    return _k2.max_per_sublist(src, default_value)
+    return _k2.max_per_sublist(src, initial_value)
+
+
+def sum_per_sublist(src: _k2.RaggedFloat,
+                    initial_value: Optional[float] = 0) -> torch.Tensor:
+    '''Return the sum per sublist.
+
+    Note:
+      sum is taken over the last axis.
+
+    Args:
+      src:
+        The source ragged tensor.
+      initial_value:
+        The initial value for computing sum.
+    '''
+    return _k2.sum_per_sublist(src, initial_value)
+
+
+def log_sum_per_sublist(src: _k2.RaggedFloat,
+                        initial_value: Optional[float] = -np.inf
+                       ) -> torch.Tensor:
+    '''Return the `log-add` sum per sublist.
+
+    Note:
+      log-add sum is taken over the last axis.
+
+    Args:
+      src:
+        The source ragged tensor.
+      initial_value:
+        The initial value for computing log-add sum.
+    '''
+    return _k2.log_sum_per_sublist(src, initial_value)

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -1,0 +1,68 @@
+# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# See ../../../../LICENSE for clarification regarding multiple authors
+
+from typing import Union
+
+import torch
+import _k2
+
+
+# Create a class `RaggedFloat` in python for backprop.
+#
+# TODO(fangjun): wrap methods from _k2.RaggedFloat if needed.
+class RaggedFloat(object):
+    '''A ragged float tensor.
+
+    It is a wrapper of :class:`_k2.RaggedFloat`, whose purpose
+    is to implement autograd for :class:`_k2.RaggedFloat`.
+    '''
+
+    def __init__(self, ragged: Union[str, _k2.RaggedFloat]):
+        if isinstance(ragged, str):
+            ragged = _k2.RaggedFloat(ragged)
+
+        self.ragged = ragged
+        self._scores = ragged.values().clone()
+
+    def __str__(self) -> str:
+        return str(self.ragged)
+
+    @property
+    def scores(self) -> torch.Tensor:
+        '''Return the underlying array as a 1-D torch.Tensor.
+        '''
+        return self._scores
+
+    @property
+    def grad(self) -> torch.Tensor:
+        return self._scores.grad
+
+    @property
+    def requires_grad(self) -> bool:
+        '''
+        Return True if this object requires grad.
+        Return False otherwise.
+        '''
+        return self._scores.requires_grad
+
+    def requires_grad_(self, requires_grad: bool) -> 'RaggedFloat':
+        '''Change if autograd should record operations on this tensor.
+
+        Sets the `scores`'s requires_grad attribute in-place.
+        Returns this object.
+        You can test whether this object has the requires_grad property
+        true or false by accessing self.requires_grad property.
+
+        Caution:
+          This is an **in-place** operation as you can see that the function
+          name ends with `_`.
+
+        Args:
+          requires_grad:
+            If autograd should record operations on this object or not.
+
+        Returns:
+          This object itself.
+        '''
+        self._scores.requires_grad_(requires_grad)
+        return self

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -22,7 +22,7 @@ class RaggedFloat(object):
             ragged = _k2.RaggedFloat(ragged)
 
         self.ragged = ragged
-        self._scores = ragged.values().clone()
+        self._scores = ragged.values()
 
     def __str__(self) -> str:
         return str(self.ragged)

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -80,7 +80,32 @@ class TestRaggedOps(unittest.TestCase):
         '''
         src = k2.RaggedFloat(s)
         ans = k2.ragged.max_per_sublist(src, -np.inf)
-        torch.allclose(ans, torch.tensor([1, 10, -np.inf, 3, 8.]))
+        assert torch.allclose(ans, torch.tensor([1, 10, -np.inf, 3, 8.]))
+
+    def test_sum_per_sublist(self):
+        s = '''
+            [ [1 -1 0] [2 10] [] [3] [5 8] ]
+        '''
+        src = k2.RaggedFloat(s)
+        ans = k2.ragged.sum_per_sublist(src, 0)
+        assert torch.allclose(ans, torch.tensor([0, 12, 0, 3, 13.]))
+
+    def test_log_sum_per_sublist(self):
+        s = '''
+            [ [1 -1 0] [2 10] [] [3] [5 8] ]
+        '''
+        src = k2.RaggedFloat(s)
+        ans = k2.ragged.log_sum_per_sublist(src)
+        assert torch.allclose(
+            ans,
+            torch.tensor([
+                np.log(np.exp(1) + np.exp(-1) + np.exp(0)),
+                np.log(np.exp(2) + np.exp(10)),
+                -np.inf,
+                3,
+                np.log(np.exp(5) + np.exp(8)),
+            ],
+                         dtype=torch.float32))
 
 
 if __name__ == '__main__':

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -11,6 +11,8 @@
 import unittest
 
 import k2
+import numpy as np
+import torch
 
 
 class TestRaggedOps(unittest.TestCase):
@@ -77,8 +79,8 @@ class TestRaggedOps(unittest.TestCase):
             [ [1 -1 0] [2 10] [] [3] [5 8] ]
         '''
         src = k2.RaggedFloat(s)
-        ans = k2.ragged.max_per_sublist(src, 0)
-        print(ans)
+        ans = k2.ragged.max_per_sublist(src, -np.inf)
+        torch.allclose(ans, torch.tensor([1, 10, -np.inf, 3, 8.]))
 
 
 if __name__ == '__main__':

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -72,6 +72,14 @@ class TestRaggedOps(unittest.TestCase):
         ans = k2.ragged.remove_values_eq(src, 8)
         self.assertEqual(str(ans), '[ [ 1 2 0 ] [ 3 0 2 ] [ 0 0 6 0 ] [ 0 ] ]')
 
+    def test_max_per_sublist(self):
+        s = '''
+            [ [1 -1 0] [2 10] [] [3] [5 8] ]
+        '''
+        src = k2.RaggedFloat(s)
+        ans = k2.ragged.max_per_sublist(src, 0)
+        print(ans)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #540 

---

A Python class `RaggedFloat` is added. 

I suggest creating another class `RaggedInt` if needed or at least moving it from `k2` to `k2.ragged`.