### PR TITLE
Make ragged pickling back compatible to old format

### DIFF
--- a/k2/python/csrc/torch/ragged.cu
+++ b/k2/python/csrc/torch/ragged.cu
@@ -181,17 +181,16 @@ static void PybindRaggedTpl(py::module &m, const char *name) {
         torch::Tensor row_splits1_tensor = t[0].cast<torch::Tensor>();
         DeviceGuard guard(GetContext(row_splits1_tensor));
         Array1<int32_t> row_splits1 = FromTorch<int32_t>(row_splits1_tensor);
-        torch::Tensor values_tensor;
         Array1<T> values;
         RaggedShape shape;
         if (t.size() == 3) {
-          values_tensor = t[2].cast<torch::Tensor>();
+          torch::Tensor values_tensor = t[2].cast<torch::Tensor>();
           values = FromTorch<T>(values_tensor);
           shape = RaggedShape2(&row_splits1, nullptr, values.Dim());
         } else if (t.size() == 5) {
           torch::Tensor row_splits2_tensor = t[2].cast<torch::Tensor>();
           Array1<int32_t> row_splits2 = FromTorch<int32_t>(row_splits2_tensor);
-          values_tensor = t[4].cast<torch::Tensor>();
+          torch::Tensor values_tensor = t[4].cast<torch::Tensor>();
           values = FromTorch<T>(values_tensor);
           shape = RaggedShape3(&row_splits1, nullptr, -1,
                                &row_splits2, nullptr, values.Dim());


### PR DESCRIPTION
We do have to make ragged pickling back compatible to old format, there is a `RaggedInt`(aux_labels) in the HLG.pt