### PR TITLE
Wrap Append to Python

### DIFF
--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -172,6 +172,17 @@ static void PybindOpPerSublist(py::module &m, Op op, const char *name) {
       py::arg("src"), py::arg("initial_value"));
 }
 
+template <typename T>
+static void PybindAppend(py::module &m, const char *name) {
+  // py::list is more efficient, but it requires more code
+  m.def(
+      name,
+      [](std::vector<Ragged<T>> &srcs, int32_t axis) -> Ragged<T> {
+        return Append(axis, srcs.size(), &srcs[0]);
+      },
+      py::arg("srcs"), py::arg("axis"));
+}
+
 }  // namespace k2
 
 void PybindRaggedOps(py::module &m) {
@@ -184,4 +195,7 @@ void PybindRaggedOps(py::module &m) {
   PybindNormalizePerSublist<float>(m, "normalize_per_sublist");
   PybindNormalizePerSublistBackward<float>(m, "normalize_per_sublist_backward");
   PybindOpPerSublist<float>(m, SumPerSublist<float>, "sum_per_sublist");
+  PybindAppend<int32_t>(m,
+                        "append");  // no need to use append_int or append_float
+                                    // since pybind11 supports overloading
 }

--- a/k2/python/k2/ragged/__init__.py
+++ b/k2/python/k2/ragged/__init__.py
@@ -1,5 +1,6 @@
 # please sort imported functions alphabetically
 from .autograd import normalize_scores
+from .ops import append
 from .ops import index
 from .ops import remove_axis
 from .ops import remove_values_eq

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -139,3 +139,18 @@ def sum_per_sublist(src: _k2.RaggedFloat,
       `src.tot_size(src.num_axes() - 2)`.
     '''
     return _k2.sum_per_sublist(src, initial_value)
+
+
+def append(srcs: List[_k2.RaggedInt], axis=0) -> _k2.RaggedInt:
+    '''Concatenate a list of :class:`_k2.RaggedInt` along a given axis.
+
+    Args:
+      srcs:
+        The input.
+      axis:
+        It can be either 0 or 1.
+    Returns:
+      A single ragged tensor.
+    '''
+    assert axis in (0, 1)
+    return _k2.append(srcs, axis)

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -10,6 +10,7 @@ from typing import Union
 import torch
 
 import _k2
+import k2.ragged
 from .fsa import Fsa
 from .symbol_table import SymbolTable
 
@@ -229,7 +230,11 @@ def create_fsa_vec(fsas):
         values = []
         for fsa in fsas:
             values.append(getattr(fsa, name))
-        value = torch.cat(values)
+        if isinstance(values[0], torch.Tensor):
+            value = torch.cat(values)
+        else:
+            assert isinstance(values[0], _k2.RaggedInt)
+            value = k2.ragged.append(values, axis=0)
         setattr(fsa_vec, name, value)
 
     non_tensor_attr_names = set(

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -621,6 +621,25 @@ class TestFsa(unittest.TestCase):
         # the underlying memory is shared!
         assert detached.scores.data_ptr() == fsa.scores.data_ptr()
 
+    def test_create_fsa_vec(self):
+        s1 = '''
+            0 1 1 0.1
+            1 2 -1 0.2
+            2
+        '''
+
+        s2 = '''
+            0 1 -1 10
+            1
+        '''
+        fsa1 = k2.Fsa.from_str(s1)
+        fsa1.aux_labels = k2.RaggedInt('[ [1 0 2] [3 5] ]')
+        fsa2 = k2.Fsa.from_str(s2)
+        fsa2.aux_labels = k2.RaggedInt('[ [5 8 9] ]')
+        fsa = k2.create_fsa_vec([fsa1, fsa2])
+        self.assertEqual(str(fsa.aux_labels),
+                         '[ [ 1 0 2 ] [ 3 5 ] [ 5 8 9 ] ]')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -200,6 +200,20 @@ class TestRaggedOps(unittest.TestCase):
         # the final state has no leaving arcs
         assert normalized_scores[-1].item() == 0
 
+    def test_append(self):
+        ragged1 = k2.RaggedInt('[ [1 2 3] [] [4 5] ]')
+        ragged2 = k2.RaggedInt('[ [] [10 20] [30] [40 50] ]')
+        ragged = k2.ragged.append([ragged1, ragged2])
+        self.assertEqual(
+            str(ragged),
+            '[ [ 1 2 3 ] [ ] [ 4 5 ] [ ] [ 10 20 ] [ 30 ] [ 40 50 ] ]')
+
+    def test_append_axis1(self):
+        ragged1 = k2.RaggedInt('[ [1 2 3] [] [4 5] ]')
+        ragged2 = k2.RaggedInt('[ [10 20] [8] [9 10] ]')
+        ragged = k2.ragged.append([ragged1, ragged2], axis=1)
+        self.assertEqual(str(ragged), '[ [ 1 2 3 10 20 ] [ 8 ] [ 4 5 9 10 ] ]')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`Append` is used to concatenate ragged tensor attributes of Fsa for `k2.create_fsa_vec`.