### PR TITLE
add benchmark for SizesToMergeMap

### DIFF
--- a/k2/csrc/array_ops_test.cu
+++ b/k2/csrc/array_ops_test.cu
@@ -1642,13 +1642,26 @@ TEST(OpsTest, Array2Assign) {
 }
 
 TEST(OpsTest, SizesToMergeMapTest) {
-  for (int loop = 0; loop < 2; loop++) {
-    ContextPtr c = ((loop % 2) == 0 ? GetCpuContext() : GetCudaContext());
-    std::vector<int32_t> sizes = {3, 5, 1};
-    Array1<uint32_t> merge_map = SizesToMergeMap(c, sizes);
-    std::vector<uint32_t> expected_map = {0, 3, 6, 1, 4, 7, 10, 13, 2};
-    K2_LOG(INFO) << "merge_map is " << merge_map;
-    CheckArrayData(merge_map, expected_map);
+  // simple test
+  for (auto &c : {GetCpuContext(), GetCudaContext()}) {
+    {
+      std::vector<int32_t> sizes = {3, 5, 1};
+      Array1<uint32_t> merge_map = SizesToMergeMap(c, sizes);
+      std::vector<uint32_t> expected_map = {0, 3, 6, 1, 4, 7, 10, 13, 2};
+      CheckArrayData(merge_map, expected_map);
+    }
+  }
+  {
+    // random case (well, I assume cpu implementation is correct and only test
+    // Cuda implementation)
+    for (int32_t i = 0; i != 2; ++i) {
+      int32_t num_srcs = RandInt(0, 100);
+      std::vector<int32_t> sizes(num_srcs);
+      for (int32_t n = 0; n != num_srcs; ++n) sizes[n] = RandInt(0, 1000);
+      Array1<uint32_t> merge_map_cpu = SizesToMergeMap(GetCpuContext(), sizes);
+      Array1<uint32_t> merge_map = SizesToMergeMap(GetCudaContext(), sizes);
+      CheckArrayData(merge_map_cpu, merge_map);
+    }
   }
 }
 


### PR DESCRIPTION
The current version works better than lbs approach for most case, so I did not replace it with lbs. Compared with previous example of `Append` and `SpliceRowSplits` , I think it may be because the kenerl task for `SizesToMergeMap` is realtive simple, and `average_elem_per_thread` approach works well. 


----------------------
The head is `SizesToMergeMap(_lbs)_NumSrcs_TotSizes_AverageSize_..., AverageTimePerIter`
```
SizesToMergeMap_3_1959_653,,kCuda,3,20,15.459202
SizesToMergeMap_5_3691_738,,kCuda,5,20,14.952000
SizesToMergeMap_10_4645_464,,kCuda,10,20,14.577601
SizesToMergeMap_20_9143_457,,kCuda,20,20,14.990399
SizesToMergeMap_50_23265_465,,kCuda,50,20,14.753599
SizesToMergeMap_100_50385_503,,kCuda,100,20,15.224000
SizesToMergeMap_200_97610_488,,kCuda,200,20,15.256000
SizesToMergeMap_500_240660_481,,kCuda,500,20,16.548800
SizesToMergeMap_1000_494808_494,,kCuda,1000,20,16.916800
SizesToMergeMap_2000_989208_494,,kCuda,2000,20,19.371201
SizesToMergeMap_5000_2505686_501,,kCuda,5000,20,39.070400
SizesToMergeMap_10000_5003965_500,,kCuda,10000,20,64.080002

SizesToMergeMap_lbs_3_1959_653,,kCuda,3,20,21.454399
SizesToMergeMap_lbs_5_3691_738,,kCuda,5,20,21.676798
SizesToMergeMap_lbs_10_4645_464,,kCuda,10,20,21.673601
SizesToMergeMap_lbs_20_9143_457,,kCuda,20,20,21.704000
SizesToMergeMap_lbs_50_23265_465,,kCuda,50,20,21.651199
SizesToMergeMap_lbs_100_50385_503,,kCuda,100,20,21.660801
SizesToMergeMap_lbs_200_97610_488,,kCuda,200,20,21.820801
SizesToMergeMap_lbs_500_240660_481,,kCuda,500,20,22.115198
SizesToMergeMap_lbs_1000_494808_494,,kCuda,1000,20,22.316799
SizesToMergeMap_lbs_2000_989208_494,,kCuda,2000,20,22.927999
SizesToMergeMap_lbs_5000_2505686_501,,kCuda,5000,20,38.502399
SizesToMergeMap_lbs_10000_5003965_500,,kCuda,10000,20,52.267200
```