### PR TITLE
Add Fsa.convert_attr_to_ragged_().

### DIFF
--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -883,7 +883,7 @@ FsaOrVec ExpandArcs(FsaOrVec &fsas, RaggedShape &labels_shape,
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   K2_CHECK_EQ(labels_shape.NumAxes(), 2);
   K2_CHECK_EQ(fsas.NumElements(), labels_shape.Dim0());
-  ContextPtr c = fsas.Context();
+  ContextPtr &c = fsas.Context();
   K2_CHECK(c->IsCompatible(*labels_shape.Context()));
 
   RaggedShape state_to_arcs = GetLayer(fsas.shape, 1);

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -553,7 +553,7 @@ Fsa Closure(Fsa &fsa, Array1<int32_t> *arc_map = nullptr);
    @return  Returns the expanded Fsa or FsaVec (will satisfy
                         `ans.NumAxes() == fsas.NumAxes()`, and will be
                         equivalent to `fsas` in both tropical or log-sum
-                        semring.
+                        semiring.
  */
 FsaOrVec ExpandArcs(FsaOrVec &fsas, RaggedShape &labels_shape,
                     Array1<int32_t> *fsas_arc_map = nullptr,

--- a/k2/csrc/ragged.h
+++ b/k2/csrc/ragged.h
@@ -26,6 +26,14 @@ namespace k2 {
 // Note: row_splits is of size num_rows + 1 and row_ids is of size
 // num_elements.
 struct RaggedShapeLayer {
+  RaggedShapeLayer() = default;
+
+  RaggedShapeLayer(const RaggedShapeLayer &) = default;
+  RaggedShapeLayer& operator=(const RaggedShapeLayer &) = default;
+
+  RaggedShapeLayer(RaggedShapeLayer &&) = default;
+  RaggedShapeLayer& operator=(RaggedShapeLayer &&) = default;
+
   // Search for "row_splits concept" in utils.h for explanation.  row_splits
   // is required; it must always be nonempty for a RaggedShapeLayer to be valid.
   Array1<int32_t> row_splits;
@@ -178,10 +186,11 @@ class RaggedShape {
   // are populated
   void Populate();
 
-  RaggedShape(const RaggedShape &other) = default;
-  // Move constructor
-  RaggedShape(RaggedShape &&other) : layers_(std::move(other.layers_)) {}
-  RaggedShape &operator=(const RaggedShape &other) = default;
+  RaggedShape(const RaggedShape &) = default;
+  RaggedShape &operator=(const RaggedShape &) = default;
+
+  RaggedShape(RaggedShape &&) = default;
+  RaggedShape &operator=(RaggedShape &&) = default;
 
   // Layers() is intended for internal-ish use; users shouldn't really have to
   // interact with it.


### PR DESCRIPTION
Related to https://github.com/k2-fsa/snowfall/pull/166#discussion_r615519499

> I think it would be more elegant to make this a function invoked like den_graphs.convert_attr_to_ragged('aux_labels', remove_eps=True).
I imagine this will still have [-1] on the final-arcs, which is probably what we want
as the num graphs likely have this.