### PR TITLE
Support building torch 1.3.1 and 1.4.0.

### DIFF
--- a/.github/workflows/nightly-cpu.yml
+++ b/.github/workflows/nightly-cpu.yml
@@ -37,10 +37,15 @@ jobs:
       matrix:
         os: [ubuntu-18.04, macos-10.15]
         # Python 3.9 is for PyTorch 1.7.1, 1.8.x, 1.9.0
+        # torch 1.3.1 supports only Python 3.5/6/7
         python-version: [3.6, 3.7, 3.8, 3.9]
-        torch: ["1.5.0", "1.5.1", "1.6.0", "1.7.0", "1.7.1", "1.8.0", "1.8.1", "1.9.0"]
+        torch: ["1.3.1", "1.4.0", "1.5.0", "1.5.1", "1.6.0", "1.7.0", "1.7.1", "1.8.0", "1.8.1", "1.9.0"]
         exclude:
-          - python-version: 3.9 # exclude Python 3.9 for [1.5.0, 1.5.1, 1.6.0, 1.7.0]
+          - python-version: 3.9 # exclude Python 3.9 for [1.3.1, 1.4.0, 1.5.0, 1.5.1, 1.6.0, 1.7.0]
+            torch: "1.3.1"
+          - python-version: 3.9
+            torch: "1.4.0"
+          - python-version: 3.9
             torch: "1.5.0"
           - python-version: 3.9
             torch: "1.5.1"
@@ -48,6 +53,8 @@ jobs:
             torch: "1.6.0"
           - python-version: 3.9
             torch: "1.7.0"
+          - python-version: 3.8 # exclude Python 3.8 for [1.3.1]
+            torch: "1.3.1"
 
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +94,8 @@ jobs:
         run: |
           python3 -m pip install -qq --upgrade pip
           python3 -m pip install -qq wheel twine typing_extensions
-          python3 -m pip install -qq torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          python3 -m pip install torch==${{ matrix.torch }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          python3 -m pip install --upgrade numpy
 
           python3 -c "import torch; print('torch version:', torch.__version__)"
 
@@ -98,6 +106,7 @@ jobs:
           python3 -m pip install -qq --upgrade pip
           python3 -m pip install -qq wheel twine
           python3 -m pip install -qq torch==${{ matrix.torch }}
+          python3 -m pip install --upgrade numpy
 
       - name: Build pip packages
         shell: bash

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -501,8 +501,14 @@ def fsa_from_unary_function_ragged(src: Fsa, dest_arcs: _k2.RaggedArc,
             # of -1 as the label precisely indicates final-arcs.
             if filler != -1:
                 value = value.clone()
-                value[torch.where(torch.logical_and(
-                    src.labels == -1, value == -1))] = filler
+                if hasattr(torch, 'logical_and'):
+                    # torch.logical_and requires torch>=1.5.0
+                    value[torch.where(
+                        torch.logical_and(src.labels == -1,
+                                          value == -1))] = filler
+                else:
+                    value[torch.where((src.labels == -1) &
+                                      (value == -1))] = filler
             new_value = index(value, arc_map)
             setattr(dest, name, k2.ragged.remove_values_eq(new_value, filler))
         else:


### PR DESCRIPTION
Add torch 1.3.1 and 1.4.0 so that ESPnet can install k2 in its GitHub actions.

See https://github.com/espnet/espnet/blob/3de98cec5d2bfe39ab4f7bbe8baa2a531e694ce3/.github/workflows/ci.yaml#L19
```
        python-version: [3.7]
        pytorch-version: [1.3.1, 1.4.0, 1.5.1, 1.6.0, 1.7.1, 1.8.1, 1.9.0]
```

ESPnet is using torch 1.3.1 and 1.4.0.