### PR TITLE
Support replicate in k2.ragged.pad

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -qq --upgrade pip
-          python3 -m pip install -qq wheel twine
+          python3 -m pip install -qq wheel twine typing_extensions
           python3 -m pip install -qq torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
           python3 -c "import torch; print('torch version:', torch.__version__)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -q --upgrade pip
-          python3 -m pip install -q wheel twine
+          python3 -m pip install -q wheel twine typing_extensions
           python3 -m pip install -q bs4 requests tqdm
 
           ./scripts/github_actions/install_torch.sh

--- a/.github/workflows/nightly-cpu.yml
+++ b/.github/workflows/nightly-cpu.yml
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -qq --upgrade pip
-          python3 -m pip install -qq wheel twine
+          python3 -m pip install -qq wheel twine typing_extensions
           python3 -m pip install -qq torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
           python3 -c "import torch; print('torch version:', torch.__version__)"

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install PyTorch ${{ matrix.torch }}
         run: |
           pip3 install -qq torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip3 install -qq wheel twine dataclasses
+          pip3 install -qq wheel twine dataclasses typing_extensions
 
           python3 -m torch.utils.collect_env
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine
+          python3 -m pip install wheel twine typing_extensions
           python3 -m pip install bs4 requests tqdm
 
           ./scripts/github_actions/install_torch.sh

--- a/.github/workflows/run-tests-cpu.yml
+++ b/.github/workflows/run-tests-cpu.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -qq --upgrade pip
-          python3 -m pip install -qq wheel twine
+          python3 -m pip install -qq wheel twine typing_extensions
           python3 -m pip install -qq torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
           python3 -m pip install -qq dataclasses graphviz
           sudo apt-get -qq install graphviz

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -qq --upgrade pip six
-          python3 -m pip install -qq bs4 requests tqdm
+          python3 -m pip install -qq bs4 requests tqdm typing_extensions
           python3 -m pip install -qq dataclasses graphviz
           sudo apt-get -qq install graphviz
 

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip typing_extensions
           python3 -m pip install --upgrade flake8==3.8.3
 
       - name: Run flake8

--- a/.github/workflows/wheel-cpu-stable.yml
+++ b/.github/workflows/wheel-cpu-stable.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -qq --upgrade pip
-          python3 -m pip install -q wheel twine
+          python3 -m pip install -q wheel twine typing_extensions
           python3 -m pip install -qq torch==${{ matrix.torch }}
 
 

--- a/.github/workflows/wheel-cpu.yml
+++ b/.github/workflows/wheel-cpu.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install -qq --upgrade pip
-          python3 -m pip install -q wheel twine
+          python3 -m pip install -q wheel twine typing_extensions
           python3 -m pip install -qq torch==${{ matrix.torch }}
 
 

--- a/.github/workflows/wheel-stable.yml
+++ b/.github/workflows/wheel-stable.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine
+          python3 -m pip install wheel twine typing_extensions
           python3 -m pip install bs4 requests tqdm
 
           ./scripts/github_actions/install_torch.sh

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine
+          python3 -m pip install wheel twine typing_extensions
           python3 -m pip install bs4 requests tqdm
 
           ./scripts/github_actions/install_torch.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install PyTorch ${{ matrix.torch }}
         run: |
           pip3 install -qq torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip3 install -qq wheel twine dataclasses numpy
+          pip3 install -qq wheel twine dataclasses numpy typing_extensions
 
           python3 -m torch.utils.collect_env
 

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -1411,11 +1411,19 @@ Ragged<T> CreateRagged2(const std::vector<std::vector<T>> &vecs);
   Pad a ragged array to be regular.
     @param [in] src  The input ragged array.
                      CAUTION: Only support `NumAxes() == 2`.
+    @param [in] mode Valid values are: "constant", "replicate".
+                     When it is "constant", the given padding_value
+                     is used for filling. When it is "replicate",
+                     the last entry of a list is used for filling.
+                     When the list is empty, the given padding_value
+                     is used for filling.
     @param [in] padding_value  Value for padded elements.
+                     Used only when mode is "constant" or a list
+                     is empty.
     @return  Returns the corresponding regular array (Array2).
  */
 template <typename T>
-Array2<T> PadRagged(Ragged<T> &src, T padding_value);
+Array2<T> PadRagged(Ragged<T> &src, const std::string &mode, T padding_value);
 
 }  // namespace k2
 

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -1271,6 +1271,16 @@ Ragged<T> Index(Array1<T> &src, Ragged<int32_t> &indexes) {
 }
 
 /*
+ * Similar to the above `Index` but also supports -1 in indexes.
+ * The given default value is used if an index is -1.
+ */
+template <typename T>
+Ragged<T> Index(Array1<T> &src, Ragged<int32_t> &indexes, T default_value) {
+  return Ragged<T>(indexes.shape,
+                   Index(src, indexes.values, true, default_value));
+}
+
+/*
    Index ragged tensor with ragged tensor.
        @param [in] src   Source tensor, to be indexed
        @param [in] indexes   Indexes into source array; the values must

--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -21,6 +21,7 @@
 #ifndef K2_CSRC_RAGGED_OPS_H_
 #define K2_CSRC_RAGGED_OPS_H_
 
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -669,9 +669,20 @@ Ragged<T> CreateRagged2(const std::vector<std::vector<T>> &vecs) {
 }
 
 template <typename T>
-Array2<T> PadRagged(Ragged<T> &src, T padding_value) {
+Array2<T> PadRagged(Ragged<T> &src, const std::string &mode, T padding_value) {
   NVTX_RANGE(K2_FUNC);
   K2_CHECK_EQ(src.NumAxes(), 2);
+
+  bool is_constant = false;
+  if (mode == "constant") {
+    is_constant = true;
+  } else if (mode == "replicate") {
+    is_constant = false;
+  } else {
+    K2_LOG(FATAL) << "Unsupported mode: " << mode << ".\n"
+                  << "Valid values are: constant, replicate";
+  }
+
   ContextPtr &c = src.Context();
   int32_t row_num = src.Dim0(),
           col_num = src.shape.MaxSize(1);
@@ -679,16 +690,36 @@ Array2<T> PadRagged(Ragged<T> &src, T padding_value) {
   auto res_acc = res.Accessor();
   const T *src_values_data = src.values.Data();
   const int32_t *src_row_splits1_data = src.RowSplits(1).Data();
-  K2_EVAL2(
-      c, res.Dim0(), res.Dim1(), lambda, (int32_t i, int32_t j)->void {
-        int32_t idx0x = src_row_splits1_data[i],
-                idx0x_next = src_row_splits1_data[i + 1],
-                len = idx0x_next - idx0x;
-        if (j >= len)
-          res_acc(i, j) = padding_value;
-        else
-          res_acc(i, j) = src_values_data[idx0x + j];
-      });
+  if (is_constant) {
+    K2_EVAL2(
+        c, res.Dim0(), res.Dim1(), lambda, (int32_t i, int32_t j)->void {
+          int32_t idx0x = src_row_splits1_data[i],
+                  idx0x_next = src_row_splits1_data[i + 1],
+                  len = idx0x_next - idx0x;
+          if (j >= len)
+            res_acc(i, j) = padding_value;
+          else
+            res_acc(i, j) = src_values_data[idx0x + j];
+        });
+  } else {
+    K2_EVAL2(
+        c, res.Dim0(), res.Dim1(), lambda, (int32_t i, int32_t j)->void {
+          int32_t idx0x = src_row_splits1_data[i],
+                  idx0x_next = src_row_splits1_data[i + 1],
+                  len = idx0x_next - idx0x;
+
+          if (len == 0) {
+            res_acc(i, j) = padding_value;
+            return;
+          }
+
+          if (j >= len)
+            // replicate the last element in this list
+            res_acc(i, j) = src_values_data[idx0x_next - 1];
+          else
+            res_acc(i, j) = src_values_data[idx0x + j];
+        });
+  }
   return res;
 }
 

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -30,6 +30,7 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/k2/csrc/ragged_test.cu
+++ b/k2/csrc/ragged_test.cu
@@ -2716,7 +2716,6 @@ static void TestPadRagged() {
                                  5, 6, 7, 8};
       CheckArrayData(dst, expected);
     }
-
   }
 }
 

--- a/k2/csrc/ragged_test.cu
+++ b/k2/csrc/ragged_test.cu
@@ -2686,7 +2686,7 @@ static void TestPadRagged() {
     {
       Ragged<T> src(c, "[ [1 2] [3 4 3] [] [5 6 7 8] ]");
       T padding_value = 0;
-      Array2<T> res = PadRagged(src, padding_value);
+      Array2<T> res = PadRagged(src, "constant", padding_value);
       Array1<T> dst = res.Flatten();
       std::vector<T> expected = {1, 2, 0, 0,
                                  3, 4, 3, 0,
@@ -2697,7 +2697,7 @@ static void TestPadRagged() {
     {
       Ragged<T> src(c, "[ [1 2] [3 4 3] [] [5 6 7 8] ]");
       T padding_value = -1;
-      Array2<T> res = PadRagged(src, padding_value);
+      Array2<T> res = PadRagged(src, "constant", padding_value);
       Array1<T> dst = res.Flatten();
       std::vector<T> expected = {1, 2, -1, -1,
                                  3, 4, 3, -1,
@@ -2705,6 +2705,18 @@ static void TestPadRagged() {
                                  5, 6, 7, 8};
       CheckArrayData(dst, expected);
     }
+    {
+      Ragged<T> src(c, "[ [1 2] [3 4 3] [] [5 6 7 8] ]");
+      T padding_value = 100;
+      Array2<T> res = PadRagged(src, "replicate", padding_value);
+      Array1<T> dst = res.Flatten();
+      std::vector<T> expected = {1, 2, 2, 2,
+                                 3, 4, 3, 3,
+                                 100, 100, 100, 100,
+                                 5, 6, 7, 8};
+      CheckArrayData(dst, expected);
+    }
+
   }
 }
 

--- a/k2/python/csrc/torch/ragged.cu
+++ b/k2/python/csrc/torch/ragged.cu
@@ -237,7 +237,7 @@ static void PybindRaggedImpl(py::module &m) {
         DeviceGuard guard(GetContext(src));
         K2_CHECK_EQ(src.dim(), 1) << "Expected dim: 1. Given: " << src.dim();
         Array1<float> src_array = FromTorch<float>(src);
-        Ragged<float> ragged = Index(src_array, indexes, float(0));
+        Ragged<float> ragged = Index<float>(src_array, indexes, 0);
         Array1<float> ans_array(ragged.Context(), ragged.Dim0());
         SumPerSublist<float>(ragged, 0, &ans_array);
         return ToTorch(ans_array);

--- a/k2/python/csrc/torch/ragged.cu
+++ b/k2/python/csrc/torch/ragged.cu
@@ -237,7 +237,7 @@ static void PybindRaggedImpl(py::module &m) {
         DeviceGuard guard(GetContext(src));
         K2_CHECK_EQ(src.dim(), 1) << "Expected dim: 1. Given: " << src.dim();
         Array1<float> src_array = FromTorch<float>(src);
-        Ragged<float> ragged = Index(src_array, indexes);
+        Ragged<float> ragged = Index(src_array, indexes, float(0));
         Array1<float> ans_array(ragged.Context(), ragged.Dim0());
         SumPerSublist<float>(ragged, 0, &ans_array);
         return ToTorch(ans_array);

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -21,6 +21,7 @@
  * limitations under the License.
  */
 
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/k2/python/csrc/torch/ragged_ops.cu
+++ b/k2/python/csrc/torch/ragged_ops.cu
@@ -120,13 +120,14 @@ static void PybindRaggedIntToList(py::module &m, const char *name) {
 template <typename T>
 static void PybindPadRaggedToTensor(py::module &m) {
   m.def(
-    "pad_ragged",
-    [](Ragged<T> &src, T padding_value) -> torch::Tensor {
-      DeviceGuard guard(src.Context());
-      Array2<T> res = PadRagged(src, padding_value);
-      return ToTorch(res);
-    },
-    py::arg("src"), py::arg("padding_value"));
+      "pad_ragged",
+      [](Ragged<T> &src, const std::string &mode,
+         T padding_value) -> torch::Tensor {
+        DeviceGuard guard(src.Context());
+        Array2<T> res = PadRagged(src, mode, padding_value);
+        return ToTorch(res);
+      },
+      py::arg("src"), py::arg("mode"), py::arg("padding_value"));
 }
 
 template <typename T>

--- a/k2/python/k2/ragged/__init__.py
+++ b/k2/python/k2/ragged/__init__.py
@@ -6,7 +6,7 @@ from .ops import create_ragged2
 from .ops import get_layer
 from .ops import index
 from .ops import max_per_sublist
-from .ops import pad_ragged
+from .ops import pad
 from .ops import regular_ragged_shape
 from .ops import remove_axis
 from .ops import remove_values_eq

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -133,15 +134,17 @@ def to_list(src: _k2.RaggedInt) -> List:
     return _k2.ragged_int_to_list(src)
 
 
-def pad_ragged(src: Union[_k2.RaggedInt, _k2.RaggedFloat],
-               padding_value: Union[int, float] = 0) -> torch.Tensor:
+def pad(src: Union[_k2.RaggedInt, _k2.RaggedFloat],
+        mode: Literal['constant', 'replicate'] = 'constant',
+        value: Union[int, float] = 0) -> torch.Tensor:
     '''Pad a ragged tensor to a torch tensor.
 
     For example, if `src` has the following values::
 
         [ [1 2 3] [4] [5 6 7 8] ]
 
-    Then it returns a 2-D tensor as follows if padding value is 0::
+    Then it returns a 2-D tensor as follows if value is 0 and
+    mode is constant::
 
         tensor([[1, 2, 3, 0],
                 [4, 0, 0, 0],
@@ -150,12 +153,21 @@ def pad_ragged(src: Union[_k2.RaggedInt, _k2.RaggedFloat],
     Args:
       src:
         The source ragged tensor, MUST have `num_axes() == 2`.
+      mode:
+        Valid values are: `constant`, `replicate`. If it is `constant`, the
+        given `value` is used for filling. If it is "replicate",
+        the last entry in a list is used for filling. If a list is empty,
+        then the given `value` is also used for filling.
+      value:
+        The filling value.
+
     Returns:
       A 2-D torch.Tensor whose dtype is torch.int32 if the input is
       _k2.RaggedInt tensor or torch.float32 if the input is _k2.RaggedFloat
       tensor. The tensor returned is on the same device as `src`.
     '''
-    return _k2.pad_ragged(src, padding_value)
+    assert mode in ['constant', 'replicate'], f'mode: {mode}'
+    return _k2.pad_ragged(src, mode, value)
 
 
 def sum_per_sublist(src: _k2.RaggedFloat,

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -144,7 +144,7 @@ def pad(src: Union[_k2.RaggedInt, _k2.RaggedFloat],
         [ [1 2 3] [4] [5 6 7 8] ]
 
     Then it returns a 2-D tensor as follows if value is 0 and
-    mode is constant::
+    mode is `constant`::
 
         tensor([[1, 2, 3, 0],
                 [4, 0, 0, 0],
@@ -155,7 +155,7 @@ def pad(src: Union[_k2.RaggedInt, _k2.RaggedFloat],
         The source ragged tensor, MUST have `num_axes() == 2`.
       mode:
         Valid values are: `constant`, `replicate`. If it is `constant`, the
-        given `value` is used for filling. If it is "replicate",
+        given `value` is used for filling. If it is `replicate`,
         the last entry in a list is used for filling. If a list is empty,
         then the given `value` is also used for filling.
       value:

--- a/k2/python/k2/ragged/ops.py
+++ b/k2/python/k2/ragged/ops.py
@@ -18,7 +18,12 @@
 # limitations under the License.
 
 from typing import List
-from typing import Literal
+
+try:
+    from typing import Literal  # for Python >= 3.8
+except ImportError:
+    from typing_extensions import Literal  # for python < 3.8
+
 from typing import Optional
 from typing import Tuple
 from typing import Union

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 graphviz
 torch>=1.6.0
+typing_extensions; python_version < '3.8'


### PR DESCRIPTION
Also,
(1) Fix a bug in k2.index_and_sum. Originally, it did not support -1 in indexes. This pull-request fixes that.
(2) Rename k2.ragged.pad_ragged to k2.ragged.pad

---

The mode `replicate` is added to support implementing top-k extraction from `Nbest`.
When an utterance has less than k paths, we repeat its last path so that each utterance has
exactly `k` paths.