### PR TITLE
[Not-for-merge] Try to implement kernels along axis with one kernel for IndexAxis0

### DIFF
--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -9,6 +9,7 @@
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/benchmark/benchmark.h"
 #include "k2/csrc/test_utils.h"
+#include "moderngpu/kernel_scan.hxx"
 
 namespace k2 {
 
@@ -268,6 +269,60 @@ static BenchmarkStat BenchmarkSizesToMergeMap(int32_t num_src,
   return stat;
 }
 
+void TransExclusiveSumOld(const Array1<int32_t> src, Array1<int32_t> *ans) {
+  ContextPtr c = src.Context();
+  int32_t dim = src.Dim();
+  K2_CHECK_EQ(dim + 1, ans->Dim());
+  const int32_t *src_data = src.Data();
+  int32_t *ans_data = ans->Data();
+  K2_EVAL(
+      c, dim, lambda_multiple2,
+      (int32_t i)->void { ans_data[i] = src_data[i] * 2; });
+  ExclusiveSum(*ans, ans);
+}
+
+void TransExclusiveSumNew(const Array1<int32_t> src, Array1<int32_t> *ans) {
+  ContextPtr c = src.Context();
+  int32_t dim = src.Dim();
+  K2_CHECK_EQ(dim + 1, ans->Dim());
+  const int32_t *src_data = src.Data();
+  int32_t *ans_data = ans->Data();
+  K2_TRANS_EXCSUM(
+      c, dim, ans_data, lambda_multiple2,
+      (int32_t i)->int32_t { return src_data[i] * 2; });
+}
+
+static BenchmarkStat BenchmarkTransExclusiveSum(int32_t dim,
+                                                DeviceType device_type) {
+  ContextPtr context;
+  if (device_type == kCpu) {
+    context = GetCpuContext();
+  } else {
+    K2_CHECK_EQ(device_type, kCuda);
+    context = GetCudaContext();
+  }
+
+  std::vector<int32_t> vec(dim);
+  std::iota(vec.begin(), vec.end(), dim);
+  Array1<int32_t> src(context, vec);
+  Array1<int32_t> ans(context, src.Dim() + 1);
+
+  BenchmarkStat stat;
+  stat.op_name = "TransExclusiveSum_New_" + std::to_string(dim);
+  int32_t num_iter = 20;
+  stat.num_iter = num_iter;
+  stat.problem_size = dim;
+  stat.device_type = device_type;
+
+  stat.eplased_per_iter =
+      BenchmarkOp(num_iter, context,
+                  (void (*)(const Array1<int32_t> &, Array1<int32_t> *))(
+                      &TransExclusiveSumNew),
+                  src, &ans);
+  stat.eplased_per_iter *= 1e6;  // from seconds to microseconds
+  return stat;
+}
+
 template <typename T>
 static void RegisterBenchmarkExclusiveSum(DeviceType device_type) {
   std::vector<int32_t> problems_sizes = {100,  500,   1000,  2000,
@@ -351,6 +406,20 @@ static void RegisterBenchmarkSizesToMergeMap(DeviceType device_type) {
   }
 }
 
+static void RegisterBenchmarkTransExclusiveSum(DeviceType device_type) {
+  std::vector<int32_t> problems_sizes = {100,    200,     500,    1000,  2000,
+                                         5000,   10000,   20000,  50000, 100000,
+                                         500000, 1000000, 5000000};
+  for (auto s : problems_sizes) {
+    std::string name =
+        GenerateBenchmarkName<int32_t>("TransExclusiveSum", device_type) + "_" +
+        std::to_string(s);
+    RegisterBenchmark(name, [s, device_type]() -> BenchmarkStat {
+      return BenchmarkTransExclusiveSum(s, device_type);
+    });
+  }
+}
+
 static void RunArrayOpsBenchmark() {
   PrintEnvironmentInfo();
 
@@ -368,6 +437,8 @@ static void RunArrayOpsBenchmark() {
   RegisterBenchmarkSpliceRowSplits(kCuda);
 
   RegisterBenchmarkSizesToMergeMap(kCuda);
+
+  RegisterBenchmarkTransExclusiveSum(kCuda);
 
   // Users can set a regular expression via environment
   // variable `K2_BENCHMARK_FILTER` such that only benchmarks

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -9,7 +9,6 @@
 #include "k2/csrc/array_ops.h"
 #include "k2/csrc/benchmark/benchmark.h"
 #include "k2/csrc/test_utils.h"
-#include "moderngpu/kernel_scan.hxx"
 
 namespace k2 {
 

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -269,60 +269,6 @@ static BenchmarkStat BenchmarkSizesToMergeMap(int32_t num_src,
   return stat;
 }
 
-void TransExclusiveSumOld(const Array1<int32_t> src, Array1<int32_t> *ans) {
-  ContextPtr c = src.Context();
-  int32_t dim = src.Dim();
-  K2_CHECK_EQ(dim + 1, ans->Dim());
-  const int32_t *src_data = src.Data();
-  int32_t *ans_data = ans->Data();
-  K2_EVAL(
-      c, dim, lambda_multiple2,
-      (int32_t i)->void { ans_data[i] = src_data[i] * 2; });
-  ExclusiveSum(*ans, ans);
-}
-
-void TransExclusiveSumNew(const Array1<int32_t> src, Array1<int32_t> *ans) {
-  ContextPtr c = src.Context();
-  int32_t dim = src.Dim();
-  K2_CHECK_EQ(dim + 1, ans->Dim());
-  const int32_t *src_data = src.Data();
-  int32_t *ans_data = ans->Data();
-  K2_TRANS_EXCSUM(
-      c, dim, ans_data, lambda_multiple2,
-      (int32_t i)->int32_t { return src_data[i] * 2; });
-}
-
-static BenchmarkStat BenchmarkTransExclusiveSum(int32_t dim,
-                                                DeviceType device_type) {
-  ContextPtr context;
-  if (device_type == kCpu) {
-    context = GetCpuContext();
-  } else {
-    K2_CHECK_EQ(device_type, kCuda);
-    context = GetCudaContext();
-  }
-
-  std::vector<int32_t> vec(dim);
-  std::iota(vec.begin(), vec.end(), dim);
-  Array1<int32_t> src(context, vec);
-  Array1<int32_t> ans(context, src.Dim() + 1);
-
-  BenchmarkStat stat;
-  stat.op_name = "TransExclusiveSum_New_" + std::to_string(dim);
-  int32_t num_iter = 20;
-  stat.num_iter = num_iter;
-  stat.problem_size = dim;
-  stat.device_type = device_type;
-
-  stat.eplased_per_iter =
-      BenchmarkOp(num_iter, context,
-                  (void (*)(const Array1<int32_t> &, Array1<int32_t> *))(
-                      &TransExclusiveSumNew),
-                  src, &ans);
-  stat.eplased_per_iter *= 1e6;  // from seconds to microseconds
-  return stat;
-}
-
 template <typename T>
 static void RegisterBenchmarkExclusiveSum(DeviceType device_type) {
   std::vector<int32_t> problems_sizes = {100,  500,   1000,  2000,
@@ -406,20 +352,6 @@ static void RegisterBenchmarkSizesToMergeMap(DeviceType device_type) {
   }
 }
 
-static void RegisterBenchmarkTransExclusiveSum(DeviceType device_type) {
-  std::vector<int32_t> problems_sizes = {100,    200,     500,    1000,  2000,
-                                         5000,   10000,   20000,  50000, 100000,
-                                         500000, 1000000, 5000000};
-  for (auto s : problems_sizes) {
-    std::string name =
-        GenerateBenchmarkName<int32_t>("TransExclusiveSum", device_type) + "_" +
-        std::to_string(s);
-    RegisterBenchmark(name, [s, device_type]() -> BenchmarkStat {
-      return BenchmarkTransExclusiveSum(s, device_type);
-    });
-  }
-}
-
 static void RunArrayOpsBenchmark() {
   PrintEnvironmentInfo();
 
@@ -437,8 +369,6 @@ static void RunArrayOpsBenchmark() {
   RegisterBenchmarkSpliceRowSplits(kCuda);
 
   RegisterBenchmarkSizesToMergeMap(kCuda);
-
-  RegisterBenchmarkTransExclusiveSum(kCuda);
 
   // Users can set a regular expression via environment
   // variable `K2_BENCHMARK_FILTER` such that only benchmarks

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -132,7 +132,6 @@ void OrPerSublist(Ragged<T> &src, T initial_value, Array1<T> *or_values) {
   SegmentedReduce<T, BitOrOp<T>>(src, initial_value, or_values);
 }
 
-
 /*
   Stack a list of RaggedShape to create a RaggedShape with one more axis.
   Similar to TF/PyTorch's Stack. The result will have Dim0 == src_size.
@@ -228,6 +227,17 @@ RaggedShape Prefix(RaggedShape &src, int32_t n);
 std::vector<RaggedShape> GetPrefixes(RaggedShape &src,
                                      const std::vector<int32_t> &sizes);
 
+void GetOldAndNewOffsets(RaggedShape &src, const Array1<int32_t> &new2old,
+                         Array2<int32_t> *old_offsets,
+                         Array2<int32_t> *new_offsets);
+void GetOldAndNewOffsets(RaggedShape &src, const Array1<int32_t> &new2old,
+                         Array1<int32_t> *old_offsets,
+                         Array1<int32_t> *new_offsets);
+
+RaggedShape IndexAxis0(RaggedShape &src, const Array1<int32_t> &new2old,
+                       Array1<int32_t> *elem_indexes /*=nullptr*/);
+RaggedShape IndexAxis0New(RaggedShape &src, const Array1<int32_t> &new2old,
+                          Array1<int32_t> *elem_indexes /*=nullptr*/);
 /*
   This object splits a ragged shape on its axis 0, giving you efficient
   axis to the sub-parts of it for each index into its axis0.
@@ -416,7 +426,8 @@ RaggedShape Unsqueeze(const RaggedShape &src, int32_t axis);
   Version of Unsqueeze() above, that works for ragged tensors.
   Note: the opposite of this is not Squeeze(); it is ans.RemoveAxis(axis).
 */
-template <typename T> Ragged<T> Unsqueeze(const Ragged<T> &src, int32_t axis) {
+template <typename T>
+Ragged<T> Unsqueeze(const Ragged<T> &src, int32_t axis) {
   return Ragged<T>(Unsqueeze(src.shape, axis), src.values);
 }
 
@@ -1027,7 +1038,6 @@ inline Ragged<T> RaggedFromTotSizes(ContextPtr &c,
                    Array1<T>(c, tot_sizes.back()));
 }
 
-
 /*
   Transpose a ragged tensor as if it were the index information of a CSR-format
   sparse matrix (but with possibly repeated elements!).  This is easiest to
@@ -1146,7 +1156,6 @@ RaggedShape Index(RaggedShape &src, int32_t axis,
                   const Array1<int32_t> &indexes,
                   Array1<int32_t> *elem_indexes = nullptr);
 
-
 /*
   Index ragged tensor with array, return ragged tensor.
 
@@ -1172,8 +1181,7 @@ RaggedShape Index(RaggedShape &src, int32_t axis,
 
 */
 template <typename T>
-Ragged<T> Index(Ragged<T> &src, int32_t axis,
-                const Array1<int32_t> &indexes,
+Ragged<T> Index(Ragged<T> &src, int32_t axis, const Array1<int32_t> &indexes,
                 Array1<int32_t> *value_indexes_out = nullptr) {
   Array1<int32_t> value_indexes;
   RaggedShape ans_shape = Index(src.shape, axis, indexes, &value_indexes);
@@ -1327,7 +1335,6 @@ Array1<int32_t> CoveringShapeForwardMap(RaggedShape &src,
 template <typename T>
 Array1<T> ComputeHash(Ragged<int32_t> &src);
 
-
 /*
   If `src` has two axes, this will return the unique sub-lists (in a possibly
   different order, but without repeats).  If `src` has 3 axes, it will
@@ -1347,7 +1354,6 @@ Array1<T> ComputeHash(Ragged<int32_t> &src);
   if the actual content in the sequence is different.
  */
 Ragged<int32_t> UniqueSequences(Ragged<int32_t> &src);
-
 
 /* Compute exclusive sum per sub-list.
  *


### PR DESCRIPTION
Just to show the idea of implementing such kernels (e.g. in `Append`/`Stack`) with one kernel, there are still a lot of TODOs, just make a PR so that we can fix them later as this task is not a P1 task currently.

Here are the benchmarks:
--------------
The header is `IndexAxis0_(New)_NumAxes_Dim0_NumElements_..._AverageTime`
```
IndexAxis0_2_46_500,int32,kCuda,50,20,65.080002
IndexAxis0_2_91_1001,int32,kCuda,100,20,64.686401
IndexAxis0_2_225_2018,int32,kCuda,200,20,65.086395
IndexAxis0_2_583_5002,int32,kCuda,500,20,65.670403
IndexAxis0_2_1112_10026,int32,kCuda,1000,20,65.625603
IndexAxis0_2_11029_100001,int32,kCuda,10000,20,67.537598
IndexAxis0_2_55306_500023,int32,kCuda,50000,20,93.817604
IndexAxis0_2_110946_1000025,int32,kCuda,100000,20,65.908806
IndexAxis0_2_222602_2000008,int32,kCuda,200000,20,172.318390

IndexAxis0New_2_46_500,int32,kCuda,50,20,63.302395
IndexAxis0New_2_91_1001,int32,kCuda,100,20,61.766396
IndexAxis0New_2_225_2018,int32,kCuda,200,20,61.952000
IndexAxis0New_2_583_5002,int32,kCuda,500,20,62.108803
IndexAxis0New_2_1112_10026,int32,kCuda,1000,20,62.512001
IndexAxis0New_2_11029_100001,int32,kCuda,10000,20,62.790401
IndexAxis0New_2_55306_500023,int32,kCuda,50000,20,62.396801
IndexAxis0New_2_110946_1000025,int32,kCuda,100000,20,62.252804
IndexAxis0New_2_222602_2000008,int32,kCuda,200000,20,78.288002


IndexAxis0_3_11_500,int32,kCuda,50,20,88.022392
IndexAxis0_3_14_1031,int32,kCuda,100,20,85.728004
IndexAxis0_3_23_2029,int32,kCuda,200,20,88.552002
IndexAxis0_3_65_5002,int32,kCuda,500,20,88.560005
IndexAxis0_3_119_10007,int32,kCuda,1000,20,88.529594
IndexAxis0_3_1261_100015,int32,kCuda,10000,20,88.505608
IndexAxis0_3_6192_500003,int32,kCuda,50000,20,88.671997
IndexAxis0_3_12424_1000003,int32,kCuda,100000,20,88.560005
IndexAxis0_3_24963_2000004,int32,kCuda,200000,20,97.596802

IndexAxis0New_3_11_500,int32,kCuda,50,20,65.598396
IndexAxis0New_3_14_1031,int32,kCuda,100,20,49.012802
IndexAxis0New_3_23_2029,int32,kCuda,200,20,68.468796
IndexAxis0New_3_65_5002,int32,kCuda,500,20,68.617599
IndexAxis0New_3_119_10007,int32,kCuda,1000,20,67.755196
IndexAxis0New_3_1261_100015,int32,kCuda,10000,20,90.870399
IndexAxis0New_3_6192_500003,int32,kCuda,50000,20,211.142395
IndexAxis0New_3_12424_1000003,int32,kCuda,100000,20,122.919998
IndexAxis0New_3_24963_2000004,int32,kCuda,200000,20,290.727997


IndexAxis0_4_6_500,int32,kCuda,50,20,146.524796
IndexAxis0_4_4_1047,int32,kCuda,100,20,7.521600
IndexAxis0_4_10_2003,int32,kCuda,200,20,147.745590
IndexAxis0_4_10_5003,int32,kCuda,500,20,146.284790
IndexAxis0_4_15_10001,int32,kCuda,1000,20,147.030396
IndexAxis0_4_141_100004,int32,kCuda,10000,20,147.188797
IndexAxis0_4_703_500025,int32,kCuda,50000,20,147.051208
IndexAxis0_4_1328_1000030,int32,kCuda,100000,20,147.732788
IndexAxis0_4_2722_2000014,int32,kCuda,200000,20,146.982407

IndexAxis0New_4_6_500,int32,kCuda,50,20,76.761597
IndexAxis0New_4_4_1047,int32,kCuda,100,20,7.526400
IndexAxis0New_4_10_2003,int32,kCuda,200,20,78.582405
IndexAxis0New_4_10_5003,int32,kCuda,500,20,76.758400
IndexAxis0New_4_15_10001,int32,kCuda,1000,20,76.278397
IndexAxis0New_4_141_100004,int32,kCuda,10000,20,147.857605
IndexAxis0New_4_703_500025,int32,kCuda,50000,20,81.131195
IndexAxis0New_4_1328_1000030,int32,kCuda,100000,20,697.676819
IndexAxis0New_4_2722_2000014,int32,kCuda,200000,20,557.192017
```

We can see that for large size the new approach will be much slower for the old one, one main reason is that we did not process multiple elements in one thread as the old approach did (so that we can save the time to index `new_offsets` and. `old_offsets`). ModernGpu did not support this, we need to write kernel by ourselves.  Another reason is that there are a few `if` in the kernel.