### PR TITLE
Optional -j argument for build process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,12 +95,18 @@ class BuildExtension(build_ext):
 
         cmake_args = os.environ.get('K2_CMAKE_ARGS', '')
         make_args = os.environ.get('K2_MAKE_ARGS', '')
+        system_make_args = os.environ.get('MAKEFLAGS', '')
 
         if cmake_args == '':
             cmake_args = '-DCMAKE_BUILD_TYPE=Release'
 
-        if make_args == '' and os.environ.get('K2_IS_GITHUB_ACTIONS', None) is None:
-            make_args = '-j'
+        if (
+            make_args == ""
+            and system_make_args == ""
+            and os.environ.get("K2_IS_GITHUB_ACTIONS", None) is None
+        ):
+            print("For fast compilation, run:")
+            print('export K2_MAKE_ARGS="-j"; python setup.py install')
 
         if is_macos():
             if not 'K2_WITH_CUDA=OFF' in cmake_args:


### PR DESCRIPTION
The current build overwrites the `make` flag for the number of processes with the flag for the maximum number of jobs `-j`.

This pull request makes this optional: The build process no longer forces `-j` but prints a message for the user to set this option themself.

This change is for two reasons:
1. Relevant for multiple libraries built at once: Options for `make` are usually passed through the environmental variable `MAKEFLAGS`. The option `-j` is a special case to limit the total number of jobs running on the system. See https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html
2. Better for low-resource systems: Compilation with `-j` requires roughly 20GB RAM on an 8-thread system.

@csukuangfj  You intended a faster build process with the `-j` flag. Is this OK for you?
