### PR TITLE
Remove old code in utils.cu

### DIFF
--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -18,55 +18,6 @@
 
 namespace k2 {
 
-// See FillValues() where this is invoked.  It fills a region with
-// a constant value.
-__global__ void FillValuesKernel(int32_t *data, int32_t num_values,
-                                 int32_t value) {
-  int32_t job_idx = (blockIdx.x * blockDim.x + threadIdx.x),
-          stride = (gridDim.x * blockDim.x);
-  for (; job_idx < num_values; job_idx += stride) data[job_idx] = value;
-}
-
-// This launches a kernel.  It's the same as doing:
-// for (int32_t i = 0; i < num_values; i++) data[i] = value;
-__device__ void FillValues(int32_t *data, int32_t num_values, int32_t value) {
-  int32_t block_size = 256;
-  int32_t grid_size = NumBlocks(num_values, block_size);
-  FillValuesKernel<<<grid_size, block_size>>>(data, num_values, value);
-}
-
-//  When we invoke this we make a big enough grid that there doesn't have to
-//  be a loop over rows, i.e. (gridDim.x * blockDim.x) / threads_per_row >=
-//  num_rows
-__global__ void RowSplitsToRowIdsKernel(int32_t num_rows,
-                                        int32_t threads_per_row,
-                                        const int32_t *row_splits,
-                                        int32_t num_elems, int32_t *row_ids) {
-  int32_t thread = blockIdx.x * blockDim.x + threadIdx.x,
-          num_threads = gridDim.x * blockDim.x, row = thread / threads_per_row,
-          thread_this_row = thread % threads_per_row;
-
-  if (row >= num_rows) return;
-  K2_CHECK_GE(num_threads / threads_per_row, num_rows);
-
-  int32_t this_row_split = row_splits[row],
-          next_row_split = row_splits[row + 1],
-          row_length = next_row_split - this_row_split;
-
-  const int32_t max_loop = 8;  // `max_loop` is heuristically chosen.
-  if (row_length / threads_per_row > max_loop) {
-    // We decide that looping too many times will be too slow, so we launch
-    // another kernel to fill in the value for this row.  (This is CUDA dynamic
-    // parallelism).
-    if (thread_this_row == 0) {
-      FillValues(row_ids + this_row_split, row_length, row);
-    }
-  } else {
-    // TODO(dan): figure out how to unroll this?
-    for (; thread_this_row < row_length; thread_this_row += threads_per_row)
-      row_ids[this_row_split + thread_this_row] = row;
-  }
-}
 
 /*
 
@@ -129,43 +80,9 @@ void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
   } else {
     K2_CHECK_EQ(d, kCuda);
     if (1) {
-#if 1
       mgpu::context_t *mgpu_allocator = GetModernGpuAllocator(c);
       mgpu::load_balance_search(num_elems, row_splits, num_rows, row_ids,
                                 *mgpu_allocator);
-#elif 0
-      auto lambda_set_minus_1 = [=] __device__(int32_t i) -> void {
-        row_ids[i] = -1;
-      };
-      EvalDevice(c, num_elems, lambda_set_minus_1);
-
-      auto lambda_set_row_ids_start = [=] __device__(int32_t i) -> void {
-        if (row_splits[i + 1] > row_splits[i]) row_ids[row_splits[i]] = i;
-      };
-      EvalDevice(c, num_rows, lambda_set_row_ids_start);
-
-      size_t temp_storage_bytes;
-      cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes, row_ids,
-                                     row_ids, MaxOp<int32_t>(), num_elems,
-                                     c->GetCudaStream());
-      Array1<int8_t> d_temp_storage(c, temp_storage_bytes);
-      cub::DeviceScan::InclusiveScan(d_temp_storage.Data(), temp_storage_bytes,
-                                     row_ids, row_ids, MaxOp<int32_t>(),
-                                     num_elems, c->GetCudaStream());
-#else
-      // TODO: compare this for speed with the other branch.  This is branch is
-      // much simpler, and will be considerably faster for "normal" cases ->
-      // probably preferred.
-      int32_t avg_elems_per_row = (num_elems + num_rows - 1) / num_rows,
-              threads_per_row = RoundUpToNearestPowerOfTwo(avg_elems_per_row),
-              tot_threads = num_rows * threads_per_row;
-      int32_t block_size = 256;
-      int32_t grid_size = NumBlocks(tot_threads, block_size);
-
-      K2_CUDA_SAFE_CALL(RowSplitsToRowIdsKernel<<<grid_size, block_size, 0,
-                                                  c->GetCudaStream()>>>(
-          num_rows, threads_per_row, row_splits, num_elems, row_ids));
-#endif
     } else {
       // TODO: Will probably just delete this branch at some point.
 
@@ -227,68 +144,6 @@ void RowSplitsToRowIds(ContextPtr c, int32_t num_rows,
   }
 }
 
-/*
-  When we invoke this we make a big enough grid that there doesn't have to
-  be a loop over elements, i.e. (gridDim.x * blockDim.x) / threads_per_elem >
-  num_elems. (must be >=, because we imagine a phantom element at [num_elems]
-  with the value `num_rows`.)
-
-
-    @param [in] num_elems         Number of elements in ragged matrix
-    @param [in] threads_per_elem  Number of threads we allocate per element.
-                                  Must be >= 1.
-    @param [in] row_ids           The row_ids vector, of length `num_elems`;
-                                  must be nonnegative and non-decreasing and
-                                  all elements < num_rows.
-    @param [in] num_rows          Number of rows, must be greater than the
-                                  largest (== last) element of `row_ids`.
-    @param [out] row_splits       This kernel will output a non-decreasing
-                                  vector of length num_rows + 1, such that
-                                  row_splits[0] == 0,
-                                  row_splits[num_rows] == num_elems,
-                                  and row_splits[row_ids[i]] <= i <
-                                  row_splits[row_ids[i]+1]
-*/
-__global__ void RowIdsToRowSplitsKernel(int32_t num_elems,
-                                        int32_t threads_per_elem,
-                                        const int32_t *row_ids,
-                                        int32_t num_rows, int32_t *row_splits) {
-  int32_t thread = (blockIdx.x * blockDim.x + threadIdx.x),
-          num_threads = gridDim.x * blockDim.x,
-          elem = thread / threads_per_elem,
-          thread_this_elem = thread % threads_per_elem;
-
-  K2_CHECK_GE(num_threads / threads_per_elem, num_elems);
-  if (elem > num_elems) return;
-
-  int32_t this_row, prev_row;
-  if (elem == 0) {
-    prev_row = -1;
-    this_row = row_ids[elem];
-  } else if (elem == num_elems) {
-    prev_row = row_ids[elem - 1];
-    this_row = num_rows;
-  } else {
-    prev_row = row_ids[elem - 1];
-    this_row = row_ids[elem];
-  }
-
-  // `num_splits` is the number of splits we have to write, usually 0 or 1
-  // but in principle unlimited as there could be empty rows.  The
-  // relationship between row_ids and row_splits is more symmetric than
-  // you might expect.
-  int32_t num_splits = this_row - prev_row;
-  const int32_t max_loop = 8;  // `max_loop` is heuristically chosen.
-  if (num_splits / threads_per_elem > max_loop) {
-    if (thread_this_elem == 0) {
-      FillValues(row_splits + prev_row + 1, num_splits, elem);
-    }
-  } else {
-    // TODO(dan): figure out how to unroll this?
-    for (; thread_this_elem < num_splits; thread_this_elem += threads_per_elem)
-      row_splits[prev_row + 1 + thread_this_elem] = elem;
-  }
-}
 
 // see declaration in utils.h for documentation.
 void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
@@ -320,8 +175,6 @@ void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
     }
   } else {
     K2_CHECK_EQ(d, kCuda);
-#if 1
-    // moderngpu is faster
     auto lambda_set_row_splits = [=] __device__(int32_t i) {
       if (i == num_rows)
         row_splits[i] = num_elems;
@@ -334,205 +187,8 @@ void RowIdsToRowSplits(ContextPtr c, int32_t num_elems, const int32_t *row_ids,
     mgpu::sorted_search<mgpu::bounds_lower>(
         row_splits, num_rows, row_ids, num_elems, row_splits,
         LessThan<int32_t>(), *mgpu_allocator);
-#elif 0
-    Array1<int32_t> counts = GetCounts(c, row_ids, num_elems, num_rows + 1);
-    ExclusiveSum(c, num_rows + 1, counts.Data(), row_splits);
-#else
-    if (no_empty_rows) {
-      auto lambda_simple = [=] __device__(int32_t i) {
-        int32_t this_row = row_ids[i], prev_row;
-        if (i > 0) {
-          // (normal case)
-          prev_row = row_ids[i - 1];
-        } else {
-          // i == 0
-          row_splits[num_rows] = num_elems;
-          prev_row = -1;
-        }
-        K2_CHECK_LE(this_row, prev_row + 1);  // no_empty_rows was asserted by
-                                              // the user
-        if (this_row > prev_row) {
-          row_splits[this_row] = i;
-        }
-      };
-      EvalDevice(c, num_elems, lambda_simple);
-      return;
-    } else {
-      // By doing "+ 2" instead of "+ 1" we increase the minimum number of
-      // threads-per-row, which may reduce latency when there are successive
-      // empty rows. Any value >= 1 is correct though.
-      int32_t avg_rows_per_elem = num_rows / num_elems + 2,
-              threads_per_elem = RoundUpToNearestPowerOfTwo(avg_rows_per_elem),
-              tot_threads =
-                  (num_elems + 1) * threads_per_elem;  // +1 for the last row
-      int32_t block_size = 256;
-      int32_t grid_size = NumBlocks(tot_threads, block_size);
-      K2_CUDA_SAFE_CALL(RowIdsToRowSplitsKernel<<<grid_size, block_size, 0,
-                                                  c->GetCudaStream()>>>(
-          num_elems, threads_per_elem, row_ids, num_rows, row_splits));
-    }
-#endif
   }
 }
-
-/*
-  Called inside GetTaskRedirect(); see documentation of that in header.
-  Each task with 0 <= task < num_tasks gets allocated `threads_per_job`
-  threads, e.g. threads_per_job = 4 or 16.  It's a kind of n-ary
-  search (generalization of binary search) where each branch is handled
-  by a different thread so they can happen in parallel.
-
-  TODO(dan): there are a lot of opportunities to further optimize this
-  using GPU hardware tricks.
-
-  The thread-block size this is called with must be jobs_per_block *
-  threads_per_job.
- */
-
-/*
-template <int32_t jobs_per_block, int32_t threads_per_job>
-__global__ void GetTaskRedirect(int32_t num_tasks, const int32_t *row_splits,
-                                TaskRedirect *redirect_out) {
-  __shared__ int32_t temp[tasks_per_block];
-  // we do __syncwarp() for synchronization below; we require threads_per_job <=
-  // 32 for this reason.
-  static_assert(threads_per_job >= 2 && threads_per_job <= 32);
-
-  // We have work to do for 0 <= job_idx < num_tasks, but be careful: job_idx
-  // may be >= num_tasks if num_tasks is small or not a power of two (we don't
-  // return because we need to do __syncwarp()).  So we have to avoid out of
-  // bounds memory access.
-  int32_t job_idx = (blockIdx.x * blockDim.x + threadIdx.x) / threads_per_job;
-  // `branch_idx` is which member we are of the group of the `threads_per_job`
-threads for this job. int32_t branch_idx = threadIdx.x % threads_per_job;  // we
-assume blockDim.x % threads_per_job == 0
-  // `temp_idx` is which index in the temporary storage `temp` we are assigned
-  // (one per job).
-  int32_t temp_idx = threadIdx.x / threads_per_job;
-
-  // TODO: we may at some point decide that row_splits[0] has to be zero.
-  int32_t row_splits0 = row_splits[0],
-      row_splits_nt = row_splits[num_tasks],
-      num_items = row_splits_nt - row_splits0;
-  if (num_items <= 0) {
-    assert(num_items == 0);
-    // This is a special case where there is no work to do; we give a trivial
-    // assignment of tasks to jobs and return
-    static_assert(threads_per_job >= 2);
-    if (branch_idx < 2 && job_idx < num_tasks) {
-      TaskRedirect tr { job_idx, 2, branch_idx };
-      redirect_out[job_idx + branch_idx * num_tasks] = tr;
-    }
-    return;
-  } else if (branch_idx == 0 && job_idx < num_tasks) {
-    // This code writes to the jobs in the first half of the output array,
-    // that are allocated to the same-numbered task.
-    int32_t task_idx = job_idx,
-        this_row_split = row_splits[task_idx],
-        next_row_split = row_splits[task_idx + 1];
-    // `num_jobs` below is the number of jobs that will be active for
-    // this task.  (The "1 +".. is the job that we assign for each
-    // task, one job per task, in the "first half" of the jobs).
-    // the job_idx we're working out below is the job_idx for the
-    // "second half" of
-    int32_t num_jobs_this_task =
-        1 + (next_row_split/dart_separation - this_row_split/dart_separation);
-    TaskRedirect tr { task_idx, num_jobs_this_task, 0 };
-    redirect_out[task_idx] = tr;
-  }
-
-
-  // Now we have the less-trivial task of assigning the jobs in the 2nd half of
-the
-   //  output array to tasks (these are allocated roughly proportional to the
-amount
-   //  of work to do for that task).
-   //  We do the selection by throwing darts at a dart-board, evenly spaced, and
-seeing which task they correspond
-   //  to.  There are `num_tasks` darts).
-   //  Note: we know dart_location < row_splits_nt because job_idx < num_tasks
-and
-   //  because integer division rounds down.
-  int32_t dart_separation = num_items / num_tasks,
-      dart_location = row_splits0 + job_idx * dart_separation;
-
-// OK, from this point the goal is to find a task_idx such that
-//     row_splits[task_idx] <= dart_location < row_splits[task_idx + 1].
-//     This is guaranteed to exist, as long as job_id < num_tasks.
-//     As long as job_id < num_tasks, we maintain the property that
-//        row_splits[lower_bound] <= dart_location &&
-//        (upper_bound > num_tasks || row_splits[upper_bound] > dart_location).
-//     (where upper_bound == lower_bound + range), i.e. they are truly
-//     lower and upper bounds
-  int32_t lower_bound = 0,
-      range = num_tasks; // we are responsible for items lower_bound through
-                         // (upper_bound = lower_bound + range) - 1.
-  while (range > threads_per_job) {
-    int32_t upper_bound = lower_bound + range;
-    // We need to narrow the range of `task_idx` that might be the correct one.
-    //    We round *up* because we require that task_idx_step * threads_per_job
->=
-    //   range, so that we cover the entire range.
-    int32_t task_idx_step = (range + threads_per_job - 1) / threads_per_job,  //
->= 2 my_lower_task_idx = lower_bound + branch_idx * task_idx_step,
-        my_upper_task_idx = my_lower_task_idx + task_idx_step;
-    // The following avoids out-of-bounds memory accesses.
-    if (my_upper_task_idx > upper_bound)
-      my_upper_task_idx = upper_bound;
-
-    // TODO (dan): it may be possible to use one of those special within-warp
-    // commands involving bitmaps to make the second comparison (dart_location <
-    // row_splits[my_upper_task_idx]) unnecessary.
-    if (my_lower_task_idx < num_tasks && row_splits[my_lower_task_idx] <=
-dart_location && dart_location < row_splits[my_upper_task_idx]) {
-      // I am the "chosen branch" (exactly one will be chosen, as long as
-      // job_idx < num_tasks).
-      temp[temp_idx] = branch_idx;
-    }
-    __syncwarp();
-    int32_t chosen_branch_idx = temp[temp_idx];
-    lower_bound = lower_bound + chosen_branch_idx * task_idx_step;
-    upper_bound = lower_bound + task_idx_step;
-    range = task_idx_step;
-    // note, we don't limit upper_bound to be <= num_tasks because we need all
-    // threads in the block to go around the while loop the same number of
-    // times.  Therefore it's possible that upper_bound > num_tasks.
-    K2_DASSERT(job_idx >= num_tasks ||
-               (row_splits[lower_bound] <= dart_location &&
-                (upper_bound > num_tasks || row_splits[upper_bound] >
-dart_location)));  // TODO: remove once debugged.
-  }
-  int32_t task_idx = lower_bound + branch_idx;
-  // TODO (dan): it may be possible to use one of those special within-warp
-  // commands involving bitmaps to make the second comparison (dart_location <
-  // row_splits[my_upper_task_idx]) unnecessary.
-  //
-  // The check `task_idx < num_tasks` is to avoid out-of-bounds access of
-row_splits.
-  // The check `job_idx < num_tasks` is to avoid out-of-bounds access of
-`redirect_out`;
-  // for these out-of-range job_idx values, it's possible for task_idx to have
-  // any value since it may be uninitialized memory.
-  if (task_idx < num_tasks && job_idx < num_tasks) {
-    int32_t this_row_split = row_splits[task_idx],
-        next_row_split = row_splits[task_idx + 1];
-    if (this_row_split <= dart_location && dart_location < next_row_split) {
-      // OK, exactly one branch per job will reach this point.  `num_jobs` below
-      // is the number of jobs that will be active for this task.  (The "1
-      // +".. is the job that we assign for each task, one job per task, in the
-      // "first half" of the jobs).  The job_id_this_task we're working out
-      // below is the job_id within the second half of the TaskRedirects,
-      // the half that are allocated by throwing darts.
-      int32_t num_jobs_this_task =
-          1 + (next_row_split/dart_separation - this_row_split/dart_separation),
-          job_idx_this_task = 1 + (dart_location -
-this_row_split)/dart_separation; K2_CHECK(job_id_this_task <
-num_jobs_this_task); TaskRedirect tr { task_idx, num_jobs_this_task,
-job_idx_this_task }; redirect_out[num_tasks + job_idx] = tr;
-    }
-  }
-}
-*/
 
 /*
   This is a quite simple implementation of GetTaskRedirect... I had a more


### PR DESCRIPTION
This enables `nsys profile` to work, i.e. so that we can see the kernels running.
It seems those tools don't support dynamic parallelism (calling __global__ functions from __device__ functions)
and that is true even if that code is never reached.