### PR TITLE
using pattern trasform_scan to merge two kenerls into one

### DIFF
--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -9,6 +9,7 @@
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/benchmark/benchmark.h"
 #include "k2/csrc/test_utils.h"
+#include "moderngpu/kernel_scan.hxx"
 
 namespace k2 {
 
@@ -268,6 +269,60 @@ static BenchmarkStat BenchmarkSizesToMergeMap(int32_t num_src,
   return stat;
 }
 
+void TransExclusiveSumOld(const Array1<int32_t> src, Array1<int32_t> *ans) {
+  ContextPtr c = src.Context();
+  int32_t dim = src.Dim();
+  K2_CHECK_EQ(dim + 1, ans->Dim());
+  const int32_t *src_data = src.Data();
+  int32_t *ans_data = ans->Data();
+  K2_EVAL(
+      c, dim, lambda_multiple2,
+      (int32_t i)->void { ans_data[i] = src_data[i] * 2; });
+  ExclusiveSum(*ans, ans);
+}
+
+void TransExclusiveSumNew(const Array1<int32_t> src, Array1<int32_t> *ans) {
+  ContextPtr c = src.Context();
+  int32_t dim = src.Dim();
+  K2_CHECK_EQ(dim + 1, ans->Dim());
+  const int32_t *src_data = src.Data();
+  int32_t *ans_data = ans->Data();
+  K2_TRANS_EXCSUM(
+      c, dim, ans_data, lambda_multiple2,
+      (int32_t i)->int32_t { return src_data[i] * 2; });
+}
+
+static BenchmarkStat BenchmarkTransExclusiveSum(int32_t dim,
+                                                DeviceType device_type) {
+  ContextPtr context;
+  if (device_type == kCpu) {
+    context = GetCpuContext();
+  } else {
+    K2_CHECK_EQ(device_type, kCuda);
+    context = GetCudaContext();
+  }
+
+  std::vector<int32_t> vec(dim);
+  std::iota(vec.begin(), vec.end(), dim);
+  Array1<int32_t> src(context, vec);
+  Array1<int32_t> ans(context, src.Dim() + 1);
+
+  BenchmarkStat stat;
+  stat.op_name = "TransExclusiveSum_New_" + std::to_string(dim);
+  int32_t num_iter = 20;
+  stat.num_iter = num_iter;
+  stat.problem_size = dim;
+  stat.device_type = device_type;
+
+  stat.eplased_per_iter =
+      BenchmarkOp(num_iter, context,
+                  (void (*)(const Array1<int32_t> &, Array1<int32_t> *))(
+                      &TransExclusiveSumNew),
+                  src, &ans);
+  stat.eplased_per_iter *= 1e6;  // from seconds to microseconds
+  return stat;
+}
+
 template <typename T>
 static void RegisterBenchmarkExclusiveSum(DeviceType device_type) {
   std::vector<int32_t> problems_sizes = {100,  500,   1000,  2000,
@@ -351,6 +406,20 @@ static void RegisterBenchmarkSizesToMergeMap(DeviceType device_type) {
   }
 }
 
+static void RegisterBenchmarkTransExclusiveSum(DeviceType device_type) {
+  std::vector<int32_t> problems_sizes = {100,    200,     500,    1000,  2000,
+                                         5000,   10000,   20000,  50000, 100000,
+                                         500000, 1000000, 5000000};
+  for (auto s : problems_sizes) {
+    std::string name =
+        GenerateBenchmarkName<int32_t>("TransExclusiveSum", device_type) + "_" +
+        std::to_string(s);
+    RegisterBenchmark(name, [s, device_type]() -> BenchmarkStat {
+      return BenchmarkTransExclusiveSum(s, device_type);
+    });
+  }
+}
+
 static void RunArrayOpsBenchmark() {
   PrintEnvironmentInfo();
 
@@ -368,6 +437,8 @@ static void RunArrayOpsBenchmark() {
   RegisterBenchmarkSpliceRowSplits(kCuda);
 
   RegisterBenchmarkSizesToMergeMap(kCuda);
+
+  RegisterBenchmarkTransExclusiveSum(kCuda);
 
   // Users can set a regular expression via environment
   // variable `K2_BENCHMARK_FILTER` such that only benchmarks

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -9,7 +9,6 @@
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/benchmark/benchmark.h"
 #include "k2/csrc/test_utils.h"
-#include "moderngpu/kernel_scan.hxx"
 
 namespace k2 {
 

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -269,60 +269,6 @@ static BenchmarkStat BenchmarkSizesToMergeMap(int32_t num_src,
   return stat;
 }
 
-void TransExclusiveSumOld(const Array1<int32_t> src, Array1<int32_t> *ans) {
-  ContextPtr c = src.Context();
-  int32_t dim = src.Dim();
-  K2_CHECK_EQ(dim + 1, ans->Dim());
-  const int32_t *src_data = src.Data();
-  int32_t *ans_data = ans->Data();
-  K2_EVAL(
-      c, dim, lambda_multiple2,
-      (int32_t i)->void { ans_data[i] = src_data[i] * 2; });
-  ExclusiveSum(*ans, ans);
-}
-
-void TransExclusiveSumNew(const Array1<int32_t> src, Array1<int32_t> *ans) {
-  ContextPtr c = src.Context();
-  int32_t dim = src.Dim();
-  K2_CHECK_EQ(dim + 1, ans->Dim());
-  const int32_t *src_data = src.Data();
-  int32_t *ans_data = ans->Data();
-  K2_TRANS_EXCSUM(
-      c, dim, ans_data, lambda_multiple2,
-      (int32_t i)->int32_t { return src_data[i] * 2; });
-}
-
-static BenchmarkStat BenchmarkTransExclusiveSum(int32_t dim,
-                                                DeviceType device_type) {
-  ContextPtr context;
-  if (device_type == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(device_type, kCuda);
-    context = GetCudaContext();
-  }
-
-  std::vector<int32_t> vec(dim);
-  std::iota(vec.begin(), vec.end(), dim);
-  Array1<int32_t> src(context, vec);
-  Array1<int32_t> ans(context, src.Dim() + 1);
-
-  BenchmarkStat stat;
-  stat.op_name = "TransExclusiveSum_New_" + std::to_string(dim);
-  int32_t num_iter = 20;
-  stat.num_iter = num_iter;
-  stat.problem_size = dim;
-  stat.device_type = device_type;
-
-  stat.eplased_per_iter =
-      BenchmarkOp(num_iter, context,
-                  (void (*)(const Array1<int32_t> &, Array1<int32_t> *))(
-                      &TransExclusiveSumNew),
-                  src, &ans);
-  stat.eplased_per_iter *= 1e6;  // from seconds to microseconds
-  return stat;
-}
-
 template <typename T>
 static void RegisterBenchmarkExclusiveSum(DeviceType device_type) {
   std::vector<int32_t> problems_sizes = {100,  500,   1000,  2000,
@@ -406,20 +352,6 @@ static void RegisterBenchmarkSizesToMergeMap(DeviceType device_type) {
   }
 }
 
-static void RegisterBenchmarkTransExclusiveSum(DeviceType device_type) {
-  std::vector<int32_t> problems_sizes = {100,    200,     500,    1000,  2000,
-                                         5000,   10000,   20000,  50000, 100000,
-                                         500000, 1000000, 5000000};
-  for (auto s : problems_sizes) {
-    std::string name =
-        GenerateBenchmarkName<int32_t>("TransExclusiveSum", device_type) + "_" +
-        std::to_string(s);
-    RegisterBenchmark(name, [s, device_type]() -> BenchmarkStat {
-      return BenchmarkTransExclusiveSum(s, device_type);
-    });
-  }
-}
-
 static void RunArrayOpsBenchmark() {
   PrintEnvironmentInfo();
 
@@ -437,8 +369,6 @@ static void RunArrayOpsBenchmark() {
   RegisterBenchmarkSpliceRowSplits(kCuda);
 
   RegisterBenchmarkSizesToMergeMap(kCuda);
-
-  RegisterBenchmarkTransExclusiveSum(kCuda);
 
   // Users can set a regular expression via environment
   // variable `K2_BENCHMARK_FILTER` such that only benchmarks


### PR DESCRIPTION
Just found the way to optimize https://github.com/k2-fsa/k2/issues/555 with `transform_scan` in modern gpu, it turns out that it would be faster for most cases after I run multiple experiments (noted it seems  the speed on GPU is not so stable somtimes, so we'd better run enough cases and times to compare the performace)

We need to replace those pattern code in our codebase, but let me do this one by one while optimizing each ops.

-----------------------------------------------
The header below is `TransExclusiveSum_Old/New_dim` where `Old` is the old pattern that uses two kenerls while `New` uses one kenerl, specially, the below benchmark is run with:

**TransformExclusiveSum_Old**:
```
K2_EVAL(
      c, dim, lambda_multiple2,
      (int32_t i)->void { ans_data[i] = src_data[i] * 2; });
  ExclusiveSum(*ans, ans);
```
**TransformExclusiveSum_New**:
```
 K2_TRANS_EXCSUM(
      c, dim, ans_data, lambda_multiple2,
      (int32_t i)->int32_t { return src_data[i] * 2; });
```

```
TransExclusiveSum_Old_100,,kCuda,100,20,15.945600
TransExclusiveSum_Old_200,,kCuda,200,20,15.963200
TransExclusiveSum_Old_500,,kCuda,500,20,16.103998
TransExclusiveSum_Old_1000,,kCuda,1000,20,16.303999
TransExclusiveSum_Old_2000,,kCuda,2000,20,16.126400
TransExclusiveSum_Old_5000,,kCuda,5000,20,15.940801
TransExclusiveSum_Old_10000,,kCuda,10000,20,15.808001
TransExclusiveSum_Old_20000,,kCuda,20000,20,15.927999
TransExclusiveSum_Old_50000,,kCuda,50000,20,15.952001
TransExclusiveSum_Old_100000,,kCuda,100000,20,16.171200
TransExclusiveSum_Old_500000,,kCuda,500000,20,15.187199
TransExclusiveSum_Old_1000000,,kCuda,1000000,20,24.180799
TransExclusiveSum_Old_5000000,,kCuda,5000000,20,110.766396

TransExclusiveSum_New_100,,kCuda,100,20,4.302400
TransExclusiveSum_New_200,,kCuda,200,20,4.358400
TransExclusiveSum_New_500,,kCuda,500,20,4.280000
TransExclusiveSum_New_1000,,kCuda,1000,20,4.468800
TransExclusiveSum_New_2000,,kCuda,2000,20,4.993600
TransExclusiveSum_New_5000,,kCuda,5000,20,8.179199
TransExclusiveSum_New_10000,,kCuda,10000,20,13.382401
TransExclusiveSum_New_20000,,kCuda,20000,20,13.470400
TransExclusiveSum_New_50000,,kCuda,50000,20,13.307199
TransExclusiveSum_New_100000,,kCuda,100000,20,13.335999
TransExclusiveSum_New_500000,,kCuda,500000,20,11.816001
TransExclusiveSum_New_1000000,,kCuda,1000000,20,20.940800
TransExclusiveSum_New_5000000,,kCuda,5000000,20,92.555199
```