### PR TITLE
Refactor code of SimpleRaggedIndexSelect

### DIFF
--- a/k2/csrc/tensor_ops.h
+++ b/k2/csrc/tensor_ops.h
@@ -9,6 +9,7 @@
 #define K2_CSRC_TENSOR_OPS_H_
 
 #include "k2/csrc/array.h"
+#include "k2/csrc/ragged.h"
 #include "k2/csrc/tensor.h"
 
 namespace k2 {
@@ -57,6 +58,8 @@ Tensor Cast(Tensor src, Dtype new_dtype);
                      shape (indexes.Dim(), src.Dim(1), src.Dim(2), ...),
                      i.e. with the same num-axes as `src` and
                      axis 0's dim replaced with indexes.Dim().
+                     Noted the ans would be contiguous even though `src`
+                     is not contiguous.
  */
 Tensor Index(Tensor &src, Array1<int32_t> &indexes,
              bool allow_minus_one = true);
@@ -106,6 +109,26 @@ Tensor IndexAdd(Tensor &src, Array1<int32_t> &indexes, int32_t dim,
 void IndexAdd(Tensor &src, Array1<int32_t> &indexes, bool allow_minus_one,
               Tensor *dest);
 
+/*
+  Returns a 1-D Tensor that is a result of indexing 1-D `src` with Ragged array
+  `indexes` whose NumAxes() is 2. ans.Dims()[0] will equal to indexes.Dims0() as
+  we suppose there is at most one non-zero element in `src` for any indexes
+  sub-list in `indexes`.
+
+     @param [in] src  Source 1-D tensor, to be indexed.
+     @param [in] indexes   Indexes to use whose NumAxes() == 2, for any
+                      sub-list `i` in `indexes`, we suppose there is at most
+                      one non-zero element in `src` and we'll set ans[i]
+                      with that non-zero element; if all elements for
+                      sub-list `i` is zero or the sub-list is empty, we just
+                      set ans[i] == 0.
+     @return   Returns a Tensor with the same dtype as `src` and shape
+                     (indexes.Dim0()), i.e. a 1-D tensor whose number of
+                     elements equal to `indexes.Dim0()`.
+                     Noted the ans would be contiguous even though `src`
+                     is not contiguous.
+ */
+Tensor SimpleRaggedIndexSelect1D(Tensor &src, Ragged<int32_t> &indexes);
 }  // namespace k2
 
 #endif  // K2_CSRC_TENSOR_OPS_H_

--- a/k2/csrc/tensor_ops.h
+++ b/k2/csrc/tensor_ops.h
@@ -111,15 +111,15 @@ void IndexAdd(Tensor &src, Array1<int32_t> &indexes, bool allow_minus_one,
 
 /*
   Returns a 1-D Tensor that is a result of indexing 1-D `src` with Ragged array
-  `indexes` whose NumAxes() is 2. ans.Dims()[0] will equal to indexes.Dims0() as
+  `indexes` whose NumAxes() is 2. ans.Dims()[0] will equal to indexes.Dim0() as
   we suppose there is at most one non-zero element in `src` for any indexes
   sub-list in `indexes`.
 
      @param [in] src  Source 1-D tensor, to be indexed.
      @param [in] indexes   Indexes to use whose NumAxes() == 2, for any
                       sub-list `i` in `indexes`, we suppose there is at most
-                      one non-zero element in `src` and we'll set ans[i]
-                      with that non-zero element; if all elements for
+                      one non-zero value in `src` and we'll set ans[i]
+                      with that non-zero value; if all values for
                       sub-list `i` is zero or the sub-list is empty, we just
                       set ans[i] == 0.
      @return   Returns a Tensor with the same dtype as `src` and shape

--- a/k2/python/csrc/torch/index_select.cu
+++ b/k2/python/csrc/torch/index_select.cu
@@ -139,8 +139,8 @@ static torch::Tensor IndexSelectWrapper(torch::Tensor src,
      @param [in] src  Source tensor, to be indexed.
      @param [in] indexes   Indexes to use whose NumAxes() == 2, for any
                       sub-list `i` in `indexes`, we suppose there is at most
-                      one non-zero element in `src` and we'll set ans[i]
-                      with that non-zero element; if all elements for
+                      one non-zero values in `src` and we'll set ans[i]
+                      with that non-zero value; if all values for
                       sub-list `i` is zero or the sub-list is empty, we just
                       set ans[i] == 0.
      @return   Returns a Tensor with the same dtype as `src` and shape

--- a/k2/python/csrc/torch/index_select.cu
+++ b/k2/python/csrc/torch/index_select.cu
@@ -6,7 +6,7 @@
  *
  * @copyright
  * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
- *                      Xiaomi Corp.       (author: Daniel Povey)
+ *                      Xiaomi Corp.       (author: Daniel Povey, Haowen Qiu)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
@@ -33,10 +33,9 @@ namespace k2 {
                         It has to satisfy:
                             -1 <= index[i] < src.numel()
                             for i in [0, index.numel())
-                        If index[i] is -1, then ans[i] is 0
                         CAUTION: We require that index.is_contiguous() is true.
    @return
-      Returns a 1-D tensor such that:
+      Returns a 1-D contiguous tensor such that:
           ans[i] = src[index[i]] if index[i] > 0
           ans[i] = 0 if index[i] is -1
  */
@@ -72,14 +71,14 @@ static torch::Tensor IndexSelect1D(torch::Tensor src, torch::Tensor index) {
 
    @param  [in]  index  A 1-D tensor with dtype torch.int32.
                         It has to satisfy:
-                            -1 <= index[i] < src.numel()
+                            -1 <= index[i] < src.shape()[0]
                             for i in [0, index.numel())
-                        If index[i] is -1, then ans[i] is 0
                         CAUTION: We require that index.is_contiguous() is true.
    @return
-      Returns a 1-D tensor such that:
+      Returns a 2-D contiguous tensor such that:
           ans[i] = src[index[i]] if index[i] > 0
-          ans[i] = 0 if index[i] is -1
+          ans[i] = zero tensor whose numel() is src.shape()[1],
+                   if index[i] is -1
  */
 template <typename T>
 static torch::Tensor IndexSelect2D(torch::Tensor src, torch::Tensor index) {
@@ -140,13 +139,15 @@ static torch::Tensor IndexSelectWrapper(torch::Tensor src,
      @param [in] src  Source tensor, to be indexed.
      @param [in] indexes   Indexes to use whose NumAxes() == 2, for any
                       sub-list `i` in `indexes`, we suppose there is at most
-                      one non-zero element in `src` and we'll set src[i]
+                      one non-zero element in `src` and we'll set ans[i]
                       with that non-zero element; if all elements for
                       sub-list `i` is zero or the sub-list is empty, we just
-                      set src[i] == 0.
+                      set ans[i] == 0.
      @return   Returns a Tensor with the same dtype as `src` and shape
                      (indexes.Dim0()), i.e. a 1-D tensor with numel() equal
                      to `indexes.Dim0()`.
+                     Noted the ans would be contiguous even though `src`
+                     is not contiguous.
  */
 template <typename T>
 static torch::Tensor SimpleRaggedIndexSelect1D(torch::Tensor src,
@@ -154,75 +155,13 @@ static torch::Tensor SimpleRaggedIndexSelect1D(torch::Tensor src,
   NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(src.dim(), 1) << "Expected dim: 1. Given: " << src.dim();
   K2_CHECK_EQ(src.scalar_type(), ToScalarType<T>::value);
-
   K2_CHECK_EQ(indexes.NumAxes(), 2);
-
   ContextPtr context = GetContext(src);
   K2_CHECK(context->IsCompatible(*indexes.Context()));
 
-  int32_t src_numel = src.numel();
-  const T *src_data = src.data_ptr<T>();
-  int32_t indexes_dim0 = indexes.Dim0(),
-          indexes_num_elems = indexes.NumElements();
-  const int32_t *indexes_row_splits1_data = indexes.RowSplits(1).Data(),
-                *indexes_row_ids1_data = indexes.RowIds(1).Data();
-  const int32_t *indexes_data = indexes.values.Data();
-
-  torch::Tensor ans = torch::zeros(indexes_dim0, src.options());
-  T *ans_data = ans.data_ptr<T>();
-  int64_t src_stride = src.strides()[0];
-  int64_t ans_stride = ans.strides()[0];
-
-  // check if there is at most one non-zero element in src for each sub-list
-  Ragged<int32_t> non_zero_elems(indexes.shape,
-                                 Array1<int32_t>(context, indexes_num_elems));
-  int32_t *elems_data = non_zero_elems.values.Data();
-  K2_EVAL(
-      context, indexes_num_elems, lambda_count_non_zeros, (int32_t i)->void {
-        int32_t src_index = indexes_data[i];
-        K2_CHECK_GE(src_index, 0);
-        K2_CHECK_LT(src_index, src_numel);
-        T value = src_data[src_index * src_stride];
-        elems_data[i] = (value != 0);
-      });
-  Array1<int32_t> counts(context, indexes_dim0);
-  SumPerSublist(non_zero_elems, 0, &counts);
-  const int32_t *counts_data = counts.Data();
-  Array1<int32_t> status(context, 1, 0);  // 0 -> success; otherwise 1 + row_id
-                                          // of bad row in `indexes`
-  int32_t *status_data = status.Data();
-  K2_EVAL(
-      context, counts.Dim(), lambda_check_status, (int32_t i)->void {
-        if (counts_data[i] > 1) status_data[0] = 1 + i;
-      });
-  int32_t s = status[0];
-  if (s != 0) {
-    Array1<T> indexed_values(context, indexes_num_elems);
-    T *indexed_values_data = indexed_values.Data();
-    K2_EVAL(context, indexes_num_elems, lambda_set_values, (int32_t i) -> void {
-        int32_t src_index = indexes_data[i];
-        indexed_values_data[i] = src_data[src_index * src_stride];
-      });
-    Array1<int32_t> row_splits = indexes.RowSplits(1);
-
-    K2_LOG(FATAL) << "There must be at most one non-zero "
-        "element in src for any sub-list in indexes; sub-list "
-                  << (s-1) << " has too many elements: "
-                  << indexed_values.Arange(row_splits[s-1],
-                                           row_splits[s]);
-  }
-
-  K2_EVAL(
-      context, indexes_num_elems, lambda_set_ans_data, (int32_t i)->void {
-        int32_t src_index = indexes_data[i];
-        T value = src_data[src_index * src_stride];
-        int32_t ans_index =
-            indexes_row_ids1_data[i];  // ans_index is idx0 in indexes
-        if (value != 0) {
-          ans_data[ans_index * ans_stride] = value;
-        }
-      });
-  return ans;
+  Tensor tensor = FromTensor(src, TensorTag{});
+  Tensor ans = SimpleRaggedIndexSelect1D(tensor, indexes);
+  return ToTensor(ans);
 }
 
 static torch::Tensor SimpleRaggedIndexSelectWrapper(torch::Tensor src,
@@ -240,7 +179,7 @@ static torch::Tensor SimpleRaggedIndexSelectWrapper(torch::Tensor src,
     }
   } else {
     K2_LOG(FATAL) << "Unsupported dim: " << src.dim()
-                  << ". It supports only 1-D tensors";
+                  << ". It supports only 1-D tensors for now";
     return {};
   }
 }


### PR DESCRIPTION
Fixed some issues metioned by https://github.com/k2-fsa/k2/issues/478. Using approach https://github.com/k2-fsa/k2/issues/478#issuecomment-741527608 to re-implement `SimpleRaggedIndexSelect` (I found `Array1<T> SelectNonzeroElements(Ragged<T> &src)` approach would not be applicable for the requirements, as for empty rows or rows which contains no non-zero elements, we need still output a value 0)