### PR TITLE
Add k2.ctc_topo

### DIFF
--- a/k2/csrc/intersect_dense.cu
+++ b/k2/csrc/intersect_dense.cu
@@ -840,7 +840,7 @@ class MultiGraphDenseIntersect {
           int32_t backward_state_idx = (2 * fsa_info.state_offset),
                   forward_state_idx =
                       backward_state_idx + (2 * fsa_info.num_states) - 1;
-          // We get the start and end scoreas after fsa_info.T steps of
+          // We get the start and end scores after fsa_info.T steps of
           // propagation, and the result is in the state_scores of the Step
           // indexed fsa_info.T.
           float *this_state_scores = state_scores_data[fsa_info.T];

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -22,6 +22,7 @@ from .fsa_algo import closure
 from .fsa_algo import compose
 from .fsa_algo import connect
 from .fsa_algo import ctc_graph
+from .fsa_algo import ctc_topo
 from .fsa_algo import determinize
 from .fsa_algo import expand_ragged_attributes
 from .fsa_algo import intersect

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -13,6 +13,8 @@ from . import utils
 from .autograd import intersect_dense
 from .autograd import intersect_dense_pruned
 from .autograd import union
+from .ctc_loss import CtcLoss
+from .ctc_loss import ctc_loss
 from .dense_fsa_vec import DenseFsaVec
 from .dense_fsa_vec import convert_dense_to_fsa_vec
 from .fsa import Fsa

--- a/k2/python/k2/ctc_loss.py
+++ b/k2/python/k2/ctc_loss.py
@@ -62,7 +62,7 @@ class CtcLoss(nn.Module):
             the total scores. False to use single precision.
           target_lengths:
             Used only when `reduction` is `mean`. It is a 1-D tensor of batch
-            size. It represent lengths of the targets, e.g., number of phones or
+            size representing lengths of the targets, e.g., number of phones or
             number of word pieces in a sentence.
         Returns:
           If `reduction` is `none`, return a 1-D tensor with size equal to batch
@@ -113,9 +113,9 @@ def ctc_loss(decoding_graph: Fsa,
         True to use double precision floating point in computing
         the total scores. False to use single precision.
       target_lengths:
-        Used only when `reduction` is `mean`. It is a 1-D tensor of batch size.
-        It represent lengths of the targets, e.g., number of phones or number of
-        word pieces in a sentence.
+        Used only when `reduction` is `mean`. It is a 1-D tensor of batch
+        size representing lengths of the targets, e.g., number of phones or
+        number of word pieces in a sentence.
     Returns:
       If `reduction` is `none`, return a 1-D tensor with size equal to batch
       size. If `reduction` is `mean` or `sum`, return a scalar.

--- a/k2/python/k2/ctc_loss.py
+++ b/k2/python/k2/ctc_loss.py
@@ -26,7 +26,8 @@ class CtcLoss(nn.Module):
     See `k2/python/tests/ctc_loss_test.py` for usage.
 
     We assume that the blank label is always 0. The arguments `reduction` and
-    `target_lengths` have the same meaning as `torch.CtcLoss`.
+    `target_lengths` have the same meaning as their counterparts in
+    `torch.CtcLoss`.
     '''
 
     def __init__(self):
@@ -36,7 +37,7 @@ class CtcLoss(nn.Module):
                 decoding_graph: Fsa,
                 dense_fsa_vec: DenseFsaVec,
                 output_beam: float = 10,
-                reduction: Literal['none', 'mean', 'sum'] = 'mean',
+                reduction: Literal['none', 'mean', 'sum'] = 'sum',
                 use_double_scores: bool = True,
                 target_lengths: Optional[torch.Tensor] = None) -> torch.Tensor:
         '''Compute the CTC loss given a decoding graph and a dense fsa vector.
@@ -89,7 +90,7 @@ class CtcLoss(nn.Module):
 def ctc_loss(decoding_graph: Fsa,
              dense_fsa_vec: DenseFsaVec,
              output_beam: float = 10,
-             reduction: Literal['none', 'mean', 'sum'] = 'mean',
+             reduction: Literal['none', 'mean', 'sum'] = 'sum',
              use_double_scores: bool = True,
              target_lengths: Optional[torch.Tensor] = None) -> torch.Tensor:
     '''Compute the CTC loss given a decoding graph and a dense fsa vector.

--- a/k2/python/k2/ctc_loss.py
+++ b/k2/python/k2/ctc_loss.py
@@ -1,0 +1,124 @@
+# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+
+try:
+    from typing import Literal  # for Python >= 3.8
+except ImportError:
+    from typing_extensions import Literal  # for python < 3.8
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from .autograd import intersect_dense
+from .dense_fsa_vec import DenseFsaVec
+from .fsa import Fsa
+
+
+class CtcLoss(nn.Module):
+    '''Ctc Loss computation in k2. It produces the same output as `torch.CtcLoss`
+    if given the same input.
+
+    One difference between `k2.CtcLoss` and `torch.CtcLoss` is that k2 accepts
+    a general FSA while PyTorch requires a linear FSA (represented as a list).
+    That means, `k2.CtcLoss` supports words with multiple pronunciations.
+
+    See `k2/python/tests/ctc_loss_test.py` for usage.
+
+    We assume that the blank label is always 0. The arguments `reduction` and
+    `target_lengths` have the same meaning as `torch.CtcLoss`.
+    '''
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self,
+                decoding_graph: Fsa,
+                dense_fsa_vec: DenseFsaVec,
+                output_beam: float = 10,
+                reduction: Literal['none', 'mean', 'sum'] = 'mean',
+                use_double_scores: bool = True,
+                target_lengths: Optional[torch.Tensor] = None) -> torch.Tensor:
+        '''Compute the CTC loss given a decoding graph and a dense fsa vector.
+
+        Args:
+          decoding_graph:
+            An FsaVec. It can be the composition result of a CTC topology
+            and a transcript.
+          dense_fsa_vec:
+            It represents the neural network output. Refer to the help
+            information in :class:`k2.DenseFsaVec`.
+          output_beam:
+             Beam to prune output, similar to lattice-beam in Kaldi.  Relative
+             to best path of output.
+          reduction:
+            Specifies the reduction to apply to the output:
+            'none' | 'mean' | 'sum'.
+            'none': no reduction will be applied, 'mean': the output losses
+            will be **divided** by the target lengths and then the **mean** over
+            the batch is taken. 'sum': sum the output losses over batches.
+          use_double_scores:
+            True to use double precision floating point in computing
+            the total scores. False to use single precision.
+          target_lengths:
+            Used only when `reduction` is `mean`. It is a 1-D tensor of batch
+            size. It represent lengths of the targets, e.g., number of phones or
+            number of word pieces in a sentence.
+        Returns:
+          If `reduction` is `none`, return a 1-D tensor with size equal to batch
+          size. If `reduction` is `mean` or `sum`, return a scalar.
+        '''
+        assert reduction in ('none', 'mean', 'sum')
+        lattice = intersect_dense(decoding_graph, dense_fsa_vec, output_beam)
+
+        tot_scores = lattice.get_tot_scores(
+            log_semiring=True, use_double_scores=use_double_scores)
+        loss = -1 * tot_scores
+        loss = loss.to(torch.float32)
+
+        if reduction == 'none':
+            return loss
+        elif reduction == 'sum':
+            return loss.sum()
+        else:
+            assert reduction == 'mean'
+            loss /= target_lengths
+            return loss.mean()
+
+
+def ctc_loss(decoding_graph: Fsa,
+             dense_fsa_vec: DenseFsaVec,
+             output_beam: float = 10,
+             reduction: Literal['none', 'mean', 'sum'] = 'mean',
+             use_double_scores: bool = True,
+             target_lengths: Optional[torch.Tensor] = None) -> torch.Tensor:
+    '''Compute the CTC loss given a decoding graph and a dense fsa vector.
+
+    Args:
+      decoding_graph:
+        An FsaVec. It can be the composition result of a ctc topology
+        and a transcript.
+      dense_fsa_vec:
+        It represents the neural network output. Refer to the help information
+        in :class:`k2.DenseFsaVec`.
+      output_beam:
+         Beam to prune output, similar to lattice-beam in Kaldi.  Relative
+         to best path of output.
+      reduction:
+        Specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'.
+        'none': no reduction will be applied, 'mean': the output losses will be
+        divided by the target lengths and then the mean over the batch is taken.
+        'sum': sum the output losses over batches.
+      use_double_scores:
+        True to use double precision floating point in computing
+        the total scores. False to use single precision.
+      target_lengths:
+        Used only when `reduction` is `mean`. It is a 1-D tensor of batch size.
+        It represent lengths of the targets, e.g., number of phones or number of
+        word pieces in a sentence.
+    Returns:
+      If `reduction` is `none`, return a 1-D tensor with size equal to batch
+      size. If `reduction` is `mean` or `sum`, return a scalar.
+    '''
+    return CtcLoss()(decoding_graph, dense_fsa_vec, output_beam, reduction,
+                     use_double_scores, target_lengths)

--- a/k2/python/k2/fsa_algo.py
+++ b/k2/python/k2/fsa_algo.py
@@ -1012,7 +1012,8 @@ def ctc_graph(symbols: Union[List[List[int]], k2.RaggedInt],
     fsa = Fsa(ragged_arc, aux_labels=aux_labels)
     return fsa
 
-def ctc_topo(max_token: int, standard: bool) -> k2.Fsa:
+
+def ctc_topo(max_token: int, modified: bool = False) -> k2.Fsa:
     '''Create a CTC topology.
 
     A token which appears once on the right side (i.e. olabels) may
@@ -1034,8 +1035,8 @@ def ctc_topo(max_token: int, standard: bool) -> k2.Fsa:
       max_token:
         The maximum token ID (inclusive). We assume that token IDs
         are contiguous (from 1 to `max_token`). 0 represents blank.
-      standard:
-        If True, create a standard CTC topology. Otherwise, create a
+      modified:
+        If False, create a standard CTC topology. Otherwise, create a
         modified CTC topology.
     Returns:
       Return either a standard or a modified CTC topology as an FSA
@@ -1065,7 +1066,7 @@ def ctc_topo(max_token: int, standard: bool) -> k2.Fsa:
         arcs = [[final_state]]
         arcs.append([start_state, start_state, blank, eps, 0])
         arcs.append([start_state, final_state, -1, -1, 0])
-        for p in range(1, max_token+1):
+        for p in range(1, max_token + 1):
             i = p
             arcs.append([start_state, start_state, p, p, 0])
 
@@ -1075,10 +1076,10 @@ def ctc_topo(max_token: int, standard: bool) -> k2.Fsa:
             arcs.append([i, start_state, p, eps, 0])
         return arcs
 
-    if standard:
-        arcs = standard_ctc_topo()
-    else:
+    if modified:
         arcs = modified_ctc_topo()
+    else:
+        arcs = standard_ctc_topo()
 
     arcs = sorted(arcs, key=lambda arc: arc[0])
     arcs = [[str(i) for i in arc] for arc in arcs]

--- a/k2/python/k2/nbest.py
+++ b/k2/python/k2/nbest.py
@@ -4,11 +4,12 @@
 #
 # See https://github.com/k2-fsa/snowfall/issues/232 for more details
 #
+import logging
 from typing import List
 
+import torch
 import _k2
 import k2
-import torch
 
 from .fsa import Fsa
 
@@ -60,7 +61,8 @@ class Nbest(object):
             :func:`whole_lattice_rescoring`.
         Returns:
           Return a new Nbest. This new Nbest shares the same shape with `self`,
-          while its `fsa` is the 1-best path from intersecting `self.fsa` and `lats.
+          while its `fsa` is the 1-best path from intersecting `self.fsa` and
+          `lats.
         '''
         assert self.fsa.device == lats.device, \
                 f'{self.fsa.device} vs {lats.device}'
@@ -103,7 +105,8 @@ class Nbest(object):
 
     def top_k(self, k: int) -> 'Nbest':
         '''Get a subset of paths in the Nbest. The resulting Nbest is regular
-        in that each sequence (i.e., utterance) has the same number of paths (k).
+        in that each sequence (i.e., utterance) has the same number of
+        paths (k).
 
         We select the top-k paths according to the total_scores of each path.
         If a utterance has less than k paths, then its last path, after sorting
@@ -130,7 +133,8 @@ class Nbest(object):
                                        mode='replicate',
                                        value=-1)
         assert torch.ge(padded_indexes, 0).all(), \
-                f'Some utterances contain empty n-best: {self.shape.row_splits(1)}'
+                'Some utterances contain empty ' \
+                f'n-best: {self.shape.row_splits(1)}'
 
         # Select the idx01's of top-k paths of each utterance
         top_k_indexes = padded_indexes[:, :k].flatten().contiguous()
@@ -249,7 +253,7 @@ def generate_nbest_list(lats: Fsa, num_paths: int) -> Nbest:
     # unique_token_seqs is still a k2.RaggedInt with axes [seq][path]token_id].
     # But then number of pathsin each sequence may be different.
     unique_token_seqs, _, _ = k2.ragged.unique_sequences(
-        word_seqs, need_num_repeats=False, need_new2old_indexes=False)
+        token_seqs, need_num_repeats=False, need_new2old_indexes=False)
 
     seq_to_path_shape = k2.ragged.get_layer(unique_token_seqs.shape(), 0)
 

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -25,8 +25,8 @@ set(py_test_files
   compose_test.py
   connect_test.py
   create_sparse_test.py
-  ctc_gradients_test.py
   ctc_graph_test.py
+  ctc_loss_test.py
   ctc_topo_test.py
   dense_fsa_vec_test.py
   determinize_test.py

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(py_test_files
   create_sparse_test.py
   ctc_gradients_test.py
   ctc_graph_test.py
+  ctc_topo_test.py
   dense_fsa_vec_test.py
   determinize_test.py
   expand_ragged_attributes_test.py

--- a/k2/python/tests/ctc_topo_test.py
+++ b/k2/python/tests/ctc_topo_test.py
@@ -49,8 +49,8 @@ class TestCtcTopo(unittest.TestCase):
             zoo 1
         ''')
 
-        standard = k2.ctc_topo(max_token, standard=True)
-        modified = k2.ctc_topo(max_token, standard=False)
+        standard = k2.ctc_topo(max_token, modified=False)
+        modified = k2.ctc_topo(max_token, modified=True)
         standard.labels_sym = labels_sym
         standard.aux_labels_sym = aux_labels_sym
 
@@ -110,8 +110,8 @@ class TestCtcTopo(unittest.TestCase):
         # should be equivalent if there are no
         # repeated neighboring symbols in the transcript
         max_token = 3
-        standard = k2.ctc_topo(max_token, standard=True)
-        modified = k2.ctc_topo(max_token, standard=False)
+        standard = k2.ctc_topo(max_token, modified=False)
+        modified = k2.ctc_topo(max_token, modified=True)
         transcript = k2.linear_fsa([1, 2, 3])
         standard_graph = k2.compose(standard, transcript)
         modified_graph = k2.compose(modified, transcript)
@@ -138,8 +138,8 @@ class TestCtcTopo(unittest.TestCase):
 
     def test_with_repeated(self):
         max_token = 2
-        standard = k2.ctc_topo(max_token, standard=True)
-        modified = k2.ctc_topo(max_token, standard=False)
+        standard = k2.ctc_topo(max_token, modified=False)
+        modified = k2.ctc_topo(max_token, modified=True)
         transcript = k2.linear_fsa([1, 2, 2])
         standard_graph = k2.compose(standard, transcript)
         modified_graph = k2.compose(modified, transcript)

--- a/k2/python/tests/ctc_topo_test.py
+++ b/k2/python/tests/ctc_topo_test.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+#
+# Copyright      2021  Xiaomi Corporation      (authors: Fangjun Kuang)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R ctc_topo_test_py
+
+import unittest
+
+import k2
+import torch
+
+
+class TestCtcTopo(unittest.TestCase):
+
+    @staticmethod
+    def visualize_ctc_topo():
+        '''This function shows how to visualize
+        standard/modified ctc topologies. It's for
+        demonstration only, not for testing.
+        '''
+        max_token = 2
+        labels_sym = k2.SymbolTable.from_str('''
+            <blk> 0
+            z 1
+            o 2
+        ''')
+        aux_labels_sym = k2.SymbolTable.from_str('''
+            z 1
+            o 2
+        ''')
+
+        word_sym = k2.SymbolTable.from_str('''
+            zoo 1
+        ''')
+
+        standard = k2.ctc_topo(max_token, standard=True)
+        modified = k2.ctc_topo(max_token, standard=False)
+        standard.labels_sym = labels_sym
+        standard.aux_labels_sym = aux_labels_sym
+
+        modified.labels_sym = labels_sym
+        modified.aux_labels_sym = aux_labels_sym
+
+        standard.draw('standard_topo.svg', title='standard CTC topo')
+        modified.draw('modified_topo.svg', title='modified CTC topo')
+        fsa = k2.linear_fst([1, 2, 2], [1, 0, 0])
+        fsa.labels_sym = labels_sym
+        fsa.aux_labels_sym = word_sym
+        fsa.draw('transcript.svg', title='transcript')
+
+        standard_graph = k2.compose(standard, fsa)
+        modified_graph = k2.compose(modified, fsa)
+        standard_graph.draw('standard_graph.svg', title='standard graph')
+        modified_graph.draw('modified_graph.svg', title='modified graph')
+
+        # z z <blk> <blk> o o <blk> o <blk>
+        inputs = k2.linear_fsa([1, 1, 0, 0, 2, 2, 0, 2, 0])
+        inputs.labels_sym = labels_sym
+        inputs.draw('inputs.svg', title='inputs')
+        standard_lattice = k2.intersect(standard_graph,
+                                        inputs,
+                                        treat_epsilons_specially=False)
+        standard_lattice.draw('standard_lattice.svg', title='standard lattice')
+
+        modified_lattice = k2.intersect(modified_graph,
+                                        inputs,
+                                        treat_epsilons_specially=False)
+        modified_lattice = k2.connect(modified_lattice)
+        modified_lattice.draw('modified_lattice.svg', title='modified lattice')
+
+        # z z <blk> <blk> o o o <blk>
+        inputs2 = k2.linear_fsa([1, 1, 0, 0, 2, 2, 2, 0])
+        inputs2.labels_sym = labels_sym
+        inputs2.draw('inputs2.svg', title='inputs2')
+        standard_lattice2 = k2.intersect(standard_graph,
+                                         inputs2,
+                                         treat_epsilons_specially=False)
+        standard_lattice2 = k2.connect(standard_lattice2)
+        # It's empty since the topo requires that there must be a blank
+        # between the two o's in zoo
+        assert standard_lattice2.num_arcs == 0
+        standard_lattice2.draw('standard_lattice2.svg',
+                               title='standard lattice2')
+
+        modified_lattice2 = k2.intersect(modified_graph,
+                                         inputs2,
+                                         treat_epsilons_specially=False)
+        modified_lattice2 = k2.connect(modified_lattice2)
+        modified_lattice2.draw('modified_lattice2.svg',
+                               title='modified lattice2')
+
+    def test_no_repeated(self):
+        # standard ctc topo and modified ctc topo
+        # should be equivalent if there are no
+        # repeated neighboring symbols in the transcript
+        max_token = 3
+        standard = k2.ctc_topo(max_token, standard=True)
+        modified = k2.ctc_topo(max_token, standard=False)
+        transcript = k2.linear_fsa([1, 2, 3])
+        standard_graph = k2.compose(standard, transcript)
+        modified_graph = k2.compose(modified, transcript)
+
+        input1 = k2.linear_fsa([1, 1, 1, 0, 0, 2, 2, 3, 3])
+        input2 = k2.linear_fsa([1, 1, 0, 0, 2, 2, 0, 3, 3])
+        inputs = [input1, input2]
+        for i in inputs:
+            lattice1 = k2.intersect(standard_graph,
+                                    i,
+                                    treat_epsilons_specially=False)
+            lattice2 = k2.intersect(modified_graph,
+                                    i,
+                                    treat_epsilons_specially=False)
+            lattice1 = k2.connect(lattice1)
+            lattice2 = k2.connect(lattice2)
+
+            aux_labels1 = lattice1.aux_labels[lattice1.aux_labels != 0]
+            aux_labels2 = lattice2.aux_labels[lattice2.aux_labels != 0]
+            aux_labels1 = aux_labels1[:-1]  # remove -1
+            aux_labels2 = aux_labels2[:-1]
+            assert torch.all(torch.eq(aux_labels1, aux_labels2))
+            assert torch.all(torch.eq(aux_labels2, torch.tensor([1, 2, 3])))
+
+    def test_with_repeated(self):
+        max_token = 2
+        standard = k2.ctc_topo(max_token, standard=True)
+        modified = k2.ctc_topo(max_token, standard=False)
+        transcript = k2.linear_fsa([1, 2, 2])
+        standard_graph = k2.compose(standard, transcript)
+        modified_graph = k2.compose(modified, transcript)
+
+        # There is a blank separating 2 in the input
+        # so standard and modified ctc topo should be equivalent
+        input = k2.linear_fsa([1, 1, 2, 2, 0, 2, 2, 0, 0])
+        lattice1 = k2.intersect(standard_graph,
+                                input,
+                                treat_epsilons_specially=False)
+        lattice2 = k2.intersect(modified_graph,
+                                input,
+                                treat_epsilons_specially=False)
+        lattice1 = k2.connect(lattice1)
+        lattice2 = k2.connect(lattice2)
+
+        aux_labels1 = lattice1.aux_labels[lattice1.aux_labels != 0]
+        aux_labels2 = lattice2.aux_labels[lattice2.aux_labels != 0]
+        aux_labels1 = aux_labels1[:-1]  # remove -1
+        aux_labels2 = aux_labels2[:-1]
+        assert torch.all(torch.eq(aux_labels1, aux_labels2))
+        assert torch.all(torch.eq(aux_labels1, torch.tensor([1, 2, 2])))
+
+        # There are no blanks separating 2 in the input.
+        # The standard ctc topo requires that there must be a blank
+        # separating 2, so lattice1 in the following is empty
+        input = k2.linear_fsa([1, 1, 2, 2, 0, 0])
+        lattice1 = k2.intersect(standard_graph,
+                                input,
+                                treat_epsilons_specially=False)
+        lattice2 = k2.intersect(modified_graph,
+                                input,
+                                treat_epsilons_specially=False)
+        lattice1 = k2.connect(lattice1)
+        lattice2 = k2.connect(lattice2)
+        assert lattice1.num_arcs == 0
+
+        # Since there are two 2s in the input and there are also two 2s
+        # in the transcript, the final output contains only one path.
+        # If there were more than two 2s in the input, the output
+        # would contain more than one path
+        aux_labels2 = lattice2.aux_labels[lattice2.aux_labels != 0]
+        aux_labels2 = aux_labels2[:-1]
+        assert torch.all(torch.eq(aux_labels1, torch.tensor([1, 2, 2])))
+
+
+if __name__ == '__main__':
+    #  TestCtcTopo.visualize_ctc_topo()
+    unittest.main()

--- a/k2/python/tests/nbest_test.py
+++ b/k2/python/tests/nbest_test.py
@@ -45,7 +45,7 @@ class TestNbest(unittest.TestCase):
 
         fsa_vec = k2.create_fsa_vec([fsa, fsa, fsa])
         shape = k2.RaggedShape('[[x x] [x]]')
-        nbest = k2.Nbest(fsa_vec, shape)
+        k2.Nbest(fsa_vec, shape)
 
     def test_top_k(self):
         fsa0 = k2.Fsa.from_str('''


### PR DESCRIPTION
## Standard ctc_topo
<img width="400" src="https://user-images.githubusercontent.com/5284924/126588984-785ad5d7-0afd-4e4d-9cd3-3734eb7f3402.png" />

It's deterministic. However, its number of arcs is `O(n^2)`, where `n` is the number of tokens.

## Modified ctc_topo
<img width="200" src="https://user-images.githubusercontent.com/5284924/126589064-4ee265dc-4108-4f27-b51c-f4de079b2c8c.png" />

It's non-deterministic. However, its number of arcs is `O(n)`, where `n` is the number of tokens.

## Transcript
<img width="400" src="https://user-images.githubusercontent.com/5284924/126589102-6ca29175-5678-4df6-b977-4c5d1b50854d.png" />


## standard graph = compose(standard_ctc_topo, transcript)
<img width="800" src="https://user-images.githubusercontent.com/5284924/126589162-fbb9623e-5b7b-4f3a-9990-08271eb68dc5.png" />



## modified graph = compose(modified_ctc_topo, transcript)
<img width="800" src="https://user-images.githubusercontent.com/5284924/126589174-4733421a-ce24-4758-a881-f6cc521fa89e.png" />

Differences between `standard_graph` and `modified_graph`:
  - In the standard graph, there is a **mandatory** blank between the two repeated symbols `o` in `zoo` (at state 4)
  - There is no such a constraint in the `modified_graph`

For the following input: `[z z <blk> <blk> o o <blk> o <blk>]`, since there is a blank in the input, when it is intersected with the `standard/modified_graph`, the outputs should be the same (shown below), that is, they are **equivalent** in this case
![inputs](https://user-images.githubusercontent.com/5284924/126589364-592a338c-8131-49f8-81e1-6703f52de883.png)

## standard lattice = intersect(standard_graph, input)
![standard_lattice](https://user-images.githubusercontent.com/5284924/126589496-0ccb0867-e694-4ca4-a1ee-b4a7cdaf8df0.png)

## modified lattice = intersect(modified_graph, input)
![modified_lattice](https://user-images.githubusercontent.com/5284924/126589501-32e8bb2c-b4d2-42ee-8899-b2b7c2a43dcf.png)

For the following input: `[z z <blk> <blk> o o  o <blk>]`, since there are no blanks between `o` in the inputs, when it is
intersected with the standard graph, the output is empty; the output for intersecting with the modified graph is not empty (given below)

![inputs2](https://user-images.githubusercontent.com/5284924/126589811-e1975d56-3e0f-4a81-abef-4b06993d6926.png)

## standard lattice2 = intersect(standard_graph, input2)
It's empty

## modified lattice2 = intersect(modified_graph, input2)
![modified_lattice2](https://user-images.githubusercontent.com/5284924/126589862-b73faacc-d5a8-4e97-baf8-7b60e8730bc5.png)

---

The code for producing the above figures is available at
https://github.com/k2-fsa/k2/blob/5ef66965509109009f4927fa5cadcf61fe3173ae/k2/python/tests/ctc_topo_test.py#L32
