### PR TITLE
Free CUDA memory in a correct way when PYTORCH_NO_CUDA_MEMORY_CACHING is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ endif()
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPERCASE)
 if("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "DEBUG")
+  # refer to https://docs.nvidia.com/cuda/cuda-memcheck/index.html#compilation-options
+  # The two options is for cuda-memcheck' stack backtrace feature more useful.
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -rdynamic --compiler-options -lineinfo")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ elseif(NOT CMAKE_BUILD_TYPE IN_LIST ALLOWABLE_BUILD_TYPES)
     choose one from ${ALLOWABLE_BUILD_TYPES}")
 endif()
 
+string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPERCASE)
+if("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "DEBUG")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -rdynamic --compiler-options -lineinfo")
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BUILD_SHARED_LIBS "Whether to build shared or static lib" ON)
@@ -131,6 +136,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(pybind11)
 if(K2_USE_PYTORCH)
   add_definitions(-DK2_USE_PYTORCH)
+  add_definitions(-DTORCH_API_INCLUDE_EXTENSION_H)
   include(torch)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPERCASE)
 if("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "DEBUG")
   # refer to https://docs.nvidia.com/cuda/cuda-memcheck/index.html#compilation-options
-  # The two options is for cuda-memcheck' stack backtrace feature more useful.
+  # The two options are for cuda-memcheck' stack backtrace feature more useful.
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -rdynamic --compiler-options -lineinfo")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPERCASE)
 if("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "DEBUG")
   # refer to https://docs.nvidia.com/cuda/cuda-memcheck/index.html#compilation-options
-  # The two options are for cuda-memcheck' stack backtrace feature more useful.
+  # The two options are to make cuda-memcheck' stack backtrace feature more useful.
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -rdynamic --compiler-options -lineinfo")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPERCASE)
 if("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "DEBUG")
   # refer to https://docs.nvidia.com/cuda/cuda-memcheck/index.html#compilation-options
-  # The two options are to make cuda-memcheck' stack backtrace feature more useful.
+  # The two options are to make cuda-memcheck's stack backtrace feature more useful.
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -rdynamic --compiler-options -lineinfo")
 endif()
 

--- a/docs/source/_k2.py
+++ b/docs/source/_k2.py
@@ -192,3 +192,10 @@ def _create_fsa_vec():
 
 def _is_rand_equivalent():
     pass
+
+
+class version:
+    build_type = None
+    git_date = None
+    git_sha1 = None
+    __version__ = None

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -190,7 +190,7 @@ can be installed with::
   All you need to do is to setup the ``PYTHONPATH`` environment variable so that
   Python can find where k2 resides.
 
-  k2 contains of two parts. The first part consists of pure Python files that are in
+  k2 contains two parts. The first part consists of pure Python files that are in
   ``k2_source_tree/k2/python/k2``. The second part is the C++ part, which has been
   compiled into a bunch of shared libraries that can be invoked from Python. These
   libraries are saved in `k2_build_tree/build/lib`.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -182,6 +182,41 @@ can be installed with::
 
   You may get a wheel with a different filename.
 
+.. Note::
+
+  [For developers]
+
+  If you are developing k2, you don't need to install k2 to use its Python APIs!
+  All you need to do is to setup the ``PYTHONPATH`` environment variable so that
+  Python can find where k2 resides.
+
+  k2 contains of two parts. The first part consists of pure Python files that are in
+  ``k2_source_tree/k2/python/k2``. The second part is the C++ part, which has been
+  compiled into a bunch of shared libraries that can be invoked from Python. These
+  libraries are saved in `k2_build_tree/build/lib`.
+
+  If you set ``PYTHONPATH`` to the following values:
+
+  .. code-block::
+
+    export PYTHONPATH=/path/to/k2/k2/python:$PYTHONPATH
+    export PYTHONPATH=/path/to/k2/build/lib:$PYTHONPATH
+
+  After ``PYTHONPATH`` is set, you can run:
+
+  .. code-block::
+
+    python3 -m k2.version
+    python3 -c 'import k2; print(k2.__file__)'
+    python3 -c 'import _k2; print(_k2.__file__)'
+
+  Whenver you change some files in ``k2/python/k2``, it comes into effect immediately
+  without uninstalling and installing operations.
+
+  Whenever you modify some `*.cu` files, it is also available after issuing ``make _k2``
+  without any installation effort.
+
+
 To run tests, you have to install the following requirements first::
 
   sudo apt-get install graphviz

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -78,7 +78,9 @@ target_link_libraries(context PUBLIC k2_nvtx)
 target_link_libraries(context PUBLIC moderngpu)
 if(K2_USE_PYTORCH)
   target_link_libraries(context PUBLIC ${TORCH_LIBRARIES})
+  target_link_libraries(context PUBLIC ${TORCH_DIR}/lib/libtorch_python.so)
 endif()
+target_include_directories(context PUBLIC ${PYTHON_INCLUDE_DIRS})
 
 #---------------------------- Test K2 CUDA sources ----------------------------
 

--- a/k2/csrc/array_inl.h
+++ b/k2/csrc/array_inl.h
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 
-#include "cub/cub.cuh"
+#include "k2/csrc/cub.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/utils.h"
 

--- a/k2/csrc/array_ops_inl.h
+++ b/k2/csrc/array_ops_inl.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "cub/cub.cuh"
+#include "k2/csrc/cub.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/moderngpu_allocator.h"
 #include "k2/csrc/utils.h"

--- a/k2/csrc/cub.h
+++ b/k2/csrc/cub.h
@@ -15,7 +15,7 @@
 // for why we need the following two macros
 //
 // NOTE: We define the following two macros so
-// that k2 and PyTorch share a different copy
+// that k2 and PyTorch use a different copy
 // of CUB.
 
 #define CUB_NS_PREFIX namespace k2 {

--- a/k2/csrc/cub.h
+++ b/k2/csrc/cub.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c)  2021  xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ */
+
+#ifndef K2_CSRC_CUB_H_
+#define K2_CSRC_CUB_H_
+
+// See
+// https://github.com/k2-fsa/k2/issues/698
+// and
+// https://github.com/pytorch/pytorch/issues/54245#issuecomment-805707551
+// for why we need the following two macros
+//
+// NOTE: We define the following two macros so
+// that k2 and PyTorch share a different copy
+// of CUB.
+
+#define CUB_NS_PREFIX namespace k2 {
+#define CUB_NS_POSTFIX }
+
+#include "cub/cub.cuh"  // NOLINT
+
+#undef CUB_NS_PREFIX
+#undef CUB_NS_POSTFIX
+
+#endif  // K2_CSRC_CUB_H_

--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -792,7 +792,7 @@ Fsa Closure(Fsa &fsa, Array1<int32_t> *arc_map /* = nullptr*/) {
 
   int32_t num_out_states = num_states;
 
-  // An arc from the start state to the final state with label == 0 is added.
+  // An arc from the start state to the final state with label == -1 is added.
   int32_t num_out_arcs = fsa.values.Dim() + 1;
 
   Array1<int32_t> out_row_ids(c, num_out_arcs);

--- a/k2/csrc/ragged.cu
+++ b/k2/csrc/ragged.cu
@@ -4,10 +4,10 @@
  * See LICENSE for clarification regarding multiple authors
  */
 
-#include <cub/cub.cuh>
 #include <vector>
 
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/cub.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/ragged.h"

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -11,8 +11,8 @@
 #include <memory>
 #include <vector>
 
-#include "cub/cub.cuh"
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/cub.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/moderngpu_allocator.h"

--- a/k2/csrc/ragged_utils.cu
+++ b/k2/csrc/ragged_utils.cu
@@ -4,10 +4,10 @@
  * See LICENSE for clarification regarding multiple authors
  */
 
-#include <cub/cub.cuh>
 #include <vector>
 
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/cub.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/ragged.h"

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -6,8 +6,8 @@
 
 #include <algorithm>
 
-#include "cub/cub.cuh"
 #include "k2/csrc/array_ops.h"
+#include "k2/csrc/cub.h"
 #include "k2/csrc/macros.h"
 #include "k2/csrc/math.h"
 #include "k2/csrc/moderngpu_allocator.h"

--- a/k2/csrc/utils_inl.h
+++ b/k2/csrc/utils_inl.h
@@ -9,10 +9,10 @@
 #define K2_CSRC_UTILS_INL_H_
 
 #include <cassert>
-#include <cub/cub.cuh>  // NOLINT
 #include <type_traits>
 
 #include "k2/csrc/array.h"
+#include "k2/csrc/cub.h"
 
 namespace k2 {
 template <typename SrcPtr, typename DestPtr>

--- a/k2/python/csrc/CMakeLists.txt
+++ b/k2/python/csrc/CMakeLists.txt
@@ -6,19 +6,13 @@ set(k2_srcs
 )
 
 if(K2_USE_PYTORCH)
-  add_definitions(-DTORCH_API_INCLUDE_EXTENSION_H)
   add_subdirectory(torch)
   set(k2_srcs ${k2_srcs} ${torch_srcs})
-  set(k2_deps
-    ${TORCH_LIBRARIES}
-    ${TORCH_DIR}/lib/libtorch_python.so
-  )
 else()
   message(FATAL_ERROR "Please select a framework.")
 endif()
 
 pybind11_add_module(_k2 ${k2_srcs})
-target_link_libraries(_k2 PRIVATE ${k2_deps})
 target_link_libraries(_k2 PRIVATE context)
 target_link_libraries(_k2 PRIVATE fsa)
 target_include_directories(_k2 PRIVATE ${CMAKE_SOURCE_DIR})

--- a/k2/python/k2/ops.py
+++ b/k2/python/k2/ops.py
@@ -267,13 +267,14 @@ def index_tensor(src: torch.Tensor, indexes: Union[torch.Tensor, _k2.RaggedInt]
         or `src.dtype == torch.float32`.
       indexes:
         It satisfies -1 <= indexes.values()[i] < src.numel().
+
         - If it's a tensor, its values will be interpreted as indexes into
-        `src`; if indexes.values()[i] is -1, then ans[i] is 0.
+          `src`; if indexes.values()[i] is -1, then ans[i] is 0.
 
         - If it's a ragged tensor, `indexes.values()` will be interpreted as
-        indexes into `src`. If src.dtype is torch.int32, it returns
-        a _k2.RaggedInt; if src.dtype is torch.float32, it performs an extra
-        sum-per-sublist operation and returns 1-D torch.Tensor.
+          indexes into `src`. If src.dtype is torch.int32, it returns
+          a _k2.RaggedInt; if src.dtype is torch.float32, it performs an extra
+          sum-per-sublist operation and returns 1-D torch.Tensor.
 
     Returns:
       Returns a tensor or a ragged tensor (depending on the type of `indexes`)


### PR DESCRIPTION
Closes #698 

Also 

1. Apply the macro `-DTORCH_API_INCLUDE_EXTENSION_H` globally
2. Add `--compiler-options -rdynamic --compiler-options -lineinfo` for debug build to support `cuda-memcheck`
3. Fix crashes caused by CUB in CUDA 11
---

~Marked as WIP as it needs more test.~