### PR TITLE
Implements ArgMaxPerSubList for device with cub::ArgMax

### DIFF
--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -602,7 +602,7 @@ void ArgMaxPerSublist(Ragged<T> &src, T initial_value, Array1<int32_t> *dst) {
     // of argmax results, we would recompute the error ones.
 
     Array1<int8_t> flag(c, 1, 0);
-    int8_t* flag_data = flag.Data();
+    int8_t *flag_data = flag.Data();
     K2_EVAL(
         c, src.NumElements(), lambda_check_argmax, (int32_t idx01) -> void {
           int32_t idx0 = row_ids[idx01];
@@ -624,9 +624,9 @@ void ArgMaxPerSublist(Ragged<T> &src, T initial_value, Array1<int32_t> *dst) {
             output_data[idx0] = max_idx;
           }
         });
-    flag_data = flag.To(GetCpuContext()).Data();
-    //flag_data = flag.Data();
-    if (flag_data[0] == 1)
+    flag = flag.To(GetCpuContext());
+    const int8_t *flag_data_c = flag.Data();
+    if (flag_data_c[0] == 1)
       K2_LOG(WARNING) << "There are errors in cub::ArgMax results,"
                       << "we have recomputed it.";
   }

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -597,6 +597,7 @@ void ArgMaxPerSublist(Ragged<T> &src, T initial_value, Array1<int32_t> *dst) {
     K2_EVAL(
         c, src.NumElements(), lambda_check_argmax, (int32_t idx01) -> void {
           int32_t idx0 = row_ids_data[idx01];
+          if (output_data[idx0] == -1) return;
           T max_value = values_data[output_data[idx0]];
           if (values_data[idx01] > max_value)
             keep[idx0] = (char)1;

--- a/k2/csrc/ragged_ops_inl.h
+++ b/k2/csrc/ragged_ops_inl.h
@@ -540,13 +540,11 @@ void ArgMaxPerSublist(Ragged<T> &src, T initial_value, Array1<int32_t> *dst) {
 
   int32_t last_axis = src.NumAxes() - 1;
   const Array1<int32_t> &row_splits_array = src.RowSplits(last_axis);
-  const Array1<int32_t> &row_ids_array = src.RowIds(last_axis);
   int32_t num_rows = row_splits_array.Dim() - 1;
   K2_CHECK_EQ(num_rows, dst->Dim());
 
   ContextPtr &c = src.Context();
-  const int32_t *row_splits = row_splits_array.Data(),
-                *row_ids = row_ids_array.Data();
+  const int32_t *row_splits = row_splits_array.Data();
   const T *values_data = src.values.Data();
   int32_t *output_data = dst->Data();
 
@@ -590,6 +588,8 @@ void ArgMaxPerSublist(Ragged<T> &src, T initial_value, Array1<int32_t> *dst) {
     // Do the same thing as the code above, but it need one more kernel to
     // add offset to the result.
 #if 0
+    const Array1<int32_t> &row_ids_array = src.RowIds(last_axis);
+    const int32_t *row_ids = row_ids_array.Data();
     size_t align = alignof(cub::KeyValuePair<int, T>);
     Array1<int8_t> out_storage(c,
         num_rows * sizeof(cub::KeyValuePair<int, T>) + align);

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -567,6 +567,20 @@ class TestRaggedOps(unittest.TestCase):
             expected = torch.tensor([0, 3, -1, 6, 9], device=device)
             assert torch.all(torch.eq(indexes, expected))
 
+    def test_argmax_per_sublist_two_axes_random(self):
+        res = []
+        # sublists with single element
+        for i in range(10000):
+            res.append([random.random() * -100])
+        # sublist with huge elements
+        res.append([random.random() * -100 for x in range(5000)])
+        ragged_cpu = k2.ragged.create_ragged2(res)
+        indexes_cpu = k2.ragged.argmax_per_sublist(ragged_cpu)
+        for device in self.devices:
+            ragged = ragged_cpu.to(device)
+            indexes = k2.ragged.argmax_per_sublist(ragged).to("cpu")
+            assert torch.all(torch.eq(indexes, indexes_cpu))
+
     def test_max_per_sublist_two_axes(self):
         for device in self.devices:
             src = k2.RaggedFloat(


### PR DESCRIPTION
There is a bug in current implementation of ArmMaxPerSubList which implements with `cub::Reduce`, the error occurs randomly, especially for the very unbalanced distributed data(size of sublists vary a lot). You can easily reproduce the bug with the code below.

```python
import k2
import torch
import random

res = []
# sublists with single element
for i in range(10000):
    res.append([random.random() * -100])
# sublist with huge elements
res.append([random.random() * -100 for x in range(5000)])
# sublists with single element
for i in range(100):
    res.append([random.random() * -100])

ragged_cpu = k2.ragged.create_ragged2(res)
ragged = ragged_cpu.to(torch.device("cuda:0"))

a = k2.ragged.argmax_per_sublist(ragged, -10000).to("cpu")
b = k2.ragged.argmax_per_sublist(ragged_cpu, -10000)

for i in range(len(a)):
    if a[i] != b[i]:
        print (a[i], b[i])
```

In this pull request, we implements the `ArgMaxPerSubList` with `cub::ArgMax`, see [here](https://nvlabs.github.io/cub/structcub_1_1_device_segmented_reduce.html#a2c61f69772a76c383ed8d34c6e5a2194), and we add a checking to confirm whether the results are right. We will see if `cub::ArgMax` works.