### PR TITLE
fix a bug in thread pool.

### DIFF
--- a/k2/csrc/thread_pool.h
+++ b/k2/csrc/thread_pool.h
@@ -99,6 +99,13 @@ class ThreadPool {
 
   // Set it to true when the task queue is empty
   bool finished_ = true;
+
+  // Whenever a thread is about to process a task,
+  // the counter is incremented
+  //
+  // Whenever a thread finishes processing a task,
+  // the counter is decremented.
+  int32_t running_counter_ = 0;
 };
 
 /* Get a pointer to global thread pool.


### PR DESCRIPTION
Wait for all tasks being finished before exiting.

Closes #591 

---

Tested with

```bash
while true; do ctest -R cu_thread_pool -V; if [ $? -ne 0 ]; then break; fi; done
```

Everything seems ok.