### PR TITLE
Fix compilation errors of some unit test

### DIFF
--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(context PUBLIC moderngpu)
 if(K2_USE_PYTORCH)
   target_link_libraries(context PUBLIC ${TORCH_LIBRARIES})
   target_link_libraries(context PUBLIC ${TORCH_DIR}/lib/libtorch_python.so)
+  target_link_libraries(context PUBLIC ${PYTHON_LIBRARY})
 endif()
 target_include_directories(context PUBLIC ${PYTHON_INCLUDE_DIRS})
 


### PR DESCRIPTION
when make -j after make _k2, got:
```
[ 70%] Building CUDA object k2/csrc/CMakeFiles/cu_pinned_context_test.dir/pinned_context_test.cu.o
[ 71%] Building CUDA object k2/csrc/CMakeFiles/cu_ragged_shape_test.dir/ragged_shape_test.cu.o
[ 72%] Linking CUDA device code CMakeFiles/cu_nvtx_test.dir/cmake_device_link.o
[ 72%] Linking CUDA executable ../../bin/cu_nvtx_test
/search/speech/wangjiawen/anaconda2/envs/python37/lib/python3.7/site-packages/torch/lib/libtorch_python.so: undefined reference to `PyUnicode_InternFromString'
......
/search/speech/wangjiawen/anaconda2/envs/python37/lib/python3.7/site-packages/torch/lib/libtorch_python.so: undefined reference to `PyCode_Addr2Line'
collect2: error: ld returned 1 exit status
make[2]: *** [k2/csrc/CMakeFiles/cu_nvtx_test.dir/build.make:162: bin/cu_nvtx_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2135: k2/csrc/CMakeFiles/cu_nvtx_test.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

```
PyUnicode_InternFromString is from libpython
some other unit test binary got similar error

Fix after this commit