### PR TITLE
Fix a bug that cmake disable CUDA support when nvcc is not in PATH bu…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(languages CXX)
 set(_K2_WITH_CUDA ON)
 
 find_program(K2_HAS_NVCC nvcc)
-if(NOT K2_HAS_NVCC)
+if(NOT K2_HAS_NVCC AND "$ENV{CUDACXX}" STREQUAL "")
   message(STATUS "No NVCC detected. Disable CUDA support")
   set(_K2_WITH_CUDA OFF)
 endif()


### PR DESCRIPTION
When cmake, if nvcc is not in PATH but specified CUDACXX, it will set K2_USE_CUDA=OFF.
build will be success but some macros ran wrongly:
```
#ifdef K2_WITH_CUDA
#define K2_CHECK_CUDA_ERROR(x) \
  K2_CHECK_EQ(x, cudaSuccess) << " Error: " << cudaGetErrorString(x) << ". "
#else
#define K2_CHECK_CUDA_ERROR(...) K2_LOG(FATAL) << "Don't call me"
#endif
```
run anything with cuda would got:
```
[F] /search/odin/wangjiawen/k2_latest/k2/csrc/device_guard.h:54:static int32_t k2::DeviceGuard::GetDevice() Don't call me