### PR TITLE
WIP: Support compiling k2 with CUDA on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ execute_process(COMMAND
 )
 
 execute_process(COMMAND
-  "${GIT_EXECUTABLE}" log -1 --format=%ad --date=local
+  "${GIT_EXECUTABLE}" log -1 --format=%ad --date=format:"%F %T %z"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE K2_GIT_DATE
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -203,7 +203,8 @@ if(K2_WITH_CUDA)
 # set(K2_COMPUTE_ARCHS 30 32 35 50 52 53 60 61 62 70 72)
   message(WARNING "arch 62/72 are not supported for now")
 
-  set(K2_COMPUTE_ARCH_CANDIDATES 35 50 60 61 70 75)
+  #set(K2_COMPUTE_ARCH_CANDIDATES 35 50 60 61 70 75)
+  set(K2_COMPUTE_ARCH_CANDIDATES 70)
   set(K2_COMPUTE_ARCHS)
 
   foreach(COMPUTE_ARCH IN LISTS K2_COMPUTE_ARCH_CANDIDATES)
@@ -246,6 +247,14 @@ if(K2_USE_PYTORCH)
   include(torch)
 endif()
 
+if(WIN32)
+  add_definitions(-DK2_IS_WINDOWS)
+
+  # See http://www.suodenjoki.dk/us/archive/2010/min-max.htm
+  # for why we need to define `-DNOMINMAX`
+  add_definitions(-DNOMINMAX)
+endif()
+
 if(K2_WITH_CUDA)
   add_definitions(-DK2_WITH_CUDA)
 endif()
@@ -262,8 +271,13 @@ endif()
 include(googletest)
 
 if(K2_WITH_CUDA)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -Wall --compiler-options -Wno-unknown-pragmas --compiler-options -Wno-strict-overflow")
-  message(STATUS "CMAKE_CUDA_FLAGS: ${CMAKE_CUDA_FLAGS}")
+  if(NOT WIN32)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -Wall --compiler-options -Wno-unknown-pragmas --compiler-options -Wno-strict-overflow")
+    message(STATUS "CMAKE_CUDA_FLAGS: ${CMAKE_CUDA_FLAGS}")
+  endif()
+  if(WIN32)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
+  endif()
 endif()
 
 if(NOT K2_WITH_CUDA AND NOT WIN32)
@@ -291,9 +305,13 @@ if(WIN32)
   # 4005: macro redefinition
   # 4722: destructor never returns
   # 4018: signed/unsigned mismatch
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4068 /wd4996 /wd4224 /wd4099 /wd4267 /wd4305 /wd4244 /wd4624 /wd4551 /wd4067 /wd4819 /wd4005 /wd4722 /wd4018")
+
+  set(disable_warnings "/wd4068 /wd4996 /wd4224 /wd4099 /wd4267 /wd4305 /wd4244 /wd4624 /wd4551 /wd4067 /wd4819 /wd4005 /wd4722 /wd4018")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${disable_warnings}")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=\"${disable_warnings}\"")
 endif()
 
-message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-
 add_subdirectory(k2)
+
+message(STATUS "CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS}")
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/cmake/moderngpu.cmake
+++ b/cmake/moderngpu.cmake
@@ -15,6 +15,7 @@ function(download_moderngpu)
   FetchContent_Declare(moderngpu
     URL               ${moderngpu_URL}
     URL_HASH          ${moderngpu_HASH}
+    PATCH_COMMAND     git init && git apply ${CMAKE_CURRENT_LIST_DIR}/moderngpu.patch
   )
 
   FetchContent_GetProperties(moderngpu)

--- a/cmake/moderngpu.patch
+++ b/cmake/moderngpu.patch
@@ -1,0 +1,49 @@
+diff --git a/src/moderngpu/meta.hxx b/src/moderngpu/meta.hxx
+index d386b6c..f7660eb 100644
+--- a/src/moderngpu/meta.hxx
++++ b/src/moderngpu/meta.hxx
+@@ -141,15 +141,6 @@ struct conditional_typedef_t {
+ ////////////////////////////////////////////////////////////////////////////////
+ // Code to treat __restrict__ as a CV qualifier.
+ 
+-template<typename arg_t>
+-struct is_restrict {
+-  enum { value = false };
+-};
+-template<typename arg_t>
+-struct is_restrict<arg_t __restrict__> {
+-  enum { value = true };
+-};
+-
+ // Add __restrict__ only to pointers.
+ template<typename arg_t>
+ struct add_restrict {
+@@ -160,15 +151,6 @@ struct add_restrict<arg_t*> {
+   typedef arg_t* __restrict__ type;
+ };
+ 
+-template<typename arg_t>
+-struct remove_restrict {
+-  typedef arg_t type;
+-};
+-template<typename arg_t>
+-struct remove_restrict<arg_t __restrict__> {
+-  typedef arg_t type;
+-};
+-
+ template<typename arg_t>
+ MGPU_HOST_DEVICE typename add_restrict<arg_t>::type make_restrict(arg_t x) {
+   typename add_restrict<arg_t>::type y = x;
+diff --git a/src/moderngpu/tuple.hxx b/src/moderngpu/tuple.hxx
+index 2e381f5..1111c3a 100644
+--- a/src/moderngpu/tuple.hxx
++++ b/src/moderngpu/tuple.hxx
+@@ -253,7 +253,7 @@ struct tuple : detail::tuple_impl<0, args_t...> {
+     >::type
+   > MGPU_HOST_DEVICE  
+   tuple(const args2_t&... args) : impl_t(args...) { }
+-} __attribute__((aligned));
++};
+ 
+ namespace detail {
+ 

--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -39,6 +39,22 @@ target_include_directories(k2_nvtx INTERFACE ${CMAKE_SOURCE_DIR})
 if(K2_ENABLE_NVTX)
   target_compile_definitions(k2_nvtx INTERFACE K2_ENABLE_NVTX=1)
 endif()
+if(WIN32 AND K2_WITH_CUDA)
+  # On windows, it throws an error:
+  #   fatal error C1083: Cannot open include file: 'nvToolsExt.h'
+  message(STATUS "CUDA_TOOLKIT_ROOT_DIR: ${CUDA_TOOLKIT_ROOT_DIR}")
+  find_path(K2_NVTX_INCLUDE_DIR
+    NAMES nvToolsExt.h
+    PATHS ${CUDA_TOOLKIT_ROOT_DIR}/include
+    PATH_SUFFIXES nvtx nvtx2 nvtx3 nvtx4
+  )
+  if(NOT K2_NVTX_INCLUDE_DIR)
+    message(FATAL_ERROR "The include dir for nvToolsExt.h" cannot be found)
+  else()
+    message(STATUS "K2_NVTX_INCLUDE_DIR: ${K2_NVTX_INCLUDE_DIR}")
+    target_include_directories(k2_nvtx INTERFACE ${K2_NVTX_INCLUDE_DIR})
+  endif()
+endif()
 
 add_subdirectory(host)
 

--- a/k2/csrc/host/CMakeLists.txt
+++ b/k2/csrc/host/CMakeLists.txt
@@ -26,11 +26,17 @@ target_link_libraries(fsa PUBLIC k2_log)
 target_link_libraries(fsa PUBLIC k2_nvtx)
 target_include_directories(fsa PUBLIC ${CUDA_TOOLKIT_INCLUDE})
 if(K2_ENABLE_NVTX)
-  target_link_libraries(fsa
-    PUBLIC
-      -L${CUDA_TOOLKIT_ROOT_DIR}/lib64  # for /usr/local/cuda
-      -L${CUDA_TOOLKIT_ROOT_DIR}/lib  # for conda
-    nvToolsExt)
+  if(NOT WIN32)
+    # For Windows, the library is not called libnvToolsExt.so
+    #
+    # NVCC on windows can pass the correct lib to the commandline
+    # automatically, so we put a guard here.
+    target_link_libraries(fsa
+      PUBLIC
+        -L${CUDA_TOOLKIT_ROOT_DIR}/lib64  # for /usr/local/cuda
+        -L${CUDA_TOOLKIT_ROOT_DIR}/lib  # for conda
+      nvToolsExt)
+  endif()
 endif()
 
 #---------------------------- Test K2 host sources ----------------------------

--- a/k2/csrc/host/fsa.h
+++ b/k2/csrc/host/fsa.h
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include "k2/csrc/types.h"
+
 #include "k2/csrc/host/array.h"
 #include "k2/csrc/host/util.h"
 

--- a/k2/csrc/log.cu
+++ b/k2/csrc/log.cu
@@ -26,6 +26,7 @@ namespace k2 {
 
 namespace internal {
 
+#ifdef K2_HAVE_CXXABI_H
 static bool LocateSymbolRange(const std::string &trace_name, std::size_t *begin,
                               std::size_t *end) {
   // Find the first '_' with leading ' ' or '('.
@@ -45,6 +46,7 @@ static bool LocateSymbolRange(const std::string &trace_name, std::size_t *begin,
   *end = trace_name.find_first_of(" +", *begin);
   return *end != std::string::npos;
 }
+#endif
 
 #ifdef K2_HAVE_EXECINFO_H
 static std::string Demangle(const std::string &trace_name) {

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -402,8 +402,11 @@ inline void GetOldAndNewOffsets(RaggedShape &src,
   ExclusiveSum(*new_offsets, new_offsets);
 }
 
-static RaggedShape IndexAxis0(RaggedShape &src, const Array1<int32_t> &new2old,
-                              Array1<int32_t> *elem_indexes /*=nullptr*/) {
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ RaggedShape IndexAxis0(RaggedShape &src,
+                                  const Array1<int32_t> &new2old,
+                                  Array1<int32_t> *elem_indexes /*=nullptr*/) {
   NVTX_RANGE(K2_FUNC);
   ContextPtr &c = src.Context();
   bool is_cpu = (c->GetDeviceType() == kCpu);
@@ -661,8 +664,10 @@ void GetRowInfoMulti(int32_t num_srcs, RaggedShape **src,
   *row_ids = row_ids_ptrs.To(ctx);
 }
 
-static RaggedShape StackAxis0(int32_t num_srcs, RaggedShape **src,
-                              Array1<uint32_t> *merge_map /* == nullptr*/) {
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ RaggedShape StackAxis0(int32_t num_srcs, RaggedShape **src,
+                                  Array1<uint32_t> *merge_map /* == nullptr*/) {
   NVTX_RANGE(K2_FUNC);
   if (num_srcs == 1) {
     if (merge_map)
@@ -1163,8 +1168,10 @@ static Array1<int32_t> GetTransposeReorderingCpu(Ragged<int32_t> &src,
   return ans;
 }
 
-static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
-                                                           int32_t num_cols) {
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ Array1<int32_t> GetTransposeReorderingThreeAxesCuda(
+    Ragged<int32_t> &src, int32_t num_cols) {
   NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(src.NumAxes(), 3);
   ContextPtr &context = src.Context();
@@ -1208,7 +1215,6 @@ static Array1<int32_t> GetTransposeReorderingThreeAxesCuda(Ragged<int32_t> &src,
                                          lambda_comp, *mgpu_context));
   return ans;
 }
-
 
 /*
 // Checks the result of GetTranspoeReordering(), in debug mode and dies if it is wrong.

--- a/k2/csrc/rm_epsilon.cu
+++ b/k2/csrc/rm_epsilon.cu
@@ -57,7 +57,9 @@ namespace k2 {
     @param [out] epsilon_closure_mapped_arc_map  The arc map from
                        `epsilon_closure_mapped` to `src`.
 */
-static void GetEpsilonClosureMapped(
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ void GetEpsilonClosureMapped(
     FsaVec &epsilon_fsa_closure,
     const Array1<int32_t> &epsilon_closure_state_map,
     Ragged<int32_t> &epsilon_closure_arc_map, FsaVec &non_epsilon_fsa,
@@ -127,7 +129,9 @@ static void GetEpsilonClosureMapped(
                        foll_shape.RowSplits(1)[i] is the number of following
                        arcs it is combined with.
 */
-static void DecideCombineWithFollowingOrPreceding(
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ void DecideCombineWithFollowingOrPreceding(
     FsaVec &epsilon_closure_mapped, FsaVec &non_epsilon_fsa,
     Renumbering *epsilon_prec_renumbering, RaggedShape *foll_shape) {
   NVTX_RANGE(K2_FUNC);
@@ -225,7 +229,9 @@ static void DecideCombineWithFollowingOrPreceding(
      @param [out] combined_foll_arc_map The arc map of `combined_foll`, from
                        arcs idx012 in `combined_foll` to the original Fsa.
 */
-static void CombineWithFollowingNonEpsilonArcs(
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ void CombineWithFollowingNonEpsilonArcs(
     FsaVec &epsilon_closure_mapped,
     Ragged<int32_t> &epsilon_closure_mapped_arc_map, FsaVec &non_epsilon_fsa,
     const Array1<int32_t> &non_epsilon_arc_map, RaggedShape &foll_shape,
@@ -329,7 +335,9 @@ static void CombineWithFollowingNonEpsilonArcs(
                        `epsilon_closure_prec_arc_map`, user will get the
                        complete arc map info for `combined_prec`.
 */
-static void CombineWithPrecedingNonEpsilonArcs(
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ void CombineWithPrecedingNonEpsilonArcs(
     FsaVec &epsilon_closure_prec, Ragged<int32_t> &epsilon_closure_prec_arc_map,
     FsaVec &non_epsilon_fsa, FsaVec *combined_prec,
     Ragged<int32_t> *epsilon_closure_prec_arc_map_prec,

--- a/k2/csrc/tensor.h
+++ b/k2/csrc/tensor.h
@@ -34,7 +34,7 @@ class Shape {
     return strides_[i];
   }
 
-  int32_t NumElements() const { return num_elements_; }
+  int32_t NumElements() const { return static_cast<int32_t>(num_elements_); }
   // storage size in elements
 
   std::vector<int32_t> Dims() const {

--- a/k2/csrc/tensor_ops.cu
+++ b/k2/csrc/tensor_ops.cu
@@ -19,11 +19,14 @@
 
 namespace k2 {
 
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
 template <typename T>
-static void CopyTensorElements2d(ContextPtr c, int32_t dim0, int32_t dim1,
-                                 const T *src_data, int32_t src_stride0,
-                                 int32_t src_stride1, T *dest_data,
-                                 int32_t dest_stride0, int32_t dest_stride1) {
+/*static*/ void CopyTensorElements2d(ContextPtr c, int32_t dim0, int32_t dim1,
+                                     const T *src_data, int32_t src_stride0,
+                                     int32_t src_stride1, T *dest_data,
+                                     int32_t dest_stride0,
+                                     int32_t dest_stride1) {
   NVTX_RANGE(K2_FUNC);
   DeviceType d = c->GetDeviceType();
   if (d == kCpu) {
@@ -131,11 +134,15 @@ Tensor Cast(Tensor src, Dtype new_dtype) {
 }
 
 // See the documentation of `Index`.
+//
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
 template <typename T>
-static void Index1DImpl(ContextPtr context, const T *src_data,
-                        int32_t src_stride, int32_t src_dim,
-                        const int32_t *indexes_data, bool allow_minus_one,
-                        int32_t ans_dim, T *ans_data, double default_value) {
+/*static*/ void Index1DImpl(ContextPtr context, const T *src_data,
+                            int32_t src_stride, int32_t src_dim,
+                            const int32_t *indexes_data, bool allow_minus_one,
+                            int32_t ans_dim, T *ans_data,
+                            double default_value) {
   if (std::is_integral<T>::value) {
     K2_CHECK_EQ(static_cast<T>(default_value), default_value);
   }
@@ -165,11 +172,15 @@ static void Index1DImpl(ContextPtr context, const T *src_data,
 }
 
 // See the documentation of `Index`.
+//
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
 template <typename T>
-static void Index2DImpl(ContextPtr context, const T *src_data,
-                        int32_t src_stride, int32_t src_dim0, int32_t src_dim1,
-                        const int32_t *indexes_data, bool allow_minus_one,
-                        int32_t ans_dim, int32_t ans_stride, T *ans_data) {
+/*static*/ void Index2DImpl(ContextPtr context, const T *src_data,
+                            int32_t src_stride, int32_t src_dim0,
+                            int32_t src_dim1, const int32_t *indexes_data,
+                            bool allow_minus_one, int32_t ans_dim,
+                            int32_t ans_stride, T *ans_data) {
   NVTX_RANGE(K2_FUNC);
   if (allow_minus_one) {
     if (context->GetDeviceType() == kCpu) {
@@ -298,8 +309,10 @@ Tensor Index(Tensor &src, Array1<int32_t> &indexes, bool allow_minus_one,
   }
 }
 
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
 template <typename T>
-static void IndexAdd1DImpl(ContextPtr context, const T *src_data,
+/*static*/ void IndexAdd1DImpl(ContextPtr context, const T *src_data,
                            int32_t src_dim, int32_t src_stride,
                            const int32_t *indexes_data, bool allow_minus_one,
                            int32_t dest_dim, int32_t dest_stride,
@@ -329,8 +342,10 @@ static void IndexAdd1DImpl(ContextPtr context, const T *src_data,
       });
 }
 
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
 template <typename T>
-static void IndexAdd2DImpl(ContextPtr context, const T *src_data,
+/*static*/ void IndexAdd2DImpl(ContextPtr context, const T *src_data,
                            int32_t src_dim0, int32_t src_dim1,
                            int32_t src_stride0, int32_t src_stride1,
                            const int32_t *indexes_data, bool allow_minus_one,
@@ -360,7 +375,9 @@ static void IndexAdd2DImpl(ContextPtr context, const T *src_data,
       });
 }
 
-static void IndexAdd1D(Tensor &src, Array1<int32_t> &indexes,
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
+/*static*/ void IndexAdd1D(Tensor &src, Array1<int32_t> &indexes,
                        bool allow_minus_one, Tensor *dest) {
   NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(src.NumAxes(), 1);
@@ -436,8 +453,10 @@ void IndexAdd(Tensor &src, Array1<int32_t> &indexes, bool allow_minus_one,
   }
 }
 
+// the static modifier causes an error on Windows for the enclosing lambda
+// since it has an internal linkage
 template <typename T>
-static void SimpleRaggedIndexSelect1DImpl(ContextPtr context, const T *src_data,
+/*static*/ void SimpleRaggedIndexSelect1DImpl(ContextPtr context, const T *src_data,
                                           int32_t src_stride, int32_t src_dim,
                                           Ragged<int32_t> &indexes,
                                           int32_t ans_dim, T *ans_data) {

--- a/k2/csrc/types.h
+++ b/k2/csrc/types.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ *                      
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ *
+ * The following environment variables are related to logging:
+ *
+ *  K2_LOG_LEVEL
+ *    - If it is not set, the default log level is INFO.
+ *      That is, only messages logged with
+ *          LOG(INFO), LOG(WARNING), LOG(ERROR) and LOG(FATAL)
+ *      get printed.
+ *    - Set it to "TRACE" to get all log message being printed
+ *    - Set it to "FATAL" to print only FATAL messages
+ */
+
+#ifndef K2_CSRC_TYPES_H_
+#define K2_CSRC_TYPES_H_
+
+#ifdef _MSC_VER
+// See https://docs.microsoft.com/en-us/cpp/cpp/int8-int16-int32-int64
+using uint16_t = unsigned __int16;
+using uint32_t = unsigned __int32;
+using uint64_t = unsigned __int64;
+
+using int16_t = __int16;
+using int32_t = __int32;
+using int64_t = __int64;
+#else
+#include <cstdint>
+#endif
+
+#endif  // K2_CSRC_TYPES_H_

--- a/k2/csrc/types.h
+++ b/k2/csrc/types.h
@@ -3,17 +3,6 @@
  *                      
  *
  * See LICENSE for clarification regarding multiple authors
- *
- *
- * The following environment variables are related to logging:
- *
- *  K2_LOG_LEVEL
- *    - If it is not set, the default log level is INFO.
- *      That is, only messages logged with
- *          LOG(INFO), LOG(WARNING), LOG(ERROR) and LOG(FATAL)
- *      get printed.
- *    - Set it to "TRACE" to get all log message being printed
- *    - Set it to "FATAL" to print only FATAL messages
  */
 
 #ifndef K2_CSRC_TYPES_H_

--- a/k2/csrc/version.h.in
+++ b/k2/csrc/version.h.in
@@ -21,59 +21,59 @@
 namespace k2 {
 
 // Version of k2 in "major.minor.patch" format
-static constexpr const char *kVersion = "@K2_VERSION@";
+static constexpr const char *kVersion = R"k2(@K2_VERSION@)k2";
 
 // The commit used to build k2
-static constexpr const char *kGitSha1 = "@K2_GIT_SHA1@";
+static constexpr const char *kGitSha1 = R"k2(@K2_GIT_SHA1@)k2";
 
 // Date of the commit used to build k2
-static constexpr const char *kGitDate = "@K2_GIT_DATE@";
+static constexpr const char *kGitDate = R"k2(@K2_GIT_DATE@)k2";
 
 // Version of CUDA used to build k2.
 // Its format is "major.minor", e.g., 10.1
-static constexpr const char *kCudaVersion = "@CUDA_VERSION@";
+static constexpr const char *kCudaVersion = R"k2(@CUDA_VERSION@)k2";
 
 // cuDNN version, e.g., 8.0.2
-static constexpr const char *kCudnnVersion = "@CUDNN_VERSION@";
+static constexpr const char *kCudnnVersion = R"k2(@CUDNN_VERSION@)k2";
 
 // clang-format off
 // Version of Python used to build k2 Python bindings.
-static constexpr const char *kPythonVersion = "@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@";
+static constexpr const char *kPythonVersion = R"k2(@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@)k2";
 
 // clang-format on
 
 // CMake build type, e.g., Release or Debug.
-static constexpr const char *kBuildType = "@CMAKE_BUILD_TYPE@";
+static constexpr const char *kBuildType = R"k2(@CMAKE_BUILD_TYPE@)k2";
 
 // The operating system that is used to build k2, e.g., Ubuntu 16.04 LTS
-static constexpr const char *kOS = "@K2_OS@";
+static constexpr const char *kOS = R"k2(@K2_OS@)k2";
 
 // e.g., 3.18.0
-static constexpr const char *kCMakeVersion = "@CMAKE_VERSION@";
+static constexpr const char *kCMakeVersion = R"k2(@CMAKE_VERSION@)k2";
 
 // Version of the compiler, e.g., 5.4.0
-static constexpr const char *kGCCVersion = "@CMAKE_CXX_COMPILER_VERSION@";
+static constexpr const char *kGCCVersion = R"k2(@CMAKE_CXX_COMPILER_VERSION@)k2";
 
 // CUDA flags used to compile k2
-static constexpr const char *kCMakeCudaFlags = "@CMAKE_CUDA_FLAGS@";
+static constexpr const char *kCMakeCudaFlags = R"k2(@CMAKE_CUDA_FLAGS@)k2";
 
 // CXX flags used to compile k2
-static constexpr const char *kCMakeCxxFlags = "@CMAKE_CXX_FLAGS@";
+static constexpr const char *kCMakeCxxFlags = R"k2(@CMAKE_CXX_FLAGS@)k2";
 
 // Which PyTorch version k2 is using, e.g., 1.6.0+cu101
-static constexpr const char *kTorchVersion = "@TORCH_VERSION@";
+static constexpr const char *kTorchVersion = R"k2(@TORCH_VERSION@)k2";
 
 // Which CUDA version PyTorch is using, e.g., 10.1
-static constexpr const char *kTorchCudaVersion = "@TORCH_CUDA_VERSION@";
+static constexpr const char *kTorchCudaVersion = R"k2(@TORCH_CUDA_VERSION@)k2";
 
 #ifndef K2_WITH_CUDA
 #cmakedefine K2_WITH_CUDA
 #endif
 
 #ifdef K2_WITH_CUDA
-  static constexpr bool kWithCuda = true;
+static constexpr bool kWithCuda = true;
 #else
-  static constexpr bool kWithCuda = false;
+static constexpr bool kWithCuda = false;
 #endif
 
 // Indicate whether NVTX is enabled or not

--- a/k2/python/csrc/CMakeLists.txt
+++ b/k2/python/csrc/CMakeLists.txt
@@ -19,8 +19,23 @@ if(NOT K2_WITH_CUDA)
   transform(OUTPUT_VARIABLE k2_srcs SRCS ${k2_srcs})
 endif()
 
+if(MSVC AND K2_WITH_CUDA)
+  # The `/bigobj` option is passed to NVCC and results in the following error:
+  # nvcc fatal   : A single input file is required for a non-link phase when an outputfile is specified
+  #
+  # We remove it here
+  get_property(old_flags TARGET pybind11::windows_extras PROPERTY INTERFACE_COMPILE_OPTIONS)
+  string(REPLACE "/bigobj" "" new_flags ${old_flags})
+  set_property(TARGET pybind11::windows_extras PROPERTY INTERFACE_COMPILE_OPTIONS ${new_flags})
+endif()
+
 pybind11_add_module(_k2 ${k2_srcs} SHARED)
 target_link_libraries(_k2 PRIVATE context)
 target_link_libraries(_k2 PRIVATE fsa)
 target_include_directories(_k2 PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(_k2 PRIVATE ${CMAKE_BINARY_DIR})
+
+if(K2_WITH_CUDA)
+  set_target_properties(_k2 PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+endif()
+

--- a/k2/python/csrc/torch/fsa.cu
+++ b/k2/python/csrc/torch/fsa.cu
@@ -458,8 +458,10 @@ static void PybindBackpropGetArcPost(py::module &m, const char *name) {
    @param [in] tot_scores_grad  The gradient of total scores.
    @return It returns the gradient of scores of all arcs.
  */
+// The static modifier causes error on Windows when compiled
+// with NVCC because there is a lambda function inside it
 template <typename T>
-static torch::Tensor GetTotScoresTropicalBackward(
+/*static*/ torch::Tensor GetTotScoresTropicalBackward(
     FsaVec &fsas, const Ragged<int32_t> &best_path_arc_indexes,
     torch::Tensor tot_scores_grad) {
   DeviceGuard guard(fsas.Context());
@@ -507,10 +509,11 @@ static torch::Tensor GetTotScoresTropicalBackward(
    @param [in] tot_scores_grad  The gradient of total scores.
    @return It returns the gradient of scores of all arcs.
  */
+// The static modifier causes error on Windows when compiled
+// with NVCC because there is a lambda function inside it
 template <typename T>
-static torch::Tensor GetTotScoresLogBackward(FsaVec &fsas,
-                                             torch::Tensor arc_post,
-                                             torch::Tensor tot_scores_grad) {
+/*static*/ torch::Tensor GetTotScoresLogBackward(
+    FsaVec &fsas, torch::Tensor arc_post, torch::Tensor tot_scores_grad) {
   DeviceGuard guard(fsas.Context());
   K2_CHECK_EQ(fsas.NumAxes(), 3);
   K2_CHECK_EQ(fsas.NumElements(), arc_post.numel());

--- a/k2/python/csrc/torch/fsa_algo.cu
+++ b/k2/python/csrc/torch/fsa_algo.cu
@@ -453,7 +453,7 @@ static void PybindRemoveEpsilonSelfLoops(py::module &m) {
       py::arg("src"), py::arg("need_arc_map") = true);
 }
 
-static void PybindExpandArcs(py::module &m) {
+/*static*/ void PybindExpandArcs(py::module &m) {
   // See doc-string below.
   m.def(
       "expand_arcs",

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -126,8 +126,9 @@ static void PybindNormalizePerSublist(py::module &m, const char *name) {
                         (out.NumElements(),).
  */
 template <typename T>
-static torch::Tensor NormalizePerSublistBackward(Ragged<T> &out, bool use_log,
-                                                 torch::Tensor out_grad) {
+/*static*/ torch::Tensor NormalizePerSublistBackward(Ragged<T> &out,
+                                                     bool use_log,
+                                                     torch::Tensor out_grad) {
   NVTX_RANGE(K2_FUNC);
   DeviceGuard guard(out.Context());
   K2_CHECK_EQ(out_grad.dim(), 1)
@@ -358,7 +359,7 @@ void PybindRaggedOps(py::module &m) {
   PybindNormalizePerSublistBackward<float>(m, "normalize_per_sublist_backward");
   PybindOpPerSublist<float>(m, SumPerSublist<float>, "sum_per_sublist");
   PybindCat<int32_t>(m);
-  PybindCat<Arc>(m);
+  PybindCat<k2::Arc>(m);
   PybindCreateRagged2<int32_t>(m);
   PybindCreateRagged2<float>(m);
   PybindGetLayer(m);

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,8 @@ class BuildExtension(build_ext):
             cmake_args += f' -DPYTHON_EXECUTABLE={sys.executable}'
 
         if is_windows():
+            if '-G' not in cmake_args:
+                cmake_args += ' -G "Visual Studio 15 2017 Win64"'
             build_cmd = f'''
                 cmake {cmake_args} -B {self.build_temp} -S {k2_dir}
                 cmake --build {self.build_temp} --target _k2 --config Release -- -m


### PR DESCRIPTION
This pull request attempts to support compiling k2 with CUDA on Windows.

The only **compile-time** error that remains is the following one:

<img width="1356" alt="Screen Shot 2021-06-04 at 3 55 54 PM" src="https://user-images.githubusercontent.com/5284924/120767071-6c983480-c54d-11eb-8e80-8e0f38566bd2.png">

It is caused by moderngpu.

The call relationships are:

(1) https://github.com/k2-fsa/k2/blob/05e309f7f83971db523cfe9015f04c8f4ee2b9b3/k2/csrc/ragged_ops.cu#L1204-L1208
(2)
https://github.com/moderngpu/moderngpu/blob/2b3985541c8e88a133769598c406c33ddde9d0a5/src/moderngpu/kernel_segsort.hxx#L434

```cpp
// Key-only segmented sort
template<typename launch_arg_t = empty_t, typename key_t, typename seg_it, 
  typename comp_t>
void segmented_sort(key_t* keys, int count, seg_it segments, 
  int num_segments, comp_t comp, context_t& context) {

  segmented_sort<launch_arg_t>(keys, (empty_t*)nullptr, count,
    segments, num_segments, comp, context);
}
```

(3) https://github.com/moderngpu/moderngpu/blob/master/src/moderngpu/kernel_segsort.hxx#L409

```cpp
// Key-value mergesort.
template<typename launch_arg_t = empty_t, typename key_t, typename val_t,
  typename seg_it, typename comp_t>
void segmented_sort(key_t* keys, val_t* vals, int count, seg_it segments, 
  int num_segments, comp_t comp, context_t& context) {

  detail::segsort_t<launch_arg_t, key_t, val_t, comp_t> 
    segsort(keys, vals, count, comp, context);

  segsort.blocksort_segments(keys, vals, segments, num_segments);
  segsort.merge_passes();
}
```

(4) https://github.com/moderngpu/moderngpu/blob/2b3985541c8e88a133769598c406c33ddde9d0a5/src/moderngpu/kernel_segsort.hxx#L74

```cpp
  template<bool sort_indices = false, typename keys_it, typename vals_it, 
    typename segments_it>
  void blocksort_segments(keys_it keys, vals_it vals, segments_it segments, 
    int num_segments) {

   ... ... ...

  cta_transform<launch_t>(blocksort_k, count, context);
  ... ... 
}
```

(5) https://github.com/moderngpu/moderngpu/blob/2b3985541c8e88a133769598c406c33ddde9d0a5/src/moderngpu/transform.hxx#L35

```cpp
template<typename launch_box, typename func_t, typename... args_t>
void cta_transform(func_t f, int count, context_t& context, args_t... args) {
  cta_dim_t cta = launch_box::cta_dim(context.ptx_version());
  int num_ctas = div_up(count, cta.nv());
  cta_launch<launch_box>(f, num_ctas, context, args...);
}
```

(6) https://github.com/moderngpu/moderngpu/blob/2b3985541c8e88a133769598c406c33ddde9d0a5/src/moderngpu/transform.hxx#L15

```cpp
template<typename launch_box, typename func_t, typename... args_t>
void cta_launch(func_t f, int num_ctas, context_t& context, args_t... args) { 
   .... ... .. .. 
  if(num_ctas)
    launch_box_cta_k<launch_box, func_t>
      <<<grid_dim, cta.nt, 0, context.stream()>>>(f, num_ctas, args...);
}
```

It is the above kernel call that causes the compile-time error.

The kernel is defined as
https://github.com/moderngpu/moderngpu/blob/2b3985541c8e88a133769598c406c33ddde9d0a5/src/moderngpu/launch_params.hxx#L76

```cpp
// Generic thread cta kernel.
template<typename launch_box, typename func_t, typename... args_t>
__global__ MGPU_LAUNCH_BOUNDS(launch_box)
void launch_box_cta_k(func_t f, int num_ctas, args_t... args) {
  // Masking threadIdx.x by (nt - 1) may help strength reduction because the
  // compiler now knows the range of tid: (0, nt).
  typedef typename launch_box::sm_ptx params_t;
  int tid = (int)(threadIdx.x % (unsigned)params_t::nt);
  int cta = blockIdx.x;

#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 300
  cta += gridDim.x * blockIdx.y;
#endif

  detail::restrict_forward(f, tid, cta, num_ctas, make_restrict(args)...);
}
```

I've no idea why it fails to compile.

@galv Could you provide any help for this?