### PR TITLE
Add linear space support to NormalizePerSublist

### DIFF
--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1154,7 +1154,7 @@ class Fsa(object):
 
         ragged_scores = k2.ragged.RaggedFloat(
             self.arcs.shape().to(scores.device), scores)
-        ragged_scores = k2.ragged.normalize_scores(ragged_scores)
+        ragged_scores = k2.ragged.normalize_scores(ragged_scores, use_log=True)
 
         # Note we use `to` here since `scores` and `self.scores` may not
         # be on the same device.

--- a/k2/python/k2/ragged/autograd.py
+++ b/k2/python/k2/ragged/autograd.py
@@ -12,15 +12,21 @@ from .tensor import RaggedFloat
 class _NormalizeScores(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, src: RaggedFloat, out: List[RaggedFloat],
+    def forward(ctx, src: RaggedFloat, use_log: bool, out: List[RaggedFloat],
                 unused_scores: torch.Tensor) -> torch.Tensor:
         '''Normalize a ragged tensor of scores.
 
-        The normalization per sublist is done as follows:
+        If use_log is True, the normalization per sublist is done as follows:
 
             1. Compute the log sum per sublist
             2. Subtract the log sum computed above from the sublist and return
             it
+
+        If use_log is False, the normalization per sublist is done as follows:
+
+            1. Compute the sum per sublist
+            2. Divide the sublist by the above sum and return the resulting
+            sublist
 
         Note:
           If a sublist contains 3 elements `[a, b, c]`, then the log sum
@@ -28,13 +34,22 @@ class _NormalizeScores(torch.autograd.Function):
 
             s = log(exp(a) + exp(b) + exp(c))
 
-          The resulting sublist looks like::
+          The resulting sublist looks like below if use_log is True::
 
             [a - s, b - s, c - s]
+
+          If use_log is False, the resulting sublist looks like::
+
+            [a/(a+b+c), b/(a+b+c), c/(a+b+c)]
+
+        Caution:
+          autograd is currently not implemented if use_log is False.
 
         Args:
           src:
             The source ragged tensor.
+          use_log:
+            It indicates which kind of normalization to be applied.
           out:
             The output ragged tensor is put in this list. It is returned
             in the list since this function can only return values of type
@@ -46,30 +61,42 @@ class _NormalizeScores(torch.autograd.Function):
           discard the return value.
         '''
         assert len(out) == 1
-        ans_ragged = _k2.normalize_per_sublist(src.ragged)
+        ans_ragged = _k2.normalize_per_sublist(src.ragged, use_log)
         out[0] = RaggedFloat(ans_ragged)
         ctx.out = out[0]  # save for backward
+        ctx.use_log = use_log
         return out[0].values
 
     @staticmethod
     def backward(ctx,
                  out_grad: torch.Tensor) -> Tuple[None, None, torch.Tensor]:
         out = ctx.out
-        ans_grad = _k2.normalize_per_sublist_backward(out.ragged, out_grad)
+        use_log = ctx.use_log
+        assert use_log is True
+        ans_grad = _k2.normalize_per_sublist_backward(out.ragged, use_log,
+                                                      out_grad)
+
         return (
             None,  # src
+            None,  # use_log
             None,  # out
-            ans_grad)
+            ans_grad)  # unused_scores
 
 
-def normalize_scores(src: RaggedFloat) -> RaggedFloat:
+def normalize_scores(src: RaggedFloat, use_log: bool) -> RaggedFloat:
     '''Normalize a ragged tensor of scores.
 
-    The normalization per sublist is done as follows:
+    If use_log is True, the normalization per sublist is done as follows:
 
         1. Compute the log sum per sublist
         2. Subtract the log sum computed above from the sublist and return
         it
+
+    If use_log is False, the normalization per sublist is done as follows:
+
+        1. Compute the sum per sublist
+        2. Divide the sublist by the above sum and return the resulting
+        sublist
 
     Note:
       If a sublist contains 3 elements `[a, b, c]`, then the log sum
@@ -77,13 +104,23 @@ def normalize_scores(src: RaggedFloat) -> RaggedFloat:
 
         s = log(exp(a) + exp(b) + exp(c))
 
-      The resulting sublist looks like::
+      The resulting sublist looks like below if use_log is True::
 
         [a - s, b - s, c - s]
+
+      If use_log is False, the resulting sublist looks like::
+
+        [a/(a+b+c), b/(a+b+c), c/(a+b+c)]
+
+    Caution:
+      autograd is currently not implemented if use_log is False.
 
     Args:
       src:
         The source ragged tensor.
+      use_log:
+        It indicates which kind of normalization to be applied.
+
     Returns:
       The normalized ragged tensor.
     '''
@@ -91,6 +128,6 @@ def normalize_scores(src: RaggedFloat) -> RaggedFloat:
 
     # the return value is discarded for the following call
     # as it equals to out[0].values
-    _NormalizeScores.apply(src, out, src.values)
+    _NormalizeScores.apply(src, use_log, out, src.values)
 
     return out[0]

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -99,3 +99,28 @@ class RaggedFloat(object):
         '''
         self._values.requires_grad_(requires_grad)
         return self
+
+    def to(self, device: Union[torch.device, str]) -> 'RaggedFloat':
+        '''Move the RaggedFloat onto a given device.
+
+        Args:
+          device:
+            An instance of `torch.device` or a string that can be used to
+            construct a `torch.device`, e.g., 'cpu', 'cuda:0'.
+            It supports only cpu and cuda devices.
+
+        Returns:
+          Returns a new RaggedFloat which is this object copied to the given
+          device (or this object itself, if the device was the same).
+        '''
+        if isinstance(device, str):
+            device = torch.device(device)
+
+        assert device.type in ('cpu', 'cuda')
+        if device == self.values.device:
+            return self
+
+        ragged_shape = self.ragged.shape().to(device)
+        values = self.values.to(device)
+
+        return RaggedFloat(ragged_shape, values)


### PR DESCRIPTION
https://github.com/k2-fsa/snowfall/pull/106#discussion_r582544398

> Basically we will be doing another pass of MMI training, except instead of summing the tot_scores we will compute a weighted sum where the weight is (num_copies_this_path / num_paths_this_seq). 

This pullrequest can be used to compute `(num_copies_this_path / num_paths_this_seq)`. Since it does not need
to support autograd in this case, autograd is not implemented at present.