### PR TITLE
Convert license header to "proper" Apache 2 license header.

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # refer to https://github.com/actions/starter-workflows/pull/47/files
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2020  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # refer to https://github.com/actions/starter-workflows/pull/47/files
 

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (author: Fangjun Kuang)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # refer to https://github.com/actions/starter-workflows/pull/47/files
 

--- a/.github/workflows/build_conda_cpu.yml
+++ b/.github/workflows/build_conda_cpu.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (author: Fangjun Kuang)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # refer to https://github.com/actions/starter-workflows/pull/47/files
 

--- a/.github/workflows/nightly-cpu.yml
+++ b/.github/workflows/nightly-cpu.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: nightly-cpu
 

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: nightly-windows
 

--- a/.github/workflows/run-tests-cpu.yml
+++ b/.github/workflows/run-tests-cpu.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # refer to https://github.com/actions/starter-workflows/pull/47/files
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2020  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # refer to https://github.com/actions/starter-workflows/pull/47/files
 

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2020  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: style_check
 

--- a/.github/workflows/windows-conda.yml
+++ b/.github/workflows/windows-conda.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 name: build-windows-conda

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,18 @@
-# Copyright (c)  2021  Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
 
 # See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 name: build-windows

--- a/cmake/cub.cmake
+++ b/cmake/cub.cmake
@@ -1,5 +1,17 @@
-# Copyright (c) 2020 Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright     2020 Fangjun Kuang (csukuangfj@gmail.com)
 # See ../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function(download_cub)
   if(CMAKE_VERSION VERSION_LESS 3.11)

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -1,5 +1,17 @@
-# Copyright (c) 2020 Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright     2020 Fangjun Kuang (csukuangfj@gmail.com)
 # See ../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function(download_googltest)
   if(CMAKE_VERSION VERSION_LESS 3.11)

--- a/cmake/moderngpu.cmake
+++ b/cmake/moderngpu.cmake
@@ -1,5 +1,17 @@
-# Copyright (c)  2020  Mobvoi AI Lab, Beijing, China (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi AI Lab, Beijing, China (authors: Fangjun Kuang)
 # See ../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function(download_moderngpu)
   if(CMAKE_VERSION VERSION_LESS 3.11)

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -1,5 +1,17 @@
-# Copyright (c) 2020 Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright     2020 Fangjun Kuang (csukuangfj@gmail.com)
 # See ../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function(download_pybind11)
   if(CMAKE_VERSION VERSION_LESS 3.11)

--- a/cmake/transform.cmake
+++ b/cmake/transform.cmake
@@ -1,5 +1,17 @@
-# Copyright (c) 2021 Fangjun Kuang (csukuangfj@gmail.com)
+# Copyright     2021 Fangjun Kuang (csukuangfj@gmail.com)
 # See ../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This function is used to copy foo.cu to foo.cc
 # Usage:

--- a/k2/csrc/algorithms.cu
+++ b/k2/csrc/algorithms.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/algorithms.h
+++ b/k2/csrc/algorithms.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_ALGORITHMS_H_

--- a/k2/csrc/algorithms_test.cu
+++ b/k2/csrc/algorithms_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/array.h
+++ b/k2/csrc/array.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_ARRAY_H_

--- a/k2/csrc/array_inl.h
+++ b/k2/csrc/array_inl.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_ARRAY_INL_H_

--- a/k2/csrc/array_ops.cu
+++ b/k2/csrc/array_ops.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/array_ops.h
+++ b/k2/csrc/array_ops.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_ARRAY_OPS_H_

--- a/k2/csrc/array_ops_inl.h
+++ b/k2/csrc/array_ops_inl.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_ARRAY_OPS_INL_H_

--- a/k2/csrc/array_ops_test.cu
+++ b/k2/csrc/array_ops_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu, Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu, Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/array_test.cu
+++ b/k2/csrc/array_test.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/benchmark/array_ops_benchmark.cu
+++ b/k2/csrc/benchmark/array_ops_benchmark.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdlib>

--- a/k2/csrc/benchmark/benchmark.cu
+++ b/k2/csrc/benchmark/benchmark.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include <ctime>
 #include <iostream>

--- a/k2/csrc/benchmark/benchmark.h
+++ b/k2/csrc/benchmark/benchmark.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_BENCHMARK_BENCHMARK_H_

--- a/k2/csrc/benchmark/ragged_ops_benchmark.cu
+++ b/k2/csrc/benchmark/ragged_ops_benchmark.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdlib>

--- a/k2/csrc/benchmark/tensor_ops_benchmark.cu
+++ b/k2/csrc/benchmark/tensor_ops_benchmark.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdlib>

--- a/k2/csrc/context.cu
+++ b/k2/csrc/context.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (author: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/csrc/context.h"

--- a/k2/csrc/context.h
+++ b/k2/csrc/context.h
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu
  *                                                   Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_CONTEXT_H_

--- a/k2/csrc/cub.h
+++ b/k2/csrc/cub.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2021  xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/k2/csrc/cudpp/cudpp.cu
+++ b/k2/csrc/cudpp/cudpp.cu
@@ -1,9 +1,21 @@
 /**
  * k2/csrc/cudpp/cudpp.cu
  *
- * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 // This file is modified from CUDPP. The code style is kept

--- a/k2/csrc/cudpp/cudpp.h
+++ b/k2/csrc/cudpp/cudpp.h
@@ -1,9 +1,21 @@
 /**
  * k2/csrc/cudpp/cudpp.h
  *
- * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_CUDPP_CUDPP_H_

--- a/k2/csrc/default_context.cu
+++ b/k2/csrc/default_context.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdlib>

--- a/k2/csrc/device_guard.h
+++ b/k2/csrc/device_guard.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_DEVICE_GUARD_H_

--- a/k2/csrc/dtype.cu
+++ b/k2/csrc/dtype.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/csrc/dtype.h"

--- a/k2/csrc/dtype.h
+++ b/k2/csrc/dtype.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_DTYPE_H_

--- a/k2/csrc/dtype_test.cu
+++ b/k2/csrc/dtype_test.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/eval.h
+++ b/k2/csrc/eval.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_EVAL_H_

--- a/k2/csrc/fake_cuda.h
+++ b/k2/csrc/fake_cuda.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 // This file is used to compile k2 for CPU only

--- a/k2/csrc/fsa.h
+++ b/k2/csrc/fsa.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *                      Guoguo Chen
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_FSA_H_

--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_FSA_ALGO_H_

--- a/k2/csrc/fsa_algo_test.cu
+++ b/k2/csrc/fsa_algo_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <limits>

--- a/k2/csrc/fsa_test.cu
+++ b/k2/csrc/fsa_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Guoguo Chen
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifdef K2_WITH_CUDA

--- a/k2/csrc/fsa_utils.h
+++ b/k2/csrc/fsa_utils.h
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Guoguo Chen
  *                      Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_FSA_UTILS_H_

--- a/k2/csrc/fsa_utils_test.cu
+++ b/k2/csrc/fsa_utils_test.cu
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Guoguo Chen
  *                      Xiaomi Corporation (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/hash.cu
+++ b/k2/csrc/hash.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/csrc/hash.h"

--- a/k2/csrc/hash.h
+++ b/k2/csrc/hash.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HASH_H_

--- a/k2/csrc/hash_test.cu
+++ b/k2/csrc/hash_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "gtest/gtest.h"

--- a/k2/csrc/host/arcsort.h
+++ b/k2/csrc/host/arcsort.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_ARCSORT_H_

--- a/k2/csrc/host/array.h
+++ b/k2/csrc/host/array.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_ARRAY_H_

--- a/k2/csrc/host/aux_labels.h
+++ b/k2/csrc/host/aux_labels.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_AUX_LABELS_H_

--- a/k2/csrc/host/connect.h
+++ b/k2/csrc/host/connect.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_CONNECT_H_

--- a/k2/csrc/host/dense_fsa.h
+++ b/k2/csrc/host/dense_fsa.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_DENSE_FSA_H_

--- a/k2/csrc/host/determinize.h
+++ b/k2/csrc/host/determinize.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_DETERMINIZE_H_

--- a/k2/csrc/host/determinize_impl.h
+++ b/k2/csrc/host/determinize_impl.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_DETERMINIZE_IMPL_H_

--- a/k2/csrc/host/fsa.h
+++ b/k2/csrc/host/fsa.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_FSA_H_

--- a/k2/csrc/host/fsa_equivalent.h
+++ b/k2/csrc/host/fsa_equivalent.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdint>

--- a/k2/csrc/host/fsa_renderer.h
+++ b/k2/csrc/host/fsa_renderer.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <string>

--- a/k2/csrc/host/fsa_util.h
+++ b/k2/csrc/host/fsa_util.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_FSA_UTIL_H_

--- a/k2/csrc/host/intersect.h
+++ b/k2/csrc/host/intersect.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_INTERSECT_H_

--- a/k2/csrc/host/properties.h
+++ b/k2/csrc/host/properties.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_PROPERTIES_H_

--- a/k2/csrc/host/rmepsilon.h
+++ b/k2/csrc/host/rmepsilon.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_RMEPSILON_H_

--- a/k2/csrc/host/topsort.h
+++ b/k2/csrc/host/topsort.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_TOPSORT_H_

--- a/k2/csrc/host/util.h
+++ b/k2/csrc/host/util.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_UTIL_H_

--- a/k2/csrc/host/weights.h
+++ b/k2/csrc/host/weights.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_WEIGHTS_H_

--- a/k2/csrc/host_shim.cu
+++ b/k2/csrc/host_shim.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <limits>

--- a/k2/csrc/host_shim.h
+++ b/k2/csrc/host_shim.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_HOST_SHIM_H_

--- a/k2/csrc/host_shim_test.cu
+++ b/k2/csrc/host_shim_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/intersect.cu
+++ b/k2/csrc/intersect.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifdef K2_WITH_CUDA

--- a/k2/csrc/intersect_dense.cu
+++ b/k2/csrc/intersect_dense.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <limits>

--- a/k2/csrc/intersect_dense_pruned.cu
+++ b/k2/csrc/intersect_dense_pruned.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/intersect_test.cu
+++ b/k2/csrc/intersect_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation    (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation    (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/log.cu
+++ b/k2/csrc/log.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * Stack trace related stuff is from kaldi.
  * Refer to

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (authors: Meixu Song)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  *
  * The following environment variables are related to logging:

--- a/k2/csrc/log_test.cu
+++ b/k2/csrc/log_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_MACROS_H_

--- a/k2/csrc/macros_test.cu
+++ b/k2/csrc/macros_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/math.cu
+++ b/k2/csrc/math.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <string.h>  // strncmp

--- a/k2/csrc/math.h
+++ b/k2/csrc/math.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_MATH_H_

--- a/k2/csrc/math_test.cu
+++ b/k2/csrc/math_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "gtest/gtest.h"

--- a/k2/csrc/moderngpu.h
+++ b/k2/csrc/moderngpu.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_MODERNGPU_H_

--- a/k2/csrc/moderngpu_allocator.cu
+++ b/k2/csrc/moderngpu_allocator.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <mutex>  // NOLINT

--- a/k2/csrc/moderngpu_allocator.h
+++ b/k2/csrc/moderngpu_allocator.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_MODERNGPU_ALLOCATOR_H_

--- a/k2/csrc/nvtx.h
+++ b/k2/csrc/nvtx.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #ifndef K2_CSRC_NVTX_H_
 #define K2_CSRC_NVTX_H_

--- a/k2/csrc/nvtx_test.cu
+++ b/k2/csrc/nvtx_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  *
  * Test for NVTX.

--- a/k2/csrc/pinned_context.cu
+++ b/k2/csrc/pinned_context.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <string.h>  // memcpy

--- a/k2/csrc/pinned_context_test.cu
+++ b/k2/csrc/pinned_context_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "gtest/gtest.h"

--- a/k2/csrc/pytorch_context.cu
+++ b/k2/csrc/pytorch_context.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <memory>

--- a/k2/csrc/pytorch_context.h
+++ b/k2/csrc/pytorch_context.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_PYTORCH_CONTEXT_H_

--- a/k2/csrc/pytorch_context_test.cu
+++ b/k2/csrc/pytorch_context_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "c10/cuda/CUDAFunctions.h"

--- a/k2/csrc/ragged.cu
+++ b/k2/csrc/ragged.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <vector>

--- a/k2/csrc/ragged.h
+++ b/k2/csrc/ragged.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_H_

--- a/k2/csrc/ragged_inl.h
+++ b/k2/csrc/ragged_inl.h
@@ -2,11 +2,23 @@
  *
  * This is to be included only from ragged_ops.h.
  *
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_INL_H_

--- a/k2/csrc/ragged_ops.cu
+++ b/k2/csrc/ragged_ops.cu
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Yiming Wang
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020-2021  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020-2021  Xiaomi Corporation (authors: Daniel Povey
  *                                                        Haowen Qiu
  *                                                        Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_OPS_H_

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_OPS_INL_H_

--- a/k2/csrc/ragged_shape_test.cu
+++ b/k2/csrc/ragged_shape_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/ragged_tensor_ops.h
+++ b/k2/csrc/ragged_tensor_ops.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_TENSOR_OPS_H_

--- a/k2/csrc/ragged_test.cu
+++ b/k2/csrc/ragged_test.cu
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Yiming Wang
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/ragged_utils.cu
+++ b/k2/csrc/ragged_utils.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <vector>

--- a/k2/csrc/ragged_utils.h
+++ b/k2/csrc/ragged_utils.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_UTILS_H_

--- a/k2/csrc/ragged_utils_inl.h
+++ b/k2/csrc/ragged_utils_inl.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAGGED_UTILS_INL_H_

--- a/k2/csrc/ragged_utils_test.cu
+++ b/k2/csrc/ragged_utils_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu, Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu, Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/rand.cu
+++ b/k2/csrc/rand.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cmath>

--- a/k2/csrc/rand.h
+++ b/k2/csrc/rand.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RAND_H_

--- a/k2/csrc/rand_test.cu
+++ b/k2/csrc/rand_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "gtest/gtest.h"

--- a/k2/csrc/rm_epsilon.cu
+++ b/k2/csrc/rm_epsilon.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <limits>

--- a/k2/csrc/rm_epsilon.h
+++ b/k2/csrc/rm_epsilon.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_RM_EPSILON_H_

--- a/k2/csrc/rm_epsilon_test.cu
+++ b/k2/csrc/rm_epsilon_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation    (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation    (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/semaphore.h
+++ b/k2/csrc/semaphore.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_SEMAPHORE_H_

--- a/k2/csrc/tensor.cu
+++ b/k2/csrc/tensor.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/tensor.h
+++ b/k2/csrc/tensor.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_TENSOR_H_

--- a/k2/csrc/tensor_ops_test.cu
+++ b/k2/csrc/tensor_ops_test.cu
@@ -1,7 +1,19 @@
 /**
-// Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang, Haowen Qiu)
+// Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/tensor_test.cu
+++ b/k2/csrc/tensor_test.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/csrc/test_utils.cu
+++ b/k2/csrc/test_utils.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/test_utils.h
+++ b/k2/csrc/test_utils.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_TEST_UTILS_H_

--- a/k2/csrc/thread_pool.cu
+++ b/k2/csrc/thread_pool.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <utility>

--- a/k2/csrc/thread_pool.h
+++ b/k2/csrc/thread_pool.h
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #ifndef K2_CSRC_THREAD_POOL_H_
 #define K2_CSRC_THREAD_POOL_H_

--- a/k2/csrc/thread_pool_test.cu
+++ b/k2/csrc/thread_pool_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/timer.cu
+++ b/k2/csrc/timer.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <chrono>  // NOLINT

--- a/k2/csrc/timer.h
+++ b/k2/csrc/timer.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_TIMER_H_

--- a/k2/csrc/top_sort.cu
+++ b/k2/csrc/top_sort.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <limits>

--- a/k2/csrc/top_sort_test.cu
+++ b/k2/csrc/top_sort_test.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/k2/csrc/utils.cu
+++ b/k2/csrc/utils.cu
@@ -1,7 +1,19 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/csrc/utils.h
+++ b/k2/csrc/utils.h
@@ -1,9 +1,21 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey
  *                                                   Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_UTILS_H_

--- a/k2/csrc/utils_inl.h
+++ b/k2/csrc/utils_inl.h
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
+ * Copyright      2020  Xiaomi Corporation (authors: Daniel Povey, Haowen Qiu)
  *                      Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_CSRC_UTILS_INL_H_

--- a/k2/csrc/utils_test.cu
+++ b/k2/csrc/utils_test.cu
@@ -1,8 +1,20 @@
 /**
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (authors: Haowen Qiu)
  *
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gmock/gmock.h>

--- a/k2/python/csrc/k2.cu
+++ b/k2/python/csrc/k2.cu
@@ -2,10 +2,22 @@
  * @brief python wrappers for k2.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/python/csrc/k2.h"

--- a/k2/python/csrc/k2.h
+++ b/k2/python/csrc/k2.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for k2.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_K2_H_

--- a/k2/python/csrc/torch.cu
+++ b/k2/python/csrc/torch.cu
@@ -2,10 +2,22 @@
  * @brief Everything related to PyTorch for k2 Python wrappers.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/python/csrc/torch.h"

--- a/k2/python/csrc/torch.h
+++ b/k2/python/csrc/torch.h
@@ -2,10 +2,22 @@
  * @brief Everything related to PyTorch for k2 Python wrappers.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_H_

--- a/k2/python/csrc/torch/arc.cu
+++ b/k2/python/csrc/torch/arc.cu
@@ -2,10 +2,22 @@
  * @brief python wrappers for Arc.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <string>

--- a/k2/python/csrc/torch/arc.h
+++ b/k2/python/csrc/torch/arc.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for Arc.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_ARC_H_

--- a/k2/python/csrc/torch/discounted_cum_sum.cu
+++ b/k2/python/csrc/torch/discounted_cum_sum.cu
@@ -2,10 +2,22 @@
  * @brief wraps discounted_cum_sum code.
  *
  * @copyright
- * Copyright (c)  2010  Xiaomi Corp.  (authors: Daniel Povey)
+ * Copyright      2010  Xiaomi Corp.  (authors: Daniel Povey)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "k2/python/csrc/torch/discounted_cum_sum.h"
 

--- a/k2/python/csrc/torch/discounted_cum_sum.h
+++ b/k2/python/csrc/torch/discounted_cum_sum.h
@@ -2,10 +2,22 @@
  * @brief python wrapper for DiscountedCumSum
  *
  * @copyright
- * Copyright (c)  2021  Xiaomi Corp.  (authors: Daniel Povey)
+ * Copyright      2021  Xiaomi Corp.  (authors: Daniel Povey)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_DISCOUNTED_CUM_SUM_H_

--- a/k2/python/csrc/torch/fsa.cu
+++ b/k2/python/csrc/torch/fsa.cu
@@ -2,12 +2,24 @@
  * @brief python wrappers for FSA.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (authors: Haowen Qiu)
  *                      Guoguo Chen
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <limits>

--- a/k2/python/csrc/torch/fsa.h
+++ b/k2/python/csrc/torch/fsa.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for FSA.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_FSA_H_

--- a/k2/python/csrc/torch/fsa_algo.cu
+++ b/k2/python/csrc/torch/fsa_algo.cu
@@ -2,11 +2,23 @@
  * @brief python wrappers for fsa_algo.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corporation (authors: Haowen Qiu)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <algorithm>

--- a/k2/python/csrc/torch/fsa_algo.h
+++ b/k2/python/csrc/torch/fsa_algo.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for fsa_algo.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_FSA_ALGO_H_

--- a/k2/python/csrc/torch/index_add.cu
+++ b/k2/python/csrc/torch/index_add.cu
@@ -7,10 +7,22 @@
  * torch.int64. Furthermore, it ignores index[i] == -1.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/csrc/context.h"

--- a/k2/python/csrc/torch/index_add.h
+++ b/k2/python/csrc/torch/index_add.h
@@ -7,10 +7,22 @@
  * torch.int64. Furthermore, it ignores index[i] == -1.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_INDEX_ADD_H_

--- a/k2/python/csrc/torch/index_select.cu
+++ b/k2/python/csrc/torch/index_select.cu
@@ -5,11 +5,23 @@
  * the destination entry to 0.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *                      Xiaomi Corp.       (author: Daniel Povey, Haowen Qiu)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include <vector>
 

--- a/k2/python/csrc/torch/index_select.h
+++ b/k2/python/csrc/torch/index_select.h
@@ -5,10 +5,22 @@
  * the destination entry to 0.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_INDEX_SELECT_H_

--- a/k2/python/csrc/torch/ragged.cu
+++ b/k2/python/csrc/torch/ragged.cu
@@ -2,11 +2,23 @@
  * @brief python wrappers for Ragged<T>.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang, Liyong Guo)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang, Liyong Guo)
  *                      Xiaomi Corporation (authors: Haowen Qiu)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <memory>

--- a/k2/python/csrc/torch/ragged.h
+++ b/k2/python/csrc/torch/ragged.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for Ragged<T>.
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_RAGGED_H_

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -2,11 +2,23 @@
  * @brief python wrappers for ragged_ops.h
  *
  * @copyright
- * Copyright (c)  2020  Xiaomi Corp.       (authors: Fangjun Kuang
+ * Copyright      2020  Xiaomi Corp.       (authors: Fangjun Kuang
  *                                                   Daniel Povey)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <tuple>

--- a/k2/python/csrc/torch/ragged_ops.h
+++ b/k2/python/csrc/torch/ragged_ops.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for ragged_ops.h
  *
  * @copyright
- * Copyright (c)  2020  Xiaomi Corp.       (author: Fangjun Kuang)
+ * Copyright      2020  Xiaomi Corp.       (author: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_RAGGED_OPS_H_

--- a/k2/python/csrc/torch/torch_util.cu
+++ b/k2/python/csrc/torch/torch_util.cu
@@ -1,9 +1,21 @@
 /**
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <vector>

--- a/k2/python/csrc/torch/torch_util.h
+++ b/k2/python/csrc/torch/torch_util.h
@@ -1,9 +1,21 @@
 /**
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_TORCH_TORCH_UTIL_H_

--- a/k2/python/csrc/version.cu
+++ b/k2/python/csrc/version.cu
@@ -2,10 +2,22 @@
  * @brief Python wrappers for k2/csrc/version.h
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "k2/csrc/log.h"

--- a/k2/python/csrc/version.h
+++ b/k2/python/csrc/version.h
@@ -2,10 +2,22 @@
  * @brief python wrappers for k2/csrc/version.h
  *
  * @copyright
- * Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+ * Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
  *
  * @copyright
  * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef K2_PYTHON_CSRC_VERSION_H_

--- a/k2/python/host/k2host/array.py
+++ b/k2/python/host/k2host/array.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/k2host/aux_labels.py
+++ b/k2/python/host/k2host/aux_labels.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/k2host/fsa.py
+++ b/k2/python/host/k2host/fsa.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/k2host/fsa_algo.py
+++ b/k2/python/host/k2host/fsa_algo.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/k2host/fsa_equivalent.py
+++ b/k2/python/host/k2host/fsa_equivalent.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/k2host/fsa_util.py
+++ b/k2/python/host/k2host/fsa_util.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import re
 import struct

--- a/k2/python/host/k2host/properties.py
+++ b/k2/python/host/k2host/properties.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/k2host/weights.py
+++ b/k2/python/host/k2host/weights.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 from torch.utils.dlpack import to_dlpack

--- a/k2/python/host/tests/arcsort_test.py
+++ b/k2/python/host/tests/arcsort_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/array_test.py
+++ b/k2/python/host/tests/array_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/aux_labels_test.py
+++ b/k2/python/host/tests/aux_labels_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/connect_test.py
+++ b/k2/python/host/tests/connect_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/determinize_test.py
+++ b/k2/python/host/tests/determinize_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/fsa_equivalent_test.py
+++ b/k2/python/host/tests/fsa_equivalent_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/fsa_test.py
+++ b/k2/python/host/tests/fsa_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/intersect_test.py
+++ b/k2/python/host/tests/intersect_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/properties_test.py
+++ b/k2/python/host/tests/properties_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/rmepsilon_test.py
+++ b/k2/python/host/tests/rmepsilon_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/topsort_test.py
+++ b/k2/python/host/tests/topsort_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/host/tests/weights_test.py
+++ b/k2/python/host/tests/weights_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (author: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/k2/autograd.py
+++ b/k2/python/k2/autograd.py
@@ -1,7 +1,19 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corp.       (authors: Daniel Povey
 #                                                   Haowen Qiu)
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import List
 from typing import Optional

--- a/k2/python/k2/autograd_utils.py
+++ b/k2/python/k2/autograd_utils.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020-2021  Xiaomi Corp.   (authors: Daniel Povey
+# Copyright      2020-2021  Xiaomi Corp.   (authors: Daniel Povey
 #                                                    Fangjun Kuang)
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Tuple
 import torch

--- a/k2/python/k2/dense_fsa_vec.py
+++ b/k2/python/k2/dense_fsa_vec.py
@@ -1,5 +1,17 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Union
 

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1,8 +1,20 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corp.       (author: Daniel Povey, Haowen Qiu)
 #                      Guoguo Chen
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Any
 from typing import Dict

--- a/k2/python/k2/fsa_algo.py
+++ b/k2/python/k2/fsa_algo.py
@@ -1,8 +1,20 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corporation (authors: Haowen Qiu)
 #                2021  Mobvoi Inc.        (authors: Yaguang Hu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import List
 from typing import Optional

--- a/k2/python/k2/fsa_properties.py
+++ b/k2/python/k2/fsa_properties.py
@@ -1,7 +1,19 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corporation (authors: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch  # noqa
 import _k2

--- a/k2/python/k2/ops.py
+++ b/k2/python/k2/ops.py
@@ -1,7 +1,19 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corp.       (author: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import List
 from typing import Tuple

--- a/k2/python/k2/ragged/autograd.py
+++ b/k2/python/k2/ragged/autograd.py
@@ -1,5 +1,17 @@
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 # See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import List, Tuple
 

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -1,8 +1,20 @@
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang
 #                                                   Daniel Povey
 #                                                   Haowen Qiu)
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import List
 from typing import Optional

--- a/k2/python/k2/ragged/tensor.py
+++ b/k2/python/k2/ragged/tensor.py
@@ -1,5 +1,17 @@
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 # See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Optional
 from typing import Union

--- a/k2/python/k2/sparse/autograd.py
+++ b/k2/python/k2/sparse/autograd.py
@@ -1,5 +1,17 @@
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import torch
 

--- a/k2/python/k2/symbol_table.py
+++ b/k2/python/k2/symbol_table.py
@@ -1,6 +1,18 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from dataclasses import dataclass
 from dataclasses import field

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -1,7 +1,19 @@
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corporation (authors: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Optional
 from typing import Tuple

--- a/k2/python/k2/version/version.py
+++ b/k2/python/k2/version/version.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
 
-# Copyright (c)  2020  Xiaomi Corp.   (author: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corp.   (author: Fangjun Kuang)
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import torch  # noqa

--- a/k2/python/tests/add_epsilon_self_loops_test.py
+++ b/k2/python/tests/add_epsilon_self_loops_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/arc_sort_test.py
+++ b/k2/python/tests/arc_sort_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/cat_test.py
+++ b/k2/python/tests/cat_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/closure_test.py
+++ b/k2/python/tests/closure_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/compose_arc_maps_test.py
+++ b/k2/python/tests/compose_arc_maps_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/compose_test.py
+++ b/k2/python/tests/compose_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/connect_test.py
+++ b/k2/python/tests/connect_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/create_sparse_test.py
+++ b/k2/python/tests/create_sparse_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/ctc_gradients_test.py
+++ b/k2/python/tests/ctc_gradients_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/dense_fsa_vec_test.py
+++ b/k2/python/tests/dense_fsa_vec_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/determinize_test.py
+++ b/k2/python/tests/determinize_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Haowen Qiu)
+# Copyright      2020  Xiaomi Corporation (authors: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/expand_ragged_attributes_test.py
+++ b/k2/python/tests/expand_ragged_attributes_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang, Daniel Povey)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang, Daniel Povey)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/fsa_from_unary_function_ragged_test.py
+++ b/k2/python/tests/fsa_from_unary_function_ragged_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/fsa_from_unary_function_tensor_test.py
+++ b/k2/python/tests/fsa_from_unary_function_tensor_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/fsa_test.py
+++ b/k2/python/tests/fsa_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                Guoguo Chen
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/get_arc_post_test.py
+++ b/k2/python/tests/get_arc_post_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corp.       (author: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/get_backward_scores_test.py
+++ b/k2/python/tests/get_backward_scores_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corp.       (author: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/get_forward_scores_test.py
+++ b/k2/python/tests/get_forward_scores_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corp.       (author: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/get_tot_scores_test.py
+++ b/k2/python/tests/get_tot_scores_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/index_add_test.py
+++ b/k2/python/tests/index_add_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/index_and_sum_test.py
+++ b/k2/python/tests/index_and_sum_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/index_select_test.py
+++ b/k2/python/tests/index_select_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corp.       (authors: Daniel Povey)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/index_test.py
+++ b/k2/python/tests/index_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #                      Xiaomi Corporation (authors: Haowen Qiu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/intersect_dense_pruned_test.py
+++ b/k2/python/tests/intersect_dense_pruned_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/intersect_dense_test.py
+++ b/k2/python/tests/intersect_dense_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corp.       (authors: Daniel Povey, Fangjun Kuang)
+# Copyright      2020  Xiaomi Corp.       (authors: Daniel Povey, Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/intersect_device_test.py
+++ b/k2/python/tests/intersect_device_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang
 #                                                   Daniel Povey)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/intersect_test.py
+++ b/k2/python/tests/intersect_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/invert_test.py
+++ b/k2/python/tests/invert_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020-2021  Xiaomi Corporation (authors: Haowen Qiu
+# Copyright      2020-2021  Xiaomi Corporation (authors: Haowen Qiu
 #                                                        Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/linear_fsa_test.py
+++ b/k2/python/tests/linear_fsa_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/linear_fst_test.py
+++ b/k2/python/tests/linear_fst_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Mobvoi Inc.        (authors: Yaguang Hu)
+# Copyright      2021  Mobvoi Inc.        (authors: Yaguang Hu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/multi_gpu_test.py
+++ b/k2/python/tests/multi_gpu_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/numerical_gradient_check_test.py
+++ b/k2/python/tests/numerical_gradient_check_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/prune_on_arc_post_test.py
+++ b/k2/python/tests/prune_on_arc_post_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 #                2021  Mobvoi Inc. (authors: Yaguang Hu)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/ragged_shape_test.py
+++ b/k2/python/tests/ragged_shape_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Liyong Guo)
+# Copyright      2020  Mobvoi Inc.        (authors: Liyong Guo)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/ragged_test.py
+++ b/k2/python/tests/ragged_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020   Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020   Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/random_paths_test.py
+++ b/k2/python/tests/random_paths_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/remove_epsilon_self_loops_test.py
+++ b/k2/python/tests/remove_epsilon_self_loops_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/remove_epsilon_test.py
+++ b/k2/python/tests/remove_epsilon_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020-2021  Xiaomi Corporation (authors: Haowen Qiu
+# Copyright      2020-2021  Xiaomi Corporation (authors: Haowen Qiu
 #                                                        Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/sparse_abs_test.py
+++ b/k2/python/tests/sparse_abs_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2021  Xiaomi Corp.       (authors: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/symbol_table_test.py
+++ b/k2/python/tests/symbol_table_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Xiaomi Corporation (authors: Fangjun Kuang)
+# Copyright      2020  Xiaomi Corporation (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/top_sort_test.py
+++ b/k2/python/tests/top_sort_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/k2/python/tests/union_test.py
+++ b/k2/python/tests/union_test.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 #
-# Copyright (c)  2020  Mobvoi Inc.        (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc.        (authors: Fangjun Kuang)
 #
 # See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To run this single test, use
 #

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 #
-# Copyright (c)  2021  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (author: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # To use this script, we assume that you have installed cudatoolkit locally.
 # That is, `which nvcc` should give the path to nvcc

--- a/scripts/build_conda_cpu.sh
+++ b/scripts/build_conda_cpu.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 #
-# Copyright (c)  2021  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (author: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # The following environment variables are supposed to be set by users
 #

--- a/scripts/build_pip.sh
+++ b/scripts/build_pip.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Steps to build a pip package:
 #

--- a/scripts/check_style_cpplint.sh
+++ b/scripts/check_style_cpplint.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Usage:
 #

--- a/scripts/conda/k2/build.sh
+++ b/scripts/conda/k2/build.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 #
-# Copyright (c)  2021  Xiaomi Corp.       (author: Fangjun Kuang)
+# Copyright      2021  Xiaomi Corp.       (author: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -ex
 

--- a/scripts/github_actions/install_cuda.sh
+++ b/scripts/github_actions/install_cuda.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 echo "cuda version: $cuda"
 

--- a/scripts/github_actions/install_cudnn.sh
+++ b/scripts/github_actions/install_cudnn.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 case $cuda in
   10.0)

--- a/scripts/github_actions/install_torch.sh
+++ b/scripts/github_actions/install_torch.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 case ${torch} in
   1.5.*)

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c)  2020  Mobvoi Inc. (authors: Fangjun Kuang)
+# Copyright      2020  Mobvoi Inc. (authors: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Usage:
 #  ./scripts/run_cppcheck.sh


### PR DESCRIPTION
It comes from here, which the NVIDIA legal team recommends:

https://gist.github.com/Rypac/7349957f95f0713143fda2f3d3bc10c8

Basically, the NVIDIA legal team requires that my code contributions
have an Apache 2 license header. If I were to contribute to an
existing file (which I want to do), I would have to manually change
each file's header for legal compliance. @danpovey said that going
ahead and changing all the file headers to an official Apache 2 header
sounded reasonable.

I used codemod (`pip install codemod`) for this, with the following
script:

```
read -r -d '' replacement << EOM
   Copyright     \1 See LICENSE for clarification regarding multiple authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
EOM

codemod --exclude-paths build -m -d . --extensions cu,h \
        "Copyright \(c\) (.+) See LICENSE for clarification regarding multiple authors" \
        "$replacement"

read -r -d '' replacement << EOM
   Copyright     \1 authors
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
EOM

codemod --exclude-paths build -m -d . --extensions cmake,py \
        "Copyright \(c\) (.+) authors" \
        "$replacement"

codemod --exclude-paths build -m -d .github --extensions yml \
        "Copyright \(c\) (.+) authors" \
        "$replacement"

read -r -d '' replacement << EOM
   Copyright     \1
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
EOM

codemod --exclude-paths build -d scripts --extensions sh \
        "Copyright \(c\) (.+)" \
        "$replacement"
```

Codemod, unlike sed, is interactive. I manually checked that every
replacement made sense. Note that I applied this only to .cu, .h,
.cmake, and .py files.