### PR TITLE
Fix k2.index_fsa to support ragged tensor attributes.

### DIFF
--- a/k2/python/k2/ops.py
+++ b/k2/python/k2/ops.py
@@ -211,7 +211,14 @@ def index_fsa(src: Fsa, indexes: torch.Tensor) -> Fsa:
     out_fsa = Fsa(ragged_arc)
 
     for name, value in src.named_tensor_attr():
-        setattr(out_fsa, name, k2.ops.index_select(value, value_indexes))
+        if isinstance(value, torch.Tensor):
+            setattr(out_fsa, name, k2.ops.index_select(value, value_indexes))
+        else:
+            assert isinstance(value, _k2.RaggedInt)
+            ragged_value, _ = k2.ragged.index(value,
+                                              value_indexes,
+                                              need_value_indexes=False)
+            setattr(out_fsa, name, ragged_value)
 
     for name, value in src.named_non_tensor_attr():
         setattr(out_fsa, name, value)

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -697,7 +697,7 @@ class TestFsa(unittest.TestCase):
                     fsa1.ragged_attr, fsa2.ragged_attr, fsa1.ragged_attr,
                     fsa2.ragged_attr, fsa2.ragged_attr
                 ],
-                                 axis=0))
+                                 axis=0))  # noqa
             assert multiples.device == device
 
 


### PR DESCRIPTION
Needed while using `path_to_seq_map` to index `num_graph`, which contains ragged `aux_labels`.