### PR TITLE
Aux labels etc

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.9]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/k2/csrc/fsa_test.cu
+++ b/k2/csrc/fsa_test.cu
@@ -38,7 +38,7 @@ TEST(FsaIO, FromAndToTensor) {
     3
   )";
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
-    Fsa fsa = FsaFromString(s);
+    Fsa fsa = FsaFromString(s, false, 0, nullptr);
     fsa = fsa.To(context);
     Tensor tensor = FsaToTensor(fsa);
     int32_t num_arcs = fsa.values.Dim();

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -242,7 +242,6 @@ static Fsa K2FsaFromStream(std::istringstream &is,
 static Fsa OpenFstFromStream(std::istringstream &is,
                              int32_t num_aux_labels,
                              Array2<int32_t> *aux_labels_out) {
-
   NVTX_RANGE(K2_FUNC);
   K2_CHECK(num_aux_labels == 0 || aux_labels_out != nullptr);
 
@@ -276,7 +275,8 @@ static Fsa OpenFstFromStream(std::istringstream &is,
       K2_CHECK_GE(src_state, 0);
       K2_CHECK_GE(dest_state, 0);
       if (start_state == -1) start_state = src_state;
-      // Add the arc to "state_to_arcs", and aux_label[s] to "state_to_aux_labels"
+      // Add the arc to "state_to_arcs", and aux_label[s] to
+      // "state_to_aux_labels"
       ++num_arcs;
       max_state = std::max(max_state, std::max(src_state, dest_state));
       if (static_cast<int32_t>(state_to_arcs.size()) <= src_state) {

--- a/k2/csrc/fsa_utils_test.cu
+++ b/k2/csrc/fsa_utils_test.cu
@@ -103,8 +103,10 @@ TEST(FsaFromString, K2Transducer) {
 )";
 
   {
-    Array1<int32_t> aux_labels;
-    auto fsa = FsaFromString(s, false, &aux_labels);
+    Array2<int32_t> aux_labels_array;
+    int32_t num_aux_labels = 1;
+    auto fsa = FsaFromString(s, false, num_aux_labels, &aux_labels_array);
+    Array1<int32_t> aux_labels = aux_labels_array.Row(0);
     EXPECT_EQ(fsa.Context()->GetDeviceType(), kCpu);
     EXPECT_EQ(aux_labels.Context()->GetDeviceType(), kCpu);
 
@@ -146,10 +148,10 @@ TEST(FsaFromString, OpenFstTransducer) {
 )";
 
   {
-    Array1<int32_t> aux_labels;
-    auto fsa = FsaFromString(s, true, &aux_labels);
+    Array2<int32_t> aux_labels_array;
+    auto fsa = FsaFromString(s, true, 1, &aux_labels_array);
     EXPECT_EQ(fsa.Context()->GetDeviceType(), kCpu);
-    EXPECT_EQ(aux_labels.Context()->GetDeviceType(), kCpu);
+    EXPECT_EQ(aux_labels_array.Context()->GetDeviceType(), kCpu);
 
     EXPECT_EQ(fsa.NumAxes(), 2);
     EXPECT_EQ(fsa.shape.Dim0(), 9);          // there are 9 states
@@ -165,6 +167,7 @@ TEST(FsaFromString, OpenFstTransducer) {
     EXPECT_EQ((fsa[{0, 8}]), (Arc{6, 8, -1, 1.2f}));
     EXPECT_EQ((fsa[{0, 9}]), (Arc{7, 8, -1, 2.3f}));
 
+    Array1<int32_t> aux_labels = aux_labels_array.Row(0);
     EXPECT_EQ(aux_labels[0], 22);
     EXPECT_EQ(aux_labels[1], 100);
     EXPECT_EQ(aux_labels[2], 33);
@@ -185,7 +188,7 @@ TEST(FsaFromString, OpenFstAcceptorNonZeroStart) {
     0 0 3 0.2
     0 0.4
   )";
-  Fsa fsa = FsaFromString(s, true, nullptr);
+  Fsa fsa = FsaFromString(s, true);
   EXPECT_EQ((fsa[{0, 0}]), (Arc{0, 1, 0, -0.1f}));
   EXPECT_EQ((fsa[{1, 0}]), (Arc{1, 1, 4, -0.3f}));
   EXPECT_EQ((fsa[{1, 1}]), (Arc{1, 1, 3, -0.2f}));
@@ -205,7 +208,7 @@ TEST(FsaFromString, OpenFstAcceptorNonZeroStartCase2) {
     0 1 9 0.9
     4 0.6
   )";
-  Fsa fsa = FsaFromString(s, true, nullptr);
+  Fsa fsa = FsaFromString(s, true);
   EXPECT_EQ((fsa[{0, 0}]), (Arc{0, 3, 10, -0.1f}));
   EXPECT_EQ((fsa[{0, 1}]), (Arc{0, 3, 20, -0.2f}));
   EXPECT_EQ((fsa[{0, 2}]), (Arc{0, 1, 90, -0.8f}));
@@ -225,9 +228,9 @@ TEST(FsaFromString, OpenFstTransducerNonZeroStart) {
     0 0 3 30 0.2
     0 0.4
   )";
-  Array1<int32_t> aux_labels;
-  Fsa fsa = FsaFromString(s, true, &aux_labels);
-  CheckArrayData(aux_labels, {0, 40, 30, -1});
+  Array2<int32_t> aux_labels_array;
+  Fsa fsa = FsaFromString(s, true, 1, &aux_labels_array);
+  CheckArrayData(aux_labels_array.Row(0), {0, 40, 30, -1});
   EXPECT_EQ((fsa[{0, 0}]), (Arc{0, 1, 0, -0.1f}));
   EXPECT_EQ((fsa[{1, 0}]), (Arc{1, 1, 4, -0.3f}));
   EXPECT_EQ((fsa[{1, 1}]), (Arc{1, 1, 3, -0.2f}));
@@ -247,9 +250,9 @@ TEST(FsaFromString, OpenFstTransducerNonZeroStartCase2) {
     0 1 9 10 0.9
     4 0.6
   )";
-  Array1<int32_t> aux_labels;
-  Fsa fsa = FsaFromString(s, true, &aux_labels);
-  CheckArrayData(aux_labels, {100, 200, 8, 500, 3, 10, 300, 400, 8, -1});
+  Array2<int32_t> aux_labels;
+  Fsa fsa = FsaFromString(s, true, 1, &aux_labels);
+  CheckArrayData(aux_labels.Row(0), {100, 200, 8, 500, 3, 10, 300, 400, 8, -1});
   EXPECT_EQ((fsa[{0, 0}]), (Arc{0, 3, 10, -0.1f}));
   EXPECT_EQ((fsa[{0, 1}]), (Arc{0, 3, 20, -0.2f}));
   EXPECT_EQ((fsa[{0, 2}]), (Arc{0, 1, 90, -0.8f}));
@@ -286,8 +289,9 @@ TEST(FsaToString, Transducer) {
 1 5  -1 300  -3.2
 5
 )";
-  Array1<int32_t> aux_labels;
-  auto fsa = FsaFromString(s, false, &aux_labels);
+  Array2<int32_t> aux_labels_array;
+  auto fsa = FsaFromString(s, false, 1, &aux_labels_array);
+  Array1<int32_t> aux_labels = aux_labels_array.Row(0);
   auto str = FsaToString(fsa, false, &aux_labels);
   K2_LOG(INFO) << "\n" << str;
 

--- a/k2/csrc/host_shim_test.cu
+++ b/k2/csrc/host_shim_test.cu
@@ -20,7 +20,7 @@ TEST(HostShim, FsaToHostFsa) {
     2 3 -1 0
     3
   )";
-  Fsa fsa = FsaFromString(s);
+  Fsa fsa = FsaFromString(s, false);
   k2host::Fsa host_fsa = FsaToHostFsa(fsa);
   K2_LOG(INFO) << k2host::FsaToString(host_fsa);
   // TODO(fangjun): check the content of host_fsa

--- a/k2/csrc/intersect_dense.cu
+++ b/k2/csrc/intersect_dense.cu
@@ -206,22 +206,22 @@ class MultiGraphDenseIntersect {
     int32_t max_states = 15000000;
 
     while (1) {
-      // This code is in a loop is in case we get too many states and have to retry.
-      // The limit `max_states` is to reduce the likelihood of out-of-memory
-      // conditions.
+      // This code is in a loop is in case we get too many states and have to
+      // retry.  The limit `max_states` is to reduce the likelihood of
+      // out-of-memory conditions.
       renumber_states = Renumbering(c_, product);
       char *keep_state_data = renumber_states.Keep().Data();
       score_cutoffs = GetScoreCutoffs();
       score_cutoffs_data = score_cutoffs.Data();
       float **state_scores_data = state_scores_.Data();
 
-      // We'll do exclusive-sum on the following array, after setting its elements
-      // to 1 if the corresponding state was not pruned away.  The order of
-      // 'counts' is: (T+1) copies of all the states of fsa index 0, (T+1) copies
-      // of all the states of FSA index 1, and so on.  In fact not all FSAs have
-      // this many frames, most of them have fewer copies, but using this regular
-      // structure avoids having to compute any extra row_ids vectors and the
-      // like.  The out-of-range elements will be set to zero.
+      // We'll do exclusive-sum on the following array, after setting its
+      // elements to 1 if the corresponding state was not pruned away.  The
+      // order of 'counts' is: (T+1) copies of all the states of fsa index 0,
+      // (T+1) copies of all the states of FSA index 1, and so on.  In fact not
+      // all FSAs have this many frames, most of them have fewer copies, but
+      // using this regular structure avoids having to compute any extra row_ids
+      // vectors and the like.  The out-of-range elements will be set to zero.
 
 
       // the following lambda will set elements within `keep_state_data` to 0
@@ -231,8 +231,8 @@ class MultiGraphDenseIntersect {
             // i is actually an idx012 of a state.
 
             // the following works because each FSA has (its num-states * T_+1)
-            // states allocated to it.  However (i / (T_+1)) does not directly map
-            // to a state index.
+            // states allocated to it.  However (i / (T_+1)) does not directly
+            // map to a state index.
             int32_t fsa_idx0 = a_fsas_row_ids1_data[(i / (T + 1))];
             FsaInfo fsa_info = fsa_info_data[fsa_idx0];
             float cutoff = score_cutoffs_data[fsa_idx0];
@@ -359,7 +359,8 @@ class MultiGraphDenseIntersect {
     int32_t scores_stride = b_fsas_.scores.ElemStride0();
     const float *scores_data = b_fsas_.scores.Data();
 
-    auto lambda_set_keep = [=] __host__ __device__(int32_t arc_idx0123, int32_t ans_state_idx012) -> bool {
+    auto lambda_set_keep = [=] __host__ __device__(
+        int32_t arc_idx0123, int32_t ans_state_idx012) -> bool {
           int32_t ans_idx012x = ans_row_splits3_data[ans_state_idx012],
                   ans_idx01 = ans_row_ids2_data[ans_state_idx012],
                   fsa_idx0 = ans_row_ids1_data[ans_idx01],
@@ -456,7 +457,7 @@ class MultiGraphDenseIntersect {
 
 
     K2_EVAL(
-        c_, num_arcs_out, lambda_set_arcs_and_maps, (int32_t arc_idx_out)->void {
+        c_, num_arcs_out, lambda_set_arcs_and_maps, (int32_t arc_idx_out) -> void {
           // arc_idx0123 below is the same as the arc_idx0123 given to
           // lambda_set_keep above.
           int32_t arc_idx0123 = arcs_new2old_data[arc_idx_out],

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -121,7 +121,7 @@ class Logger {
     }
 
     if (cur_level_ <= level_) {
-      printf("%s:%s:%u ", filename, func_name, line_num);
+      printf("%s:%u:%s ", filename, line_num, func_name);
 #if defined(__CUDA_ARCH__)
       printf("block:[%u,%u,%u], thread: [%u,%u,%u] ", blockIdx.x, blockIdx.y,
              blockIdx.z, threadIdx.x, threadIdx.y, threadIdx.z);

--- a/k2/csrc/rm_epsilon_test.cu
+++ b/k2/csrc/rm_epsilon_test.cu
@@ -86,12 +86,12 @@ void CheckComputeSubset(FsaVec &src, FsaVec &dst, Array1<int32_t> &state_map,
 TEST(RmEpsilon, ComputeEpsilonAndNonEpsilonSubsetSimple) {
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     std::string s1 = R"(0 1 1 1
-    1 2 0 1 
-    1 3 2 1 
-    2 3 3 1 
-    3 4 4 1 
-    3 5 5 1 
-    4 5 6 1 
+    1 2 0 1
+    1 3 2 1
+    2 3 3 1
+    3 4 4 1
+    3 5 5 1
+    4 5 6 1
     4 6 7 1
     5 6 0 1
     5 7 -1 0
@@ -99,10 +99,10 @@ TEST(RmEpsilon, ComputeEpsilonAndNonEpsilonSubsetSimple) {
     7
   )";
     std::string s2 = R"(0 1 0 1
-    1 2 0 1 
-    2 3 0 1 
-    3 4 4 1 
-    3 5 -1 1 
+    1 2 0 1
+    2 3 0 1
+    3 4 4 1
+    3 5 -1 1
     4 5 -1 1
     5
   )";
@@ -191,21 +191,21 @@ TEST(RmEpsilon, ComputeEpsilonAndNonEpsilonSubsetRandom) {
 TEST(RmEpsilon, MapFsaVecStatesSimple) {
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     std::string s1 = R"(0 1 1 1
-    1 2 0 1 
-    1 3 2 1 
-    2 3 3 1 
-    3 4 4 1 
-    3 5 5 1 
-    4 5 6 1 
+    1 2 0 1
+    1 3 2 1
+    2 3 3 1
+    3 4 4 1
+    3 5 5 1
+    4 5 6 1
     4 6 -1 1
     5 6 -1 1
     6
   )";
     std::string s2 = R"(0 1 0 1
-    1 2 0 1 
-    2 3 0 1 
-    3 4 4 1 
-    3 5 -1 1 
+    1 2 0 1
+    2 3 0 1
+    3 4 4 1
+    3 5 -1 1
     4 5 -1 1
     5
   )";
@@ -247,18 +247,18 @@ TEST(RmEpsilon, MapFsaVecStatesSimple) {
 TEST(RmEpsilon, ComputeEpsilonClosureOneIterSimple) {
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     std::string s1 = R"(0 1 0 1
-    1 2 0 1 
-    1 3 0 1 
-    2 3 0 1 
-    3 4 0 1 
-    3 5 0 1 
-    4 5 0 1 
+    1 2 0 1
+    1 3 0 1
+    2 3 0 1
+    3 4 0 1
+    3 5 0 1
+    4 5 0 1
     6
   )";
     std::string s2 = R"(0 1 0 1
-    1 2 0 1 
-    2 3 0 1 
-    3 4 0 1 
+    1 2 0 1
+    2 3 0 1
+    3 4 0 1
     5
   )";
     Fsa fsa1 = FsaFromString(s1);
@@ -283,18 +283,18 @@ TEST(RmEpsilon, ComputeEpsilonClosureOneIterSimple) {
 TEST(RmEpsilon, ComputeEpsilonClosureSimple) {
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     std::string s1 = R"(0 1 0 1
-    1 2 0 1 
-    1 3 0 1 
-    2 3 0 1 
-    3 4 0 1 
-    3 5 0 1 
-    4 5 0 1 
+    1 2 0 1
+    1 3 0 1
+    2 3 0 1
+    3 4 0 1
+    3 5 0 1
+    4 5 0 1
     6
   )";
     std::string s2 = R"(0 1 0 1
-    1 2 0 1 
-    2 3 0 1 
-    3 4 0 1 
+    1 2 0 1
+    2 3 0 1
+    3 4 0 1
     5
   )";
     Fsa fsa1 = FsaFromString(s1);
@@ -343,12 +343,12 @@ void CheckArcMap(FsaVec &src, FsaVec &dest, Ragged<int32_t> &arc_map) {
 TEST(RmEpsilon, RemoveEpsilonDeviceSimple) {
   for (auto &context : {GetCpuContext(), GetCudaContext()}) {
     std::string s1 = R"(0 1 1 1
-    1 2 0 1 
-    1 3 2 1 
-    2 3 3 1 
-    3 4 4 1 
-    3 5 5 1 
-    4 5 6 1 
+    1 2 0 1
+    1 3 2 1
+    2 3 3 1
+    3 4 4 1
+    3 5 5 1
+    4 5 6 1
     4 6 7 1
     5 6 0 1
     5 7 -1 0
@@ -356,10 +356,10 @@ TEST(RmEpsilon, RemoveEpsilonDeviceSimple) {
     7
   )";
     std::string s2 = R"(0 1 0 1
-    1 2 0 1 
-    2 3 0 1 
-    3 4 4 1 
-    3 5 -1 1 
+    1 2 0 1
+    2 3 0 1
+    3 4 4 1
+    3 5 -1 1
     4 5 -1 1
     5
   )";

--- a/k2/python/csrc/torch/fsa.cu
+++ b/k2/python/csrc/torch/fsa.cu
@@ -98,12 +98,13 @@ static void PybindFsaUtil(py::module &m) {
 
   m.def(
       "fsa_from_str",
-      [](const std::string &s, bool acceptor = true, bool openfst = false)
+      [](const std::string &s, int num_aux_labels = 0, bool openfst = false)
           -> std::pair<Fsa, torch::optional<torch::Tensor>> {
-        Array1<int32_t> aux_labels;
-        Fsa fsa = FsaFromString(s, openfst, acceptor ? nullptr : &aux_labels);
+        Array2<int32_t> aux_labels;
+        Fsa fsa = FsaFromString(s, openfst, num_aux_labels,
+                                &aux_labels);
         torch::optional<torch::Tensor> tensor;
-        if (aux_labels.Dim() > 0) tensor = ToTensor(aux_labels);
+        if (num_aux_labels != 0) tensor = ToTensor(aux_labels);
         return std::make_pair(fsa, tensor);
       },
       py::arg("s"), py::arg("acceptor") = true, py::arg("openfst") = false,

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1063,7 +1063,10 @@ class Fsa(object):
 
     @classmethod
     def from_str(cls, s: str, num_aux_labels: int = 0,
-                 aux_label_names: List[str] = ['aux_labels', 'aux_labels2', 'aux_labels3']) -> 'Fsa':
+                 acce
+                 aux_label_names: List[str] = ['aux_labels',
+                                               'aux_labels2',
+                                               'aux_labels3']) -> 'Fsa':
         '''Create an Fsa from a string in the k2 format.
         (See also from_openfst).
 
@@ -1096,20 +1099,20 @@ class Fsa(object):
         try:
             arcs, aux_labels = _k2.fsa_from_str(s, num_aux_labels, False)
             ans = Fsa(arcs)
-            if aux_labels != None:
+            if aux_labels is not None:
                 for i in range(aux_labels.shape[0]):
                     setattr(ans, aux_label_names[i], aux_labels[i,:])
             return ans
-        except:
+        except Exception:
             raise ValueError(f'The following is not a valid Fsa (with '
                              f'num_aux_labels={num_aux_labels}): {s}')
-
-
 
     @classmethod
     def from_openfst(cls, s: str, acceptor: bool = True,
                      num_aux_labels: int = 0,
-                     aux_label_names: List[str] = ['aux_labels', 'aux_labels2', 'aux_labels3'])  -> 'Fsa':
+                     aux_label_names: List[str] = ['aux_labels',
+                                                   'aux_labels2',
+                                                   'aux_labels3']) -> 'Fsa':
         '''Create an Fsa from a string in OpenFST format (or a slightly
         more general format, if num_aux_labels > 1).
 
@@ -1136,8 +1139,8 @@ class Fsa(object):
           acceptor [deprecated, prefer to use num_aux_labels]:
             Set to false to denote transducer format (i.e. num_aux_labels == 1).
           num_aux_labels:
-            The number of auxiliary labels to expect on each line (in addition to
-            the 'acceptor' label; is 1 for traditional transducers but can be
+            The number of auxiliary labels to expect on each line (in addition
+            to the 'acceptor' label; is 1 for traditional transducers but can be
             any nonnegative number.
           aux_label_names:
             If provided, must be a list of length >= num_aux_labels.  By default
@@ -1145,14 +1148,15 @@ class Fsa(object):
         '''
         # user should not provide both 'acceptor' and 'num_aux_labels' args.
         if num_aux_labels != 0 and not acceptor:
-            raise ValueError("Both acceptor and num_aux_labels args should not be provided.")
+            raise ValueError("Do not provide both acceptor and "
+                             "num_aux_labels args.");
         if num_aux_labels == 0 and not acceptor:
             num_aux_labels = 1
         arcs, aux_labels = _k2.fsa_from_str(s, num_aux_labels, True)
         ans = Fsa(arcs)
         if aux_labels is not None:
             for i in range(aux_labels.shape[0]):
-                setattr(ans, aux_label_names[i], aux_labels[i,:])
+                setattr(ans, aux_label_names[i], aux_labels[i, :])
         return ans
 
     def set_scores_stochastic_(self, scores) -> None:

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -7,6 +7,7 @@
 from typing import Any
 from typing import Dict
 from typing import Iterator
+from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -1061,19 +1062,15 @@ class Fsa(object):
             raise ValueError(f'Unsupported num_axes: {self.arcs.num_axes()}')
 
     @classmethod
-    def from_str(cls, s: str) -> 'Fsa':
+    def from_str(cls, s: str, num_aux_labels: int = 0,
+                 aux_label_names: List[string] = ['aux_labels', 'aux_labels2', 'aux_labels3']) -> 'Fsa':
         '''Create an Fsa from a string in the k2 format.
         (See also from_openfst).
 
         The given string `s` consists of lines with the following format:
 
-        (1) When it represents an acceptor::
 
-                src_state dest_state label score
-
-        (2) When it represents a transducer::
-
-                src_state dest_state label aux_label score
+          src_state dest_state label [aux_label1 aux_label2...] score
 
         The line for the final state consists of only one field::
 
@@ -1096,19 +1093,21 @@ class Fsa(object):
           s:
             The input string. Refer to the above comment for its format.
         '''
-        # Figure out acceptor/transducer for k2 fsa.
-        acceptor = True
-        line = s.strip().split('\n', 1)[0]
-        fields = line.strip().split()
-        assert len(fields) != 0
-        if len(fields) == 5:
-            acceptor = False
-        arcs, aux_labels = _k2.fsa_from_str(s, acceptor, False)
-        return Fsa(arcs, aux_labels=aux_labels)
+        arcs, aux_labels = _k2.fsa_from_str(s, num_aux_labels, False)
+        ans = Fsa(arcs)
+        if aux_labels != None:
+            for i in range(aux_labels.shape[0]):
+                setattr(ans, aux_label_names[i], aux_labels[i,:])
+
+
+
 
     @classmethod
-    def from_openfst(cls, s: str, acceptor: bool = True) -> 'Fsa':
-        '''Create an Fsa from a string in OpenFST format.
+    def from_openfst(cls, s: str, acceptor: bool = True,
+                     num_aux_labels: int = 0,
+                     aux_label_names: Optional[List[string]] = None)  -> 'Fsa':
+        '''Create an Fsa from a string in OpenFST format (or a slightly
+        more general format, if num_aux_labels > 1).
 
         The given string `s` consists of lines with the following format:
 
@@ -1119,6 +1118,10 @@ class Fsa(object):
         (2) When it represents a transducer::
 
                 src_state dest_state label aux_label score
+
+        (3) When it has additional auxiliary labels (2 aux-labels shown):
+
+                src_state dest_state label aux_label aux_label2 score ..
 
         The line for the final state consists of two fields::
 
@@ -1134,17 +1137,26 @@ class Fsa(object):
         Args:
           s:
             The input string. Refer to the above comment for its format.
-          acceptor:
-            Optional. If true, interpret the input string as an acceptor;
-            otherwise, interpret it as a transducer.
+          acceptor [deprecated, prefer to use num_aux_labels]:
+            Set to false to denote transducer format (i.e. num_aux_labels == 1).
+          num_aux_labels:
+            The number of auxiliary labels to expect on each line (in addition to
+            the 'acceptor' label; is 1 for traditional transducers but can be
+            any nonnegative number.
+          aux_label_names:
+            If provided, must be a list of length >= num_aux_labels.  By default
+            the labels are 'aux_labels', 'aux_labels2', 'aux_labels3' and so on.
         '''
-        line = s.strip().split('\n', 1)[0]
-        fields = line.strip().split()
-        assert len(fields) != 0
-        if len(fields) == 5:
-            acceptor = False
-        arcs, aux_labels = _k2.fsa_from_str(s, acceptor, True)
-        return Fsa(arcs, aux_labels=aux_labels)
+        # user should not provide both 'acceptor' and 'num_aux_labels' args.
+        if num_aux_labels != 0 and not acceptor:
+            raise ValueError("Both acceptor and num_aux_labels args should not be provided.")
+        if num_aux_labels == 0 and not acceptor:
+            num_aux_labels = 1
+        arcs, aux_labels = _k2.fsa_from_str(s, num_aux_labels, True)
+        ans = Fsa(arcs)
+        if aux_labels != None:
+            for i in range(aux_labels.shape[0]):
+                setattr(ans, aux_label_names[i], aux_labels[i,:])
 
     def set_scores_stochastic_(self, scores) -> None:
         '''Normalize the given `scores` and assign it to `self.scores`.

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1063,7 +1063,6 @@ class Fsa(object):
 
     @classmethod
     def from_str(cls, s: str, num_aux_labels: int = 0,
-                 acce
                  aux_label_names: List[str] = ['aux_labels',
                                                'aux_labels2',
                                                'aux_labels3']) -> 'Fsa':
@@ -1101,7 +1100,7 @@ class Fsa(object):
             ans = Fsa(arcs)
             if aux_labels is not None:
                 for i in range(aux_labels.shape[0]):
-                    setattr(ans, aux_label_names[i], aux_labels[i,:])
+                    setattr(ans, aux_label_names[i], aux_labels[i, :])
             return ans
         except Exception:
             raise ValueError(f'The following is not a valid Fsa (with '
@@ -1149,7 +1148,7 @@ class Fsa(object):
         # user should not provide both 'acceptor' and 'num_aux_labels' args.
         if num_aux_labels != 0 and not acceptor:
             raise ValueError("Do not provide both acceptor and "
-                             "num_aux_labels args.");
+                             "num_aux_labels args.")
         if num_aux_labels == 0 and not acceptor:
             num_aux_labels = 1
         arcs, aux_labels = _k2.fsa_from_str(s, num_aux_labels, True)

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1100,12 +1100,11 @@ class Fsa(object):
         acceptor = True
         line = s.strip().split('\n', 1)[0]
         fields = line.strip().split()
-        assert len(fields) == 4 or len(fields) == 5
+        assert len(fields) != 0
         if len(fields) == 5:
             acceptor = False
         arcs, aux_labels = _k2.fsa_from_str(s, acceptor, False)
-        ans = Fsa(arcs, aux_labels=aux_labels)
-        return ans
+        return Fsa(arcs, aux_labels=aux_labels)
 
     @classmethod
     def from_openfst(cls, s: str, acceptor: bool = True) -> 'Fsa':
@@ -1139,6 +1138,11 @@ class Fsa(object):
             Optional. If true, interpret the input string as an acceptor;
             otherwise, interpret it as a transducer.
         '''
+        line = s.strip().split('\n', 1)[0]
+        fields = line.strip().split()
+        assert len(fields) != 0
+        if len(fields) == 5:
+            acceptor = False
         arcs, aux_labels = _k2.fsa_from_str(s, acceptor, True)
         return Fsa(arcs, aux_labels=aux_labels)
 

--- a/k2/python/tests/compose_test.py
+++ b/k2/python/tests/compose_test.py
@@ -24,7 +24,7 @@ class TestCompose(unittest.TestCase):
             2 3 -1 -1 2.5
             3
         '''
-        a_fsa = k2.Fsa.from_str(s).requires_grad_(True)
+        a_fsa = k2.Fsa.from_str(s, num_aux_labels=1).requires_grad_(True)
 
         s = '''
             0 1 1 1 1.0
@@ -33,7 +33,7 @@ class TestCompose(unittest.TestCase):
             2 3 -1 -1 2.0
             3
         '''
-        b_fsa = k2.Fsa.from_str(s).requires_grad_(True)
+        b_fsa = k2.Fsa.from_str(s, num_aux_labels=1).requires_grad_(True)
 
         ans = k2.compose(a_fsa, b_fsa, inner_labels='inner')
         ans = k2.connect(ans)
@@ -73,10 +73,10 @@ class TestCompose(unittest.TestCase):
         '''
 
         # https://git.io/JqN2j
-        fsa1 = k2.Fsa.from_str(s1)
+        fsa1 = k2.Fsa.from_str(s1, num_aux_labels=1)
 
         # https://git.io/JqNaJ
-        fsa2 = k2.Fsa.from_str(s2)
+        fsa2 = k2.Fsa.from_str(s2, num_aux_labels=1)
 
         # https://git.io/JqNaT
         ans = k2.connect(k2.compose(fsa1, fsa2, inner_labels='phones'))
@@ -111,7 +111,7 @@ class TestCompose(unittest.TestCase):
         fsa1.aux_labels = k2.RaggedInt('[[2] [2 4] [5] [3] [2] [-1] [-1]]')
 
         # https://git.io/JqNaJ
-        fsa2 = k2.Fsa.from_str(s2)
+        fsa2 = k2.Fsa.from_str(s2, num_aux_labels = 1)
 
         # https://git.io/JqNon
         ans = k2.connect(k2.compose(fsa1, fsa2, inner_labels='phones'))

--- a/k2/python/tests/compose_test.py
+++ b/k2/python/tests/compose_test.py
@@ -111,7 +111,7 @@ class TestCompose(unittest.TestCase):
         fsa1.aux_labels = k2.RaggedInt('[[2] [2 4] [5] [3] [2] [-1] [-1]]')
 
         # https://git.io/JqNaJ
-        fsa2 = k2.Fsa.from_str(s2, num_aux_labels = 1)
+        fsa2 = k2.Fsa.from_str(s2, num_aux_labels=1)
 
         # https://git.io/JqNon
         ans = k2.connect(k2.compose(fsa1, fsa2, inner_labels='phones'))

--- a/k2/python/tests/ctc_gradients_test.py
+++ b/k2/python/tests/ctc_gradients_test.py
@@ -46,7 +46,7 @@ def build_ctc_topo(tokens: List[int]) -> k2.Fsa:
                 arcs += f'{i} {j} {tokens[j]} {tokens[j]} 0.0\n'
         arcs += f'{i} {final_state} -1 -1 0.0\n'
     arcs += f'{final_state}'
-    ans = k2.Fsa.from_str(arcs)
+    ans = k2.Fsa.from_str(arcs, num_aux_labels=1)
     return ans
 
 

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -143,7 +143,7 @@ class TestFsa(unittest.TestCase):
             self.assertEqual(k2.to_str(fsa1), '')
 
             with self.assertRaises(ValueError):
-                fsa2 = k2.Fsa.from_str(_remove_leading_spaces(s2))
+                fsa2_ = k2.Fsa.from_str(_remove_leading_spaces(s2))
 
             fsa3 = k2.Fsa.from_str(_remove_leading_spaces(s3))
             self.assertEqual(fsa3.arcs.dim0(), 0)
@@ -178,8 +178,6 @@ class TestFsa(unittest.TestCase):
             8
         '''
 
-        print(_remove_leading_spaces(expected_str), " VS. ", _remove_leading_spaces(
-            k2.to_str(fsa, openfst=True)))
         assert _remove_leading_spaces(expected_str) == _remove_leading_spaces(
             k2.to_str(fsa, openfst=True))
 
@@ -229,15 +227,15 @@ class TestFsa(unittest.TestCase):
                 k2.to_str(fsa2)),
                 "1 2 -1 -0.1\n2")
             arcs2 = fsa2.arcs.values()[:, :-1]
-            self.assertTrue(torch.allclose(arcs2,
-                torch.tensor([[1, 2, -1]], dtype=torch.int32)))
+            self.assertTrue(
+                torch.allclose(arcs2,
+                               torch.tensor([[1, 2, -1]], dtype=torch.int32)))
 
             fsa3 = k2.Fsa.from_openfst(_remove_leading_spaces(s3))
             self.assertEqual(fsa3.arcs.dim0(), 4)
             self.assertEqual(_remove_leading_spaces(
                 k2.to_str(fsa3)),
                 "1 3 -1 -0.1\n2 3 -1 -0.2\n3")
-
 
     def test_transducer_from_tensor(self):
         for device in self.devices:

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -143,7 +143,7 @@ class TestFsa(unittest.TestCase):
             self.assertEqual(k2.to_str(fsa1), '')
 
             with self.assertRaises(ValueError):
-                fsa2_ = k2.Fsa.from_str(_remove_leading_spaces(s2))
+                _ = k2.Fsa.from_str(_remove_leading_spaces(s2))
 
             fsa3 = k2.Fsa.from_str(_remove_leading_spaces(s3))
             self.assertEqual(fsa3.arcs.dim0(), 0)

--- a/k2/python/tests/invert_test.py
+++ b/k2/python/tests/invert_test.py
@@ -36,7 +36,7 @@ class TestInvert(unittest.TestCase):
             4 5 -1 -1 0
             5
         '''
-        fsa = k2.Fsa.from_str(s)
+        fsa = k2.Fsa.from_str(s, num_aux_labels=1)
         assert fsa.device.type == 'cpu'
         dest = k2.invert(fsa)
         print(dest)

--- a/k2/python/tests/remove_epsilon_test.py
+++ b/k2/python/tests/remove_epsilon_test.py
@@ -80,7 +80,7 @@ class TestRemoveEpsilonDevice(unittest.TestCase):
             4 5 -1 6 1
             5
         '''
-        fsa = k2.Fsa.from_str(s).to(device)
+        fsa = k2.Fsa.from_str(s, num_aux_labels=1).to(device)
         print(fsa.aux_labels)
         prop = fsa.properties
         self.assertFalse(prop & k2.fsa_properties.EPSILON_FREE)

--- a/k2/python/tests/top_sort_test.py
+++ b/k2/python/tests/top_sort_test.py
@@ -28,7 +28,7 @@ class TestTopSort(unittest.TestCase):
             0 2 2 2
             1 3 -1 3
             2 1 3 4
-            1
+            3
         '''
         fsa = k2.Fsa.from_str(s)
         fsa.requires_grad_(True)


### PR DESCRIPTION
This builds on #611 to support multiple auxiliary labels when reading in FSAs.
Because of interface changes in k2.Fsa.from_str (which I feel were necessary), there is unfortunately
no backward or forward compatibility and we have to 
apply the following update to snowfall:
https://github.com/k2-fsa/snowfall/pull/136