### PR TITLE
Fix installing conda packages

### DIFF
--- a/scripts/conda-cpu/cpuonly/meta.yaml
+++ b/scripts/conda-cpu/cpuonly/meta.yaml
@@ -1,0 +1,10 @@
+# this file is copied from
+# https://github.com/pytorch/builder/tree/master/conda/cpuonly
+package:
+  name: cpuonly
+  version: 1.0
+
+build:
+  track_features:
+      - cpuonly
+  noarch: generic

--- a/scripts/conda-cpu/k2/meta.yaml
+++ b/scripts/conda-cpu/k2/meta.yaml
@@ -18,6 +18,8 @@ build:
     - K2_CMAKE_ARGS
     - K2_MAKE_ARGS
   script: conda install -y -q -c pytorch pytorch={{ environ.get('K2_TORCH_VERSION') }} cpuonly & {{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt
+  features:
+    - cpuonly # [not osx]
 
 requirements:
   build:
@@ -30,11 +32,10 @@ requirements:
     - python
     - pytorch={{ environ.get('K2_TORCH_VERSION') }}
     - gcc_linux-64=7 # [linux]
-    - cpuonly # to install CPU version of PyTorch
+    - cpuonly
   run:
     - python
     - pytorch={{ environ.get('K2_TORCH_VERSION') }}
-    - cpuonly
 
 about:
   home: https://github.com/k2-fsa/k2


### PR DESCRIPTION
This pull request fixes the default behavior of installing k2 with conda.

## CUDA
```
conda install -c conda-forge -c pytorch -c k2-fsa k2
```
 installs a CUDA version by default.

## CPU
```
conda install -c conda-forge -c pytorch -c k2-fsa k2 cpuonly
```
installs a CPU version if `cpuonly` is provided.

---

@pzelasko 
Please try again. Sorry for the inconvenience.