### PR TITLE
Support ragged aux_labels in k2.compose

### DIFF
--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <mutex>  // NOLINT
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "k2/csrc/macros.h"
@@ -128,7 +129,7 @@ class Logger {
     }
   }
 
-  K2_CUDA_HOSTDEV ~Logger() {
+  K2_CUDA_HOSTDEV ~Logger() noexcept(false) {
     printf("\n");
     if (level_ == FATAL) {
 #if defined(__CUDA_ARCH__)
@@ -143,7 +144,11 @@ class Logger {
         printf("\n\n%s\n", stack_trace.c_str());
       }
       fflush(nullptr);
-      abort();
+      // abort();
+      //
+      // NOTE: abort() will terminate the program immediately without
+      // printing the Python stack backtrace.
+      throw std::runtime_error("Some bad things happed.");
 #endif
     }
   }

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -2219,12 +2219,13 @@ Array1<T> ComputeHash(Ragged<int32_t> &src) {
 }
 
 Ragged<int32_t> UniqueSequences(Ragged<int32_t> &src,
-                                Ragged<int32_t> *num_repeats /*=nullptr*/) {
+                                Ragged<int32_t> *num_repeats /*=nullptr*/,
+                                Array1<int32_t> *new2old_indexes /*=nullptr*/) {
   ContextPtr &c = src.Context();
   if (src.NumAxes() == 2) {
     // Put 'fake' layer at front, process, then remove.
     Ragged<int32_t> temp = Unsqueeze(src, 0);
-    return UniqueSequences(temp, num_repeats).RemoveAxis(0);
+    return UniqueSequences(temp, num_repeats, new2old_indexes).RemoveAxis(0);
   }
   Array1<int64_t> hashes = ComputeHash<int64_t>(src);
   int32_t hashes_dim = hashes.Dim();
@@ -2271,6 +2272,9 @@ Ragged<int32_t> UniqueSequences(Ragged<int32_t> &src,
         });
     *num_repeats = Ragged<int32_t>(GetLayer(ans.shape, ans.NumAxes() - 3),
                                    num_repeats_array);
+  }
+  if (new2old_indexes != nullptr) {
+    *new2old_indexes = std::move(new2unsorted);
   }
   return ans;
 }

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -1349,6 +1349,8 @@ Array1<T> ComputeHash(Ragged<int32_t> &src);
      @param [out] new2old_indexes
                        If not NULL, on return new2old_indexes[i] contains
                        the original input sublist for the i-th output sublist.
+                       If `src` has 2 axes, this array contains `src_idx0`;
+                       if `src` has 3 axes, this array contains `src_idx01`.
 
      @return   Returns a tensor with the same number of axes as `src` and
             possibly fewer elements due to removing repeated sequences on the

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -1346,6 +1346,9 @@ Array1<T> ComputeHash(Ragged<int32_t> &src);
                        repeats (i.e., multiplicity) of each output sequence.
                        The caller does not need to pre-allocate it. It is
                        allocated inside the function.
+     @param [out] new2old_indexes
+                       If not NULL, on return new2old_indexes[i] contains
+                       the original input sublist for the i-th output sublist.
 
      @return   Returns a tensor with the same number of axes as `src` and
             possibly fewer elements due to removing repeated sequences on the
@@ -1358,7 +1361,8 @@ Array1<T> ComputeHash(Ragged<int32_t> &src);
   if the actual content in the sequence is different.
  */
 Ragged<int32_t> UniqueSequences(Ragged<int32_t> &src,
-                                Ragged<int32_t> *num_repeats = nullptr);
+                                Ragged<int32_t> *num_repeats = nullptr,
+                                Array1<int32_t> *new2old_indexes = nullptr);
 
 /* Compute exclusive sum per sub-list.
  *

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -1351,6 +1351,9 @@ Array1<T> ComputeHash(Ragged<int32_t> &src);
                        the original input sublist for the i-th output sublist.
                        If `src` has 2 axes, this array contains `src_idx0`;
                        if `src` has 3 axes, this array contains `src_idx01`.
+                       CAUTION: For repeated sublists, only one of them is kept.
+                       The choice of which one to keep is **deterministic** and
+                       is an implementation detail.
 
      @return   Returns a tensor with the same number of axes as `src` and
             possibly fewer elements due to removing repeated sequences on the
@@ -1361,6 +1364,10 @@ Array1<T> ComputeHash(Ragged<int32_t> &src);
   be present in the output, as it relies on a hash and ignores collisions.
   If several sequences have the same hash, only one of them is kept, even
   if the actual content in the sequence is different.
+
+  CAUTION: Even if there are no repeated sequences, the output may be different
+  from `src`. That is, `new2old_indexes` may NOT be an identity map even if
+  nothing was removed.
  */
 Ragged<int32_t> UniqueSequences(Ragged<int32_t> &src,
                                 Ragged<int32_t> *num_repeats = nullptr,

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -263,6 +263,23 @@ static void PybindRegularRaggedShape(py::module &m) {
       py::arg("dim0"), py::arg("dim1"));
 }
 
+template <typename T>
+static void PybindArgMaxPerSublist(py::module &m) {
+  m.def(
+      "argmax_per_sublist",
+      [](Ragged<T> &src, T initial_value) -> torch::Tensor {
+        int32_t last_axis = src.NumAxes() - 1;
+        const Array1<int32_t> &row_splits_array = src.RowSplits(last_axis);
+        int32_t num_rows = row_splits_array.Dim() - 1;
+
+        Array1<int32_t> indexes(src.Context(), num_rows);
+        ArgMaxPerSublist(src, initial_value, &indexes);
+
+        return ToTensor(indexes);
+      },
+      py::arg("src"), py::arg("initial_value"));
+}
+
 }  // namespace k2
 
 void PybindRaggedOps(py::module &m) {
@@ -282,4 +299,5 @@ void PybindRaggedOps(py::module &m) {
   PybindUniqueSequences(m);
   PybindIndex(m);
   PybindRegularRaggedShape(m);
+  PybindArgMaxPerSublist<float>(m);
 }

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -1,4 +1,5 @@
 import torch  # noqa
+from _k2 import RaggedFloat  # TODO(fangjun): move it to k2.ragged
 from _k2 import RaggedInt  # TODO(fangjun): move it to k2.ragged
 from _k2 import simple_ragged_index_select
 

--- a/k2/python/k2/ragged/__init__.py
+++ b/k2/python/k2/ragged/__init__.py
@@ -1,6 +1,7 @@
 # please sort imported functions alphabetically
 from .autograd import normalize_scores
 from .ops import append
+from .ops import argmax_per_sublist
 from .ops import create_ragged2
 from .ops import get_layer
 from .ops import index

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -188,7 +188,9 @@ def get_layer(src: _k2.RaggedShape, layer: int) -> _k2.RaggedShape:
     return _k2.get_layer(src, layer)
 
 
-def unique_sequences(src: _k2.RaggedInt, need_num_repeats: bool = True
+def unique_sequences(src: _k2.RaggedInt,
+                     need_num_repeats: bool = True,
+                     need_new2old_indexes: bool = False
                     ) -> Tuple[_k2.RaggedInt, Optional[_k2.RaggedInt]]:  # noqa
     '''Remove repeated sequences.
 
@@ -209,6 +211,8 @@ def unique_sequences(src: _k2.RaggedInt, need_num_repeats: bool = True
         or `src_num_axes() == 3`
       need_num_repeats:
         If True, it also returns the number of repeats of each sequence.
+      need_new2old_indexes:
+        If true, it returns an extra 1-D tensor `new2old_indexes`.
 
     Returns:
      Returns a tuple containing:
@@ -223,8 +227,13 @@ def unique_sequences(src: _k2.RaggedInt, need_num_repeats: bool = True
          num_repeats.num_elements() == ans.dim0().
          If ans.num_axes() is 3, then num_repeats.dim0() == ans.dim0() and
          num_repeats.num_elements() == ans.tot_size(1).
+
+       - new2old_indexes: A 1-D tensor whose i-th element specifies the
+         input sublist that the i-th output sublist corresponds to.
     '''
-    return _k2.unique_sequences(src, need_num_repeats=need_num_repeats)
+    return _k2.unique_sequences(src,
+                                need_num_repeats=need_num_repeats,
+                                need_new2old_indexes=need_new2old_indexes)
 
 
 def regular_ragged_shape(dim0: int, dim1: int) -> _k2.RaggedShape:
@@ -249,7 +258,7 @@ def regular_ragged_shape(dim0: int, dim1: int) -> _k2.RaggedShape:
 
 def argmax_per_sublist(src: _k2.RaggedFloat,
                        initial_value: float = torch.finfo(torch.float32).min
-                      ) -> torch.Tensor:
+                      ) -> torch.Tensor:  # noqa
     '''Compute the argmax per sublist for a ragged tensor.
 
     The argmax is computed on the last axis.

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -205,6 +205,11 @@ def unique_sequences(src: _k2.RaggedInt,
       If several sequences have the same hash, only one of them is kept, even
       if the actual content in the sequence is different.
 
+    Caution:
+      Even if there are no repeated sequences, the output may be different
+      from `src`. That is, `new2old_indexes` may NOT be an identity map even if
+      nothing was removed.
+
     Args:
       src:
         The input ragged tensor. Must have `src.num_axes() == 2`
@@ -213,6 +218,14 @@ def unique_sequences(src: _k2.RaggedInt,
         If True, it also returns the number of repeats of each sequence.
       need_new2old_indexes:
         If true, it returns an extra 1-D tensor `new2old_indexes`.
+        If `src` has 2 axes, this tensor contains `src_idx0`;
+        if `src` has 3 axes, this tensor contains `src_idx01`.
+
+        Caution:
+          For repeated sublists, only one of them is kept.
+          The choice of which one to keep is **deterministic** and
+          is an implementation detail.
+
 
     Returns:
      Returns a tuple containing:

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -245,3 +245,21 @@ def regular_ragged_shape(dim0: int, dim1: int) -> _k2.RaggedShape:
       Return a ragged shape with 2 axes.
     '''
     return _k2.regular_ragged_shape(dim0, dim1)
+
+
+def argmax_per_sublist(src: _k2.RaggedFloat,
+                       initial_value: float = torch.finfo(torch.float32).min
+                      ) -> torch.Tensor:
+    '''Compute the argmax per sublist for a ragged tensor.
+
+    The argmax is computed on the last axis.
+
+    Args:
+      src:
+        The input ragged tensor.
+      initial_value:
+        The initial value used to compute the argmax.
+    Returns:
+      Return a 1-D tensor with dtype torch.int32.
+    '''
+    return _k2.argmax_per_sublist(src, initial_value)

--- a/k2/python/tests/invert_test.py
+++ b/k2/python/tests/invert_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+# Copyright (c)  2020-2021  Xiaomi Corporation (authors: Haowen Qiu
+#                                                        Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
 
@@ -15,6 +16,12 @@ import k2
 
 
 class TestInvert(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.devices = [torch.device('cpu')]
+        if torch.cuda.is_available():
+            cls.devices.append(torch.device('cuda', 0))
 
     def test_aux_as_tensor(self):
         s = '''
@@ -58,6 +65,36 @@ class TestInvert(unittest.TestCase):
         dest = k2.invert(fsa)
         print(dest)  # will print aux_labels as well
         # TODO(haowen): wrap C++ code to check equality for Ragged?
+
+    def test_aux_ragged(self):
+        for device in self.devices:
+            s = '''
+                0 1 1 0.1
+                0 2 2 0.2
+                1 3 3 0.3
+                2 3 4 0.6
+                3 4 -1 0.7
+                4
+            '''
+            # https://git.io/JqNiR
+            fsa = k2.Fsa.from_str(s).to(device)
+            fsa.aux_labels = k2.RaggedInt('[[2 3] [3 4] [] [5] [-1]]').to(
+                device)
+            fsa.tensor_attr1 = torch.tensor([1, 2, 3, 4, 5]).to(device)
+
+            # https://git.io/JqNiw
+            ans = k2.invert(fsa)
+
+            assert torch.all(
+                torch.eq(ans.tensor_attr1,
+                         torch.tensor([1, 2, 0, 0, 3, 4, 5], device=device)))
+
+            assert str(ans.aux_labels) == str(
+                k2.RaggedInt('[[1] [2] [] [] [3] [4] [-1]]'))
+
+            assert torch.all(
+                torch.eq(ans.labels,
+                         torch.tensor([2, 3, 3, 4, 0, 5, -1], device=device)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It is needed in
```python
k2.compose(decoding_lats, word_fsas)
```
where `aux_labels` in `decoding_lats` is a ragged tensor.

This pull-request extends `k2.compose` to support that.

---

[EDITED]: Mark it as WIP. Will merge after testing it in snowfall.

Used in https://github.com/k2-fsa/snowfall/pull/106