### PR TITLE
Fix a bug in invalidating the caches of an FSA.

### DIFF
--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -246,7 +246,7 @@ class Fsa(object):
         if scores_only is False:
             self.__dict__['_cache'] = dict()
         else:
-            pattern = re.compile('score')
+            pattern = re.compile(r'score|arc_cdf|arc_post')
             to_remove = []
 
             for key in self.__dict__['_cache']:


### PR DESCRIPTION
We should also remove arc_cdf and arc_post.

Found this bug during calling `k2.random_paths` with a scaled `lattice.scores`.

This patch should fix it.