### PR TITLE
Add `allow_truncate` to DenseFsaVec.__init__

### DIFF
--- a/k2/csrc/intersect_dense.cu
+++ b/k2/csrc/intersect_dense.cu
@@ -993,6 +993,6 @@ void IntersectDense(FsaVec &a_fsas, DenseFsaVec &b_fsas,
 
   intersector.Intersect();
   FsaVec ret = intersector.FormatOutput(arc_map_a, arc_map_b);
-  *out = ret;
+  *out = std::move(ret);
 }
 }  // namespace k2

--- a/k2/python/k2/dense_fsa_vec.py
+++ b/k2/python/k2/dense_fsa_vec.py
@@ -117,18 +117,22 @@ class DenseFsaVec(object):
                                  dtype=torch.int32)
         row_splits[1:] = torch.tensor(last_frame_indexes) + 1
 
+        # minus one to exclude the fake row [0, -inf, -inf, ...]
+        self._duration = row_splits[1:] - row_splits[:-1] - 1
+
         row_splits = row_splits.to(device)
         self.dense_fsa_vec = _k2.DenseFsaVec(scores, row_splits)
         self.scores = scores  # for back propagation
 
     @property
     def duration(self) -> torch.Tensor:
-        '''Return the duration of each seq.
+        '''Return the duration (on CPU) of each seq.
         '''
         if not hasattr(self, '_duration'):
             row_splits = self.dense_fsa_vec.shape().row_splits(1)
             # minus one to exclude the fake row [0, -inf, -inf, ...]
-            self._duration = row_splits[1:] - row_splits[:-1] - 1
+            duration = row_splits[1:] - row_splits[:-1] - 1
+            self._duration = duration.cpu()
         return self._duration
 
     @classmethod

--- a/k2/python/k2/dense_fsa_vec.py
+++ b/k2/python/k2/dense_fsa_vec.py
@@ -29,8 +29,10 @@ class DenseFsaVec(object):
     # correspond to the final-arcs in the FSAs; the 0 corresponds to
     # symbol -1.)
 
-    def __init__(self, log_probs: torch.Tensor,
-                 supervision_segments: torch.Tensor) -> None:
+    def __init__(self,
+                 log_probs: torch.Tensor,
+                 supervision_segments: torch.Tensor,
+                 allow_truncate: int = 0) -> None:
         '''Construct a DenseFsaVec from neural net log-softmax outputs.
 
         Args:
@@ -47,7 +49,7 @@ class DenseFsaVec(object):
             segment.
 
             Note:
-              - `0 < start_frame + duration <= T`
+              - `0 < start_frame + duration <= T + allow_truncate`
               - `0 <= start_frame < T`
               - `duration > 0`
 
@@ -55,12 +57,16 @@ class DenseFsaVec(object):
               The last column, i.e., the duration column, has to be sorted
               in **decreasing** order. That is, the first supervision_segment
               (the first row) has the largest duration.
+          allow_truncate:
+            If not zero, it truncates at most this number of frames from
+            duration in case start_frame + duration > T.
         '''
         assert log_probs.ndim == 3
         assert log_probs.dtype == torch.float32
         assert supervision_segments.ndim == 2
         assert supervision_segments.dtype == torch.int32
         assert supervision_segments.device.type == 'cpu'
+        assert allow_truncate >= 0
 
         N, T, C = log_probs.shape
 
@@ -72,17 +78,21 @@ class DenseFsaVec(object):
         indexes = []
         last_frame_indexes = []
         cur = 0
-        for segment in supervision_segments:
-            segment_index, start_frame, duration = segment.tolist()
+        for segment in supervision_segments.tolist():
+            segment_index, start_frame, duration = segment
             assert 0 <= segment_index < N
             assert 0 <= start_frame < T
             assert duration > 0
-            assert start_frame + duration <= T
+            assert start_frame + duration <= T + allow_truncate
             offset = segment_index * T
-            indexes.append(
-                torch.arange(start_frame, start_frame + duration) + offset)
+            end_frame = min(start_frame + duration, T)  # exclusive
+
+            # update duration if it's too large
+            duration = end_frame - start_frame
+
+            indexes.append(torch.arange(start_frame, end_frame) + offset)
             indexes.append(placeholder)
-            cur += duration
+            cur += duration  # NOTE: the duration may be updated above
             last_frame_indexes.append(cur)
             cur += 1  # increment for the extra row
 
@@ -106,9 +116,19 @@ class DenseFsaVec(object):
                                  device='cpu',
                                  dtype=torch.int32)
         row_splits[1:] = torch.tensor(last_frame_indexes) + 1
+        # minus one to exclude the fake row [0, -inf, -inf, ...]
+        duration = row_splits[1:] - row_splits[:-1] - 1
+
         row_splits = row_splits.to(device)
         self.dense_fsa_vec = _k2.DenseFsaVec(scores, row_splits)
         self.scores = scores  # for back propagation
+        self._duration = duration.to(device)
+
+    @property
+    def duration(self) -> torch.Tensor:
+        '''Return the duration of each seq.
+        '''
+        return self._duration
 
     @classmethod
     def _from_dense_fsa_vec(cls, dense_fsa_vec: _k2.DenseFsaVec,

--- a/k2/python/tests/dense_fsa_vec_test.py
+++ b/k2/python/tests/dense_fsa_vec_test.py
@@ -41,14 +41,13 @@ class TestDenseFsaVec(unittest.TestCase):
             dense_fsa_vec = k2.DenseFsaVec(log_prob, supervision_segments)
             assert dense_fsa_vec.dim0() == 5, 'It should contain 5 segments'
             assert dense_fsa_vec.device == device
+            assert dense_fsa_vec.duration.device == torch.device('cpu')
             assert torch.all(
-                torch.eq(dense_fsa_vec.duration.cpu(),
-                         supervision_segments[:, 2]))
+                torch.eq(dense_fsa_vec.duration, supervision_segments[:, 2]))
 
             del dense_fsa_vec._duration
             assert torch.all(
-                torch.eq(dense_fsa_vec.duration.cpu(),
-                         supervision_segments[:, 2]))
+                torch.eq(dense_fsa_vec.duration, supervision_segments[:, 2]))
 
             assert torch.allclose(dense_fsa_vec.scores[:3, 1:],
                                   log_prob[0][0:3])
@@ -89,8 +88,7 @@ class TestDenseFsaVec(unittest.TestCase):
                                            supervision_segments,
                                            allow_truncate=3)
             assert torch.all(
-                torch.eq(dense_fsa_vec.duration,
-                         torch.tensor([3, 1, 2, 4], device=device)))
+                torch.eq(dense_fsa_vec.duration, torch.tensor([3, 1, 2, 4])))
 
             assert torch.allclose(dense_fsa_vec.scores[:3, 1:],
                                   log_prob[0][0:3])

--- a/k2/python/tests/dense_fsa_vec_test.py
+++ b/k2/python/tests/dense_fsa_vec_test.py
@@ -45,6 +45,11 @@ class TestDenseFsaVec(unittest.TestCase):
                 torch.eq(dense_fsa_vec.duration.cpu(),
                          supervision_segments[:, 2]))
 
+            del dense_fsa_vec._duration
+            assert torch.all(
+                torch.eq(dense_fsa_vec.duration.cpu(),
+                         supervision_segments[:, 2]))
+
             assert torch.allclose(dense_fsa_vec.scores[:3, 1:],
                                   log_prob[0][0:3])
 

--- a/k2/python/tests/dense_fsa_vec_test.py
+++ b/k2/python/tests/dense_fsa_vec_test.py
@@ -16,87 +16,91 @@ import torch
 
 class TestDenseFsaVec(unittest.TestCase):
 
-    def test_dense_fsa_vec_cpu(self):
-        log_prob = torch.arange(20).reshape(2, 5, 2).to(torch.float32)
-        supervision_segments = torch.tensor([
-            # seq_index, start_time, duration
-            [0, 0, 3],
-            [0, 1, 4],
-            [1, 0, 2],
-            [0, 2, 3],
-            [1, 3, 2],
-        ]).to(torch.int32)
-
-        dense_fsa_vec = k2.DenseFsaVec(log_prob, supervision_segments)
-        assert dense_fsa_vec.dim0() == 5, 'It should contain 5 segments'
-        assert dense_fsa_vec.is_cpu()
+    @classmethod
+    def setUpClass(cls):
+        cls.devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            dense_fsa_vec_cuda = dense_fsa_vec.to('cuda:0')
-            assert dense_fsa_vec_cuda.is_cuda()
-        print(dense_fsa_vec)
-        print(log_prob)
-        # TODO(fangjun): Let the computer check the output
-        '''
-        num_axes: 2
-        device_type: kCpu
-        row_splits1: [ 0 4 9 12 16 19 ]
-        row_ids1: [ 0 0 0 0 1 1 1 1 1 2 2 2 3 3 3 3 4 4 4 ]
-        scores:
-        [[ -inf 0 1 ]
-        [ -inf 2 3 ]
-        [ -inf 4 5 ]
-        [ 0 -inf -inf ]
-        [ -inf 2 3 ]
-        [ -inf 4 5 ]
-        [ -inf 6 7 ]
-        [ -inf 8 9 ]
-        [ 0 -inf -inf ]
-        [ -inf 10 11 ]
-        [ -inf 12 13 ]
-        [ 0 -inf -inf ]
-        [ -inf 4 5 ]
-        [ -inf 6 7 ]
-        [ -inf 8 9 ]
-        [ 0 -inf -inf ]
-        [ -inf 16 17 ]
-        [ -inf 18 19 ]
-        [ 0 -inf -inf ]
-        ]
+            cls.devices.append(torch.device('cuda', 0))
 
-        tensor([[[ 0.,  1.],
-                 [ 2.,  3.],
-                 [ 4.,  5.],
-                 [ 6.,  7.],
-                 [ 8.,  9.]],
+    def test_dense_fsa_vec(self):
+        for device in self.devices:
+            log_prob = torch.arange(20, dtype=torch.float32,
+                                    device=device).reshape(
+                                        2, 5, 2).log_softmax(dim=-1)
+            supervision_segments = torch.tensor(
+                [
+                    # seq_index, start_time, duration
+                    [0, 0, 3],
+                    [0, 1, 4],
+                    [1, 0, 2],
+                    [0, 2, 3],
+                    [1, 3, 2],
+                ],
+                dtype=torch.int32)
 
-                [[10., 11.],
-                 [12., 13.],
-                 [14., 15.],
-                 [16., 17.],
-                 [18., 19.]]])
-        '''
+            dense_fsa_vec = k2.DenseFsaVec(log_prob, supervision_segments)
+            assert dense_fsa_vec.dim0() == 5, 'It should contain 5 segments'
+            assert dense_fsa_vec.device == device
+            assert torch.all(
+                torch.eq(dense_fsa_vec.duration.cpu(),
+                         supervision_segments[:, 2]))
 
-    def test_dense_fsa_vec_cuda(self):
-        if not torch.cuda.is_available():
-            return
-        log_prob = torch.arange(20).reshape(2, 5, 2).to(torch.float32)
-        supervision_segments = torch.tensor([
-            [0, 0, 3],
-            [0, 1, 4],
-            [1, 0, 2],
-            [0, 2, 3],
-            [1, 3, 2],
-        ]).to(torch.int32)
+            assert torch.allclose(dense_fsa_vec.scores[:3, 1:],
+                                  log_prob[0][0:3])
 
-        log_prob = log_prob.to('cuda:0')
+            offset = 3 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 4, 1:],
+                                  log_prob[0][1:5])
 
-        dense_fsa_vec = k2.DenseFsaVec(log_prob, supervision_segments)
-        assert dense_fsa_vec.dim0() == 5, 'It should contain 5 segments'
-        assert dense_fsa_vec.is_cuda()
-        cpu_dense_fsa_vec = dense_fsa_vec.to('cpu')
-        assert cpu_dense_fsa_vec.is_cpu()
-        print(dense_fsa_vec)
-        print(log_prob)
+            offset += 4 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 2, 1:],
+                                  log_prob[1][0:2])
+
+            offset += 2 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 3, 1:],
+                                  log_prob[0][2:5])
+
+            offset += 3 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 2, 1:],
+                                  log_prob[1][3:5])
+
+    def test_duration(self):
+        for device in self.devices:
+            log_prob = torch.arange(20, dtype=torch.float32,
+                                    device=device).reshape(
+                                        2, 5, 2).log_softmax(dim=-1)
+
+            supervision_segments = torch.tensor(
+                [
+                    # seq_index, start_time, duration
+                    [0, 0, 3],
+                    [0, 4, 2],  # exceed 1
+                    [0, 3, 4],  # exceed 2
+                    [1, 1, 7],  # exceed 3
+                ],
+                dtype=torch.int32)
+
+            dense_fsa_vec = k2.DenseFsaVec(log_prob,
+                                           supervision_segments,
+                                           allow_truncate=3)
+            assert torch.all(
+                torch.eq(dense_fsa_vec.duration,
+                         torch.tensor([3, 1, 2, 4], device=device)))
+
+            assert torch.allclose(dense_fsa_vec.scores[:3, 1:],
+                                  log_prob[0][0:3])
+
+            offset = 3 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 1, 1:],
+                                  log_prob[0][4:5])
+
+            offset += 1 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 2, 1:],
+                                  log_prob[0][3:5])
+
+            offset += 2 + 1
+            assert torch.allclose(dense_fsa_vec.scores[offset:offset + 4, 1:],
+                                  log_prob[1][1:5])
 
 
 if __name__ == '__main__':

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -26,7 +26,7 @@ class TestFsa(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.devices = [torch.device("cpu")]
+        cls.devices = [torch.device('cpu')]
         if torch.cuda.is_available():
             cls.devices.append(torch.device('cuda', 0))
 


### PR DESCRIPTION
See https://github.com/k2-fsa/snowfall/pull/181#discussion_r623684445

> I think the easiest way to resolve this would be to add an option with default:
> `allow_truncate=0`
> to `DenseFsaVec.__init__()` in k2, so it would truncate the last few frames from a segment if necessary to
> make it fit within the nnet output; we could set this to 2 or 3, for instance. It seems to me that this
> would be very easy to implement. The only thing that would not be quite right is in mmi.py where we do:
> 
> ```
>         tot_score, tot_frames, all_frames = get_tot_objf_and_num_frames(
>             tot_scores,
>             supervision_segments[:, 2]
>         )
> ```
> 
> supervision_segments[:, 2] may not have quite the right lengths. But we could easily add a member function to the
> DenseFsaVec object in Python, that would provide the correct length (e.g. we could save something in the constructor, to avoid an extra GPU->CPU transfer).

---

Ready for review.