### PR TITLE
support assigning random scores to an FSA.

### DIFF
--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1039,7 +1039,7 @@ class Fsa(object):
           The function name ends with a underline indicating this function
           will change `self` in-place.
         '''
-        scores = torch.randn(self.scores.size())
+        scores = torch.randn_like(self.scores)
         ragged_scores = k2.ragged.RaggedFloat(self.arcs.shape(), scores)
         ragged_scores = k2.ragged.normalize_scores(ragged_scores)
 

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -4,19 +4,23 @@
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
-import k2
 from typing import Any
 from typing import Dict
 from typing import Iterator
 from typing import Optional
 from typing import Tuple
 from typing import Union
-from k2 import fsa_properties
+
 import os
 import shutil
 import torch
+
+import k2
+import k2.ragged
 import _k2
+
 from _k2 import RaggedArc
+from k2 import fsa_properties
 
 
 class Fsa(object):
@@ -1024,3 +1028,20 @@ class Fsa(object):
         '''
         arcs, aux_labels = _k2.fsa_from_str(s, acceptor, True)
         return Fsa(arcs, aux_labels=aux_labels)
+
+    def set_scores_stochastic_(self) -> None:
+        '''Set `scores` to random numbers.
+
+        Scores are normalized per state. That is, the sum of the probabilities
+        of all arcs leaving a state equal to 1.
+
+        Caution:
+          The function name ends with a underline indicating this function
+          will change `self` in-place.
+        '''
+        scores = torch.randn(self.scores.size())
+        ragged_scores = k2.ragged.RaggedFloat(self.arcs.shape(), scores)
+        ragged_scores = k2.ragged.normalize_scores(ragged_scores)
+
+        # note that `self.scores` also works here, but [:] is more efficient
+        self.scores[:] = ragged_scores.scores

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1036,8 +1036,8 @@ class Fsa(object):
         of all arcs leaving a state equal to 1.
 
         Caution:
-          The function name ends with a underline indicating this function
-          will change `self` in-place.
+          The function name ends with an underline indicating this function
+          will modify `self` **in-place**.
         '''
         scores = torch.randn_like(self.scores)
         ragged_scores = k2.ragged.RaggedFloat(self.arcs.shape(), scores)

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -36,8 +36,9 @@ class RaggedFloat(object):
                 - an instance of :class:`_k2.RaggedShape`. In this case, you
                   have to provide the additional argument `values`.
           values:
-            Needed only when `ragged` is an instance of :class:`_k2.RaggedFloat`.
-            It is a 1-D torch.Tensor with dtype torch.float32.
+            Needed only when `ragged` is an instance of
+            :class:`_k2.RaggedFloat`. It is a 1-D torch.Tensor with dtype
+            torch.float32.
         '''
         if isinstance(ragged, str):
             ragged = _k2.RaggedFloat(ragged)

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -1,6 +1,7 @@
 # Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
 # See ../../../../LICENSE for clarification regarding multiple authors
 
+from typing import Optional
 from typing import Union
 
 import torch
@@ -17,9 +18,34 @@ class RaggedFloat(object):
     is to implement autograd for :class:`_k2.RaggedFloat`.
     '''
 
-    def __init__(self, ragged: Union[str, _k2.RaggedFloat]):
+    def __init__(self,
+                 ragged: Union[str, _k2.RaggedFloat, _k2.RaggedShape],
+                 values: Optional[torch.Tensor] = None):
+        '''Construct an instance of :class:`k2.RaggedFloat`.
+
+        Args:
+          ragged:
+            It can be the following types:
+
+                - a string. Example value:
+
+                    [ [1 2] [] [5 10 20] ]
+
+                - an instance of :class:`_k2.RaggedFloat`
+
+                - an instance of :class:`_k2.RaggedShape`. In this case, you
+                  have to provide the additional argument `values`.
+          values:
+            Needed only when `ragged` is an instance of :class:`_k2.RaggedFloat`.
+            It is a 1-D torch.Tensor with dtype torch.float32.
+        '''
         if isinstance(ragged, str):
             ragged = _k2.RaggedFloat(ragged)
+        elif isinstance(ragged, _k2.RaggedShape):
+            assert values is not None
+            ragged = _k2.RaggedFloat(ragged, values)
+
+        assert isinstance(ragged, _k2.RaggedFloat)
 
         self.ragged = ragged
         self._scores = ragged.values()

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -25,19 +25,19 @@ class RaggedFloat(object):
 
         Args:
           ragged:
-            It can be the following types:
+            It can be one of the following types:
 
-                - a string. Example value:
+                - A string. Example value::
 
                     [ [1 2] [] [5 10 20] ]
 
-                - an instance of :class:`_k2.RaggedFloat`
+                - An instance of :class:`_k2.RaggedFloat`
 
-                - an instance of :class:`_k2.RaggedShape`. In this case, you
+                - An instance of :class:`_k2.RaggedShape`. In this case, you
                   have to provide the additional argument `values`.
           values:
-            Needed only when `ragged` is an instance of
-            :class:`_k2.RaggedFloat`. It is a 1-D torch.Tensor with dtype
+            Required only when `ragged` is an instance of
+            :class:`_k2.RaggedShape`. It is a 1-D torch.Tensor with dtype
             torch.float32.
         '''
         if isinstance(ragged, str):

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -599,6 +599,11 @@ class TestFsa(unittest.TestCase):
         assert fsa.scores.item() == 100, f'fsa.scores is {fsa.scores}'
         assert scores.item() == 98
 
+        # CAUTION: had we used fsa.scores = scores,
+        # would we have `fsa.scores != fsa.arcs.values()[:, -1]`.
+        # That is, `fsa.scores` shares memory with `scores`, but not with fsa.arcs.values!
+        assert _k2.as_float(fsa.arcs.values()[:, -1]).item() == 100
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It also demonstrates how to use `torch.optim.SGD` to update the scores of an FSA.

# CAUTION

When an FSA is constructed, `fsa.scores` shares the underlying memory with `fsa.arcs.values`.
But if you do `fsa.scores = something`, then `fsa.scores` shares memory with `something`, but.not.with `fsa.arcs.values`!

Whenever you do `fsa.scores = something`, the code copies `something` to `fsa.arcs.values` and updates `fsa.scores`
to point to `something`.