### PR TITLE
Fix a bug in Fsa._invalidate_cache.

### DIFF
--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -249,17 +249,17 @@ class Fsa(object):
             pattern = re.compile('score')
             to_remove = []
 
-            for key in self._cache:
+            for key in self.__dict__['_cache']:
                 if pattern.search(key):
                     to_remove.append(key)
 
-            if 'entering_arcs' in self._cache:
+            if 'entering_arcs' in self.__dict__['_cache']:
                 # We also need to remove "entering_arcs"
                 # since it may be set in get_forward_scores()
                 to_remove.append('entering_arcs')
 
             for key in to_remove:
-                del self._cache[key]
+                del self.__dict__['_cache'][key]
 
     def to_str(self, openfst: bool = False) -> str:
         extra_labels = []

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -249,12 +249,17 @@ class Fsa(object):
             pattern = re.compile('score')
             to_remove = []
 
-            for key in self.__dict__['_cache']:
+            for key in self._cache:
                 if pattern.search(key):
                     to_remove.append(key)
 
+            if 'entering_arcs' in self._cache:
+                # We also need to remove "entering_arcs"
+                # since it may be set in get_forward_scores()
+                to_remove.append('entering_arcs')
+
             for key in to_remove:
-                del self.__dict__['_cache'][key]
+                del self._cache[key]
 
     def to_str(self, openfst: bool = False) -> str:
         extra_labels = []


### PR DESCRIPTION
We also need to remove "entering_arcs" since
it may be set in get_forward_scores(). See
https://github.com/k2-fsa/k2/blob/926f160f3d4dc986b5f556852f65cbaebb78a717/k2/python/k2/fsa.py#L603-L618

---

I am encountering this bug because the WER of different lm_scale values are the same when rescoring with the whole lattice.
This pull request fixes it.