### PR TITLE
Support indexing 2-axes RaggedTensor, Support slicing for RaggedTensor

### DIFF
--- a/.github/workflows/nightly-cpu.yml
+++ b/.github/workflows/nightly-cpu.yml
@@ -17,6 +17,9 @@
 name: nightly-cpu
 
 on:
+  push:
+    branches:
+      - nightly-cpu
   schedule:
     # minute (0-59)
     # hour (0-23)

--- a/k2/python/csrc/torch/v2/any.cu
+++ b/k2/python/csrc/torch/v2/any.cu
@@ -76,9 +76,10 @@ void PybindRaggedAny(py::module &m) {
           return py::cast(ragged);
         } else {
           K2_CHECK_EQ(self.any.NumAxes(), 2);
-          const int32_t *row_split1_data = self.any.RowSplits(1).Data();
-          int32_t begin = row_split1_data[i],
-                  end = row_split1_data[i + 1];
+          Array1<int32_t> row_split = self.any.RowSplits(1).To(GetCpuContext());
+          const int32_t *row_split_data = row_split.Data();
+          int32_t begin = row_split_data[i],
+                  end = row_split_data[i + 1];
           Dtype t = self.any.GetDtype();
           FOR_REAL_AND_INT32_TYPES(t, T, {
             Array1<T> array =
@@ -108,7 +109,7 @@ void PybindRaggedAny(py::module &m) {
       }, kRaggedAnyGetItemSliceDoc);
 
   any.def("index",
-          static_cast<RaggedAny (RaggedAny::*)(RaggedAny &, bool)>(
+          static_cast<RaggedAny (RaggedAny::*)(RaggedAny &)>(
               &RaggedAny::Index),
           py::arg("indexes"),
           kRaggedAnyRaggedIndexDoc);

--- a/k2/python/csrc/torch/v2/any.cu
+++ b/k2/python/csrc/torch/v2/any.cu
@@ -70,15 +70,47 @@ void PybindRaggedAny(py::module &m) {
 
   any.def(
       "__getitem__",
-      [](RaggedAny &self, int32_t i) -> RaggedAny {
-        return self.Index(/*axis*/ 0, i);
+      [](RaggedAny &self, int32_t i) -> py::object {
+        if (self.any.NumAxes() > 2) {
+          RaggedAny ragged = self.Index(/*axis*/ 0, i);
+          return py::cast(ragged);
+        } else {
+          K2_CHECK_EQ(self.any.NumAxes(), 2);
+          const int32_t *row_split1_data = self.any.RowSplits(1).Data();
+          int32_t begin = row_split1_data[i],
+                  end = row_split1_data[i + 1];
+          Dtype t = self.any.GetDtype();
+          FOR_REAL_AND_INT32_TYPES(t, T, {
+            Array1<T> array =
+                self.any.Specialize<T>().values.Arange(begin, end);
+            torch::Tensor tensor = ToTorch(array);
+            return py::cast(tensor);
+          });
+        }
+        // Unreachable code
+        return py::none();
       },
       py::arg("i"), kRaggedAnyGetItemDoc);
+
+  any.def(
+      "__getitem__",
+      [](RaggedAny &self, const py::slice &slice) -> RaggedAny {
+        py::ssize_t start = 0, stop = 0, step = 0, slicelength = 0;
+        if (!slice.compute(self.any.Dim0(), &start, &stop, &step, &slicelength))
+          throw py::error_already_set();
+        int32_t istart = static_cast<int32_t>(start);
+        int32_t istop  = static_cast<int32_t>(stop);
+        int32_t istep  = static_cast<int32_t>(step);
+        K2_CHECK_EQ(istep, 1) << "Only support slicing with step 1, given : "
+                              << istep;
+
+        return self.Arange(/*axis*/ 0, istart, istop);
+      }, kRaggedAnyGetItemSliceDoc);
 
   any.def("index",
           static_cast<RaggedAny (RaggedAny::*)(RaggedAny &, bool)>(
               &RaggedAny::Index),
-          py::arg("indexes"), py::arg("remove_axis") = true,
+          py::arg("indexes"),
           kRaggedAnyRaggedIndexDoc);
 
   any.def("index",

--- a/k2/python/csrc/torch/v2/any.cu
+++ b/k2/python/csrc/torch/v2/any.cu
@@ -358,8 +358,8 @@ void PybindRaggedAny(py::module &m) {
   // Return the underlying memory of this tensor.
   // No data is copied. Memory is shared.
   any.def_property_readonly(
-      "data", [](RaggedAny &self) -> torch::Tensor { return self.Data(); },
-      kRaggedAnyDataDoc);
+      "values", [](RaggedAny &self) -> torch::Tensor { return self.Data(); },
+      kRaggedAnyValuesDoc);
 
   any.def_property_readonly(
       "shape", [](RaggedAny &self) -> RaggedShape { return self.any.shape; },

--- a/k2/python/csrc/torch/v2/any.cu
+++ b/k2/python/csrc/torch/v2/any.cu
@@ -106,7 +106,7 @@ void PybindRaggedAny(py::module &m) {
                               << istep;
 
         return self.Arange(/*axis*/ 0, istart, istop);
-      }, kRaggedAnyGetItemSliceDoc);
+      }, py::arg("key"), kRaggedAnyGetItemSliceDoc);
 
   any.def("index",
           static_cast<RaggedAny (RaggedAny::*)(RaggedAny &)>(

--- a/k2/python/csrc/torch/v2/doc/any.h
+++ b/k2/python/csrc/torch/v2/doc/any.h
@@ -350,9 +350,6 @@ Select the i-th sublist along axis 0.
 Caution:
   Support for autograd is to be implemented.
 
-Note:
-  It requires that this tensor has at least 3 axes.
-
 >>> import torch
 >>> import k2.ragged as k2r
 >>> a = k2r.RaggedTensor('[ [[1 3] [] [9]]  [[8]] ]')
@@ -363,11 +360,43 @@ Note:
 >>> a[1]
 [ [ 8 ] ]
 
+>>> a = k2r.RaggedTensor('[ [1 3] [9] [8] ]')
+>>> a
+[ [ 1 3 ] [ 9 ] [ 8 ] ]
+>>> a[0]
+tensor([1, 3], dtype=torch.int32)
+>>> a[1]
+tensor([9], dtype=torch.int32)
+
 Args:
   i:
     The i-th sublist along axis 0.
 Returns:
-  Return a new ragged tensor with one fewer axis.
+  Return a new ragged tensor with one fewer axis. If `num_axes == 2`, the
+  return value will be a 1D tensor.
+)doc";
+
+static constexpr const char *kRaggedAnyGetItemSliceDoc = R"doc(
+Slices sublists along axis 0 with the given range. Only support slicing step
+equals to 1.
+
+Caution:
+  Support for autograd is to be implemented.
+
+>>> import torch
+>>> import k2.ragged as k2r
+>>> a = k2r.RaggedTensor('[ [[1 3] [] [9]]  [[8]] [[10 11]] ]')
+>>> a
+[ [ [ 1 3 ] [ ] [ 9 ] ] [ [ 8 ] ] [ [ 10 11 ] ] ]
+>>> a[0:2]
+[ [ [ 1 3 ] [ ] [ 9 ] [ [ 8 ] ] ] ]
+>>> a[1:2]
+[ [ [ 8 ] ] [ [ 10 11 ] ] ]
+
+Args:
+Returns:
+  Return a new ragged tensor with the same axes as original ragged tensor, but
+  only contains the sublists within the range.
 )doc";
 
 static constexpr const char *kRaggedAnyCloneDoc = R"doc(
@@ -1301,14 +1330,10 @@ Index a ragged tensor with a ragged tensor.
   >>> import k2.ragged as k2r
   >>> src = k2r.RaggedTensor([[10, 11], [12, 13.5]])
   >>> indexes = k2r.RaggedTensor([[0, 1]])
-  >>> src.index(indexes, remove_axis=True)
-  [ [ 10 11 12 13.5 ] ]
-  >>> src.index(indexes, remove_axis=False)
+  >>> src.index(indexes)
   [ [ [ 10 11 ] [ 12 13.5 ] ] ]
   >>> i = k2r.RaggedTensor([[0], [1], [0, 0]])
-  >>> src.index(i, remove_axis=True)
-  [ [ 10 11 ] [ 12 13.5 ] [ 10 11 10 11 ] ]
-  >>> src.index(i, remove_axis=False)
+  >>> src.index(i)
   [ [ [ 10 11 ] ] [ [ 12 13.5 ] ] [ [ 10 11 ] [ 10 11 ] ] ]
 
 **Example 2**:
@@ -1316,9 +1341,7 @@ Index a ragged tensor with a ragged tensor.
   >>> import k2.ragged as k2r
   >>> src = k2r.RaggedTensor([ [[1, 0], [], [2]], [[], [3], [0, 0, 1]], [[1, 2], [-1]]])
   >>> i = k2r.RaggedTensor([[[0, 2], [1]], [[0]]])
-  >>> src.index(i, remove_axis=True)
-  [ [ [ [ 1 0 2 ] [ 1 2 -1 ] ] [ [ 3 0 0 1 ] ] ] [ [ [ 1 0 2 ] ] ] ]
-  >>> src.index(i, remove_axis=False)
+  >>> src.index(i)
   [ [ [ [ [ 1 0 ] [ ] [ 2 ] ] [ [ 1 2 ] [ -1 ] ] ] [ [ [ ] [ 3 ] [ 0 0 1 ] ] ] ] [ [ [ [ 1 0 ] [ ] [ 2 ] ] ] ] ]
 
 Args:
@@ -1328,13 +1351,6 @@ Args:
     Caution:
       Its dtype has to be ``torch.int32``.
 
-  remove_axis:
-    If ``True``, then we remove the last-but-one axis,
-    which has the effect of appending lists, e.g.
-    if ``self`` is ``[[ 10 11 ] [ 12 13 ]]`` and ``indexes``
-    is ``[[0 1]]`, this function will give us ``[[ 10 11 12 13 ]]``.
-    If ``False`` the answer will have at least 3 axes, e.g., ``[[[10 11]] [12 13]]]`` ,
-    in this case.
 Returns:
   Return indexed tensor.
 )doc";

--- a/k2/python/csrc/torch/v2/doc/any.h
+++ b/k2/python/csrc/torch/v2/doc/any.h
@@ -673,23 +673,23 @@ device(type='cuda', index=0)
 >>> b.device == torch.device('cuda:0')
 )doc";
 
-static constexpr const char *kRaggedAnyDataDoc = R"doc(
+static constexpr const char *kRaggedAnyValuesDoc = R"doc(
 Return the underlying memory as a 1-D tensor.
 
 >>> import torch
 >>> import k2.ragged as k2r
 >>> a = k2r.RaggedTensor([[1, 2], [], [5], [], [8, 9, 10]])
->>> a.data
+>>> a.values
 tensor([ 1,  2,  5,  8,  9, 10], dtype=torch.int32)
->>> isinstance(a.data, torch.Tensor)
+>>> isinstance(a.values, torch.Tensor)
 True
->>> a.data[0] = -1
+>>> a.values[-2] = -1
 >>> a
 [ [ -1 2 ] [ ] [ 5 ] [ ] [ 8 9 10 ] ]
->>> a.data[3] = -3
+>>> a.values[3] = -3
 >>> a
 [ [ -1 2 ] [ ] [ 5 ] [ ] [ -3 9 10 ] ]
->>> a.data[2] = -2
+>>> a.values[2] = -2
 >>> a
 [ [ -1 2 ] [ ] [ -2 ] [ ] [ -3 9 10 ] ]
 )doc";

--- a/k2/python/csrc/torch/v2/doc/any.h
+++ b/k2/python/csrc/torch/v2/doc/any.h
@@ -394,6 +394,8 @@ Caution:
 [ [ [ 8 ] ] [ [ 10 11 ] ] ]
 
 Args:
+  key:
+    Slice containing integer constants.
 Returns:
   Return a new ragged tensor with the same axes as original ragged tensor, but
   only contains the sublists within the range.

--- a/k2/python/csrc/torch/v2/ragged_any.cu
+++ b/k2/python/csrc/torch/v2/ragged_any.cu
@@ -560,13 +560,13 @@ torch::optional<torch::Tensor> RaggedAny::Sort(
   return ans;
 }
 
-RaggedAny RaggedAny::Index(RaggedAny &indexes,
-                           bool remove_axis /* = true*/) /*const*/ {
+RaggedAny RaggedAny::Index(RaggedAny &indexes) /*const*/ {
   K2_CHECK_EQ(indexes.any.GetDtype(), kInt32Dtype)
       << "Unsupported dtype: " << TraitsOf(indexes.any.GetDtype()).Name();
 
   DeviceGuard guard(any.Context());
 
+  bool remove_axis = false;
   Dtype t = any.GetDtype();
   FOR_REAL_AND_INT32_TYPES(t, T, {
     return RaggedAny(k2::Index<T>(any.Specialize<T>(),

--- a/k2/python/csrc/torch/v2/ragged_any.h
+++ b/k2/python/csrc/torch/v2/ragged_any.h
@@ -226,7 +226,7 @@ struct RaggedAny {
                                       bool need_new2old_indexes = false);
 
   /// Wrapper for k2::Index
-  RaggedAny Index(RaggedAny &indexes, bool remove_axis = true) /*const*/;
+  RaggedAny Index(RaggedAny &indexes) /*const*/;
 
   /// Wrapper for k2::Index
   std::pair<RaggedAny, torch::optional<torch::Tensor>> Index(

--- a/k2/python/k2/autograd_utils.py
+++ b/k2/python/k2/autograd_utils.py
@@ -105,7 +105,7 @@ class _PhantomIndexAndSumScoresFunction(torch.autograd.Function):
                           dtype=torch.float32,
                           device=unused_in_fsa_scores.device,
                           requires_grad=False)
-        _k2.index_add(arc_map.data, expanded, ans)
+        _k2.index_add(arc_map.values, expanded, ans)
 
         return (
             None,  # out_fsa

--- a/k2/python/k2/fsa.py
+++ b/k2/python/k2/fsa.py
@@ -1394,7 +1394,7 @@ class Fsa(object):
 
         # Note we use `to` here since `scores` and `self.scores` may not
         # be on the same device.
-        self.scores = ragged_scores.data.to(self.scores.device)
+        self.scores = ragged_scores.values.to(self.scores.device)
 
     def convert_attr_to_ragged_(self, name: str,
                                 remove_eps: bool = True) -> 'Fsa':

--- a/k2/python/k2/fsa_algo.py
+++ b/k2/python/k2/fsa_algo.py
@@ -466,7 +466,7 @@ def shortest_path(fsa: Fsa, use_double_scores: bool) -> Fsa:
     '''
     entering_arcs = fsa._get_entering_arcs(use_double_scores)
     ragged_arc, ragged_int = _k2.shortest_path(fsa.arcs, entering_arcs)
-    arc_map = ragged_int.data
+    arc_map = ragged_int.values
 
     out_fsa = k2.utils.fsa_from_unary_function_tensor(fsa, ragged_arc, arc_map)
     return out_fsa
@@ -1016,7 +1016,7 @@ def ctc_graph(symbols: Union[List[List[int]], k2.RaggedTensor],
     if isinstance(symbols, k2.RaggedTensor):
         assert device is None
         assert symbols.num_axes == 2
-        symbol_values = symbols.data
+        symbol_values = symbols.values
     else:
         symbol_values = torch.tensor(
             [it for symbol in symbols for it in symbol],

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -169,7 +169,7 @@ def to_dot(fsa: Fsa, title: Optional[str] = None) -> 'Digraph':  # noqa
         if end == begin:
             return ':<eps>'
 
-        labels = aux_labels.data[begin:end]
+        labels = aux_labels.values[begin:end]
         ans = []
         for label in labels.tolist():
             if label == -1:

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -538,6 +538,7 @@ def fsa_from_unary_function_ragged(src: Fsa,
                 # We currently don't support float ragged attributes
                 assert value.dtype == torch.int32
                 new_value = value.index(arc_map)
+                new_value = new_value.remove_axis(new_value.num_axes - 2)
             setattr(dest, name, new_value)
 
     for name, value in src.named_non_tensor_attr():

--- a/k2/python/tests/index_test.py
+++ b/k2/python/tests/index_test.py
@@ -145,6 +145,7 @@ class TestIndexRaggedTensor(unittest.TestCase):
                                         device=device)
             ragged_index = k2.RaggedTensor(index_shape, index_values)
             ans = src.index(ragged_index)
+            ans = ans.remove_axis(1)
             expected_row_splits = torch.tensor([0, 5, 5, 5, 9],
                                                dtype=torch.int32,
                                                device=device)

--- a/k2/python/tests/index_test.py
+++ b/k2/python/tests/index_test.py
@@ -154,7 +154,7 @@ class TestIndexRaggedTensor(unittest.TestCase):
             expected_values = torch.tensor([1, 2, 4, 5, 6, 3, 3, 1, 2],
                                            dtype=torch.int32,
                                            device=device)
-            self.assertTrue(torch.allclose(ans.data, expected_values))
+            self.assertTrue(torch.allclose(ans.values, expected_values))
 
             # index with tensor
             tensor_index = torch.tensor([0, 3, 2, 1, 2, 1],
@@ -169,7 +169,7 @@ class TestIndexRaggedTensor(unittest.TestCase):
             expected_values = torch.tensor([1, 2, 4, 5, 6, 3, 3],
                                            dtype=torch.int32,
                                            device=device)
-            self.assertTrue(torch.allclose(ans.data, expected_values))
+            self.assertTrue(torch.allclose(ans.values, expected_values))
 
 
 class TestIndexTensorWithRaggedInt(unittest.TestCase):
@@ -204,7 +204,7 @@ class TestIndexTensorWithRaggedInt(unittest.TestCase):
             expected_values = torch.tensor([1, 4, 3, 4, 6, 2, 4],
                                            dtype=torch.int32,
                                            device=device)
-            self.assertTrue(torch.allclose(ans.data, expected_values))
+            self.assertTrue(torch.allclose(ans.values, expected_values))
 
 
 if __name__ == '__main__':

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -591,11 +591,11 @@ class TestRaggedOps(unittest.TestCase):
             res.append([random.random() * -100])
         # sublist with huge elements
         res.append([random.random() * -100 for x in range(5000)])
-        ragged_cpu = k2.ragged.create_ragged2(res)
-        indexes_cpu = k2.ragged.argmax_per_sublist(ragged_cpu)
+        ragged_cpu = k2.RaggedTensor(res)
+        indexes_cpu = ragged_cpu.argmax()
         for device in self.devices:
             ragged = ragged_cpu.to(device)
-            indexes = k2.ragged.argmax_per_sublist(ragged).to("cpu")
+            indexes = ragged.argmax().to("cpu")
             assert torch.all(torch.eq(indexes, indexes_cpu))
 
     def test_max_per_sublist_two_axes(self):

--- a/k2/python/tests/ragged_ops_test.py
+++ b/k2/python/tests/ragged_ops_test.py
@@ -195,7 +195,7 @@ class TestRaggedOps(unittest.TestCase):
         for device in self.devices:
             for dtype in [torch.float32, torch.float64]:
                 src = k2.RaggedTensor(s, dtype).to(device)
-                saved = src.data.clone().detach()
+                saved = src.values.clone().detach()
                 saved.requires_grad_(True)
                 src.requires_grad_(True)
 
@@ -204,9 +204,9 @@ class TestRaggedOps(unittest.TestCase):
                 scale = torch.arange(ans.numel(), device=device)
 
                 # the stride of grad is not 0
-                (ans.data * scale).sum().backward()
+                (ans.values * scale).sum().backward()
 
-                expected = saved.new_zeros(*ans.data.shape)
+                expected = saved.new_zeros(*ans.values.shape)
 
                 normalizer = saved[:3].exp().sum().log()
                 expected[:3] = saved[:3] - normalizer
@@ -219,7 +219,7 @@ class TestRaggedOps(unittest.TestCase):
                 normalizer = saved[6:8].exp().sum().log()
                 expected[6:8] = saved[6:8] - normalizer
 
-                self.assertTrue(torch.allclose(expected, ans.data))
+                self.assertTrue(torch.allclose(expected, ans.values))
                 (expected * scale).sum().backward()
 
                 self.assertTrue(torch.allclose(saved.grad, src.grad))
@@ -231,16 +231,16 @@ class TestRaggedOps(unittest.TestCase):
         for device in self.devices:
             for dtype in [torch.float32, torch.float64]:
                 src = k2.RaggedTensor(s, dtype).to(device)
-                saved = src.data.clone().detach()
+                saved = src.values.clone().detach()
                 saved.requires_grad_(True)
                 src.requires_grad_(True)
 
                 ans = src.normalize(use_log=True)
 
                 # the stride of grad is 0
-                ans.data.sum().backward()
+                ans.values.sum().backward()
 
-                expected = saved.new_zeros(*ans.data.shape)
+                expected = saved.new_zeros(*ans.values.shape)
 
                 normalizer = saved[:3].exp().sum().log()
                 expected[:3] = saved[:3] - normalizer
@@ -253,7 +253,7 @@ class TestRaggedOps(unittest.TestCase):
                 normalizer = saved[6:8].exp().sum().log()
                 expected[6:8] = saved[6:8] - normalizer
 
-                self.assertTrue(torch.allclose(expected, ans.data))
+                self.assertTrue(torch.allclose(expected, ans.values))
                 expected.sum().backward()
 
                 self.assertTrue(torch.allclose(saved.grad, src.grad))
@@ -281,7 +281,7 @@ class TestRaggedOps(unittest.TestCase):
             normalized_scores = ragged_scores.normalize(use_log=True)
             assert normalized_scores.requires_grad is True
 
-            fsa.scores = normalized_scores.data
+            fsa.scores = normalized_scores.values
             assert fsa.scores.requires_grad is True
 
             # arcs leaving state 0
@@ -306,16 +306,16 @@ class TestRaggedOps(unittest.TestCase):
                     [ [1 3 5] [2 -1] [] [3] [5 2] ]
                 '''
                 src = k2.RaggedTensor(s, dtype=dtype).to(device)
-                saved = src.data
+                saved = src.values
 
                 ans = src.normalize(use_log=False)
-                expected = saved.new_zeros(*ans.data.shape)
+                expected = saved.new_zeros(*ans.values.shape)
                 expected[:3] = saved[:3] / saved[:3].sum()
                 expected[3:5] = saved[3:5] / saved[3:5].sum()
                 expected[5] = 1
                 expected[6:8] = saved[6:8] / saved[6:8].sum()
 
-                assert torch.allclose(ans.data, expected)
+                assert torch.allclose(ans.values, expected)
 
     def test_sum_per_sublist(self):
         s = '''
@@ -636,8 +636,8 @@ class TestRaggedOps(unittest.TestCase):
                 assert src == expected_src
                 assert torch.all(torch.eq(new2old, expected_new2old))
 
-                expected_sorted = k2.index_select(src_clone.data, new2old)
-                sorted = src.data
+                expected_sorted = k2.index_select(src_clone.values, new2old)
+                sorted = src.values
                 assert torch.all(torch.eq(expected_sorted, sorted))
 
     def test_sort_sublist_descending(self):
@@ -655,8 +655,8 @@ class TestRaggedOps(unittest.TestCase):
                 assert src == sorted_src
                 assert torch.all(torch.eq(new2old, expected_new2old))
 
-                expected_sorted = k2.index_select(src_clone.data, new2old)
-                sorted = src.data
+                expected_sorted = k2.index_select(src_clone.values, new2old)
+                sorted = src.values
                 assert torch.all(torch.eq(expected_sorted, sorted))
 
 

--- a/k2/python/tests/ragged_shape_test.py
+++ b/k2/python/tests/ragged_shape_test.py
@@ -118,7 +118,7 @@ class TestRaggedShape(unittest.TestCase):
             abshape2 = ashape.compose(bshape)
             assert abshape == prod.shape
             assert abshape2 == prod.shape
-            prod2 = k2.RaggedTensor(abshape2, b.data)
+            prod2 = k2.RaggedTensor(abshape2, b.values)
             assert prod == prod2
 
 

--- a/k2/python/tests/ragged_tensor_test.py
+++ b/k2/python/tests/ragged_tensor_test.py
@@ -65,22 +65,22 @@ class TestRaggedTensor(unittest.TestCase):
         assert b.num_axes == 3
         assert b.dim0 == 2
 
-    def test_property_data(self):
+    def test_property_values(self):
         a = k2r.RaggedTensor([[1], [2], [], [3, 4]])
-        assert torch.all(torch.eq(a.data, torch.tensor([1, 2, 3, 4])))
+        assert torch.all(torch.eq(a.values, torch.tensor([1, 2, 3, 4])))
 
         with self.assertRaises(AttributeError):
-            # the `data` attribute is const. You cannot rebind it
-            a.data = 10
+            # the `values` attribute is const. You cannot rebind it
+            a.values = 10
 
-        # However, we can change the elements of a.data
-        a.data[0] = 10
-        a.data[-1] *= 2
+        # However, we can change the elements of a.values
+        a.values[0] = 10
+        a.values[-1] *= 2
 
         expected = k2r.RaggedTensor([[10], [2], [], [3, 8]])
         assert a == expected
 
-        a.data[0] = 1
+        a.values[0] = 1
         assert a != expected
 
     def test_clone(self):
@@ -88,7 +88,7 @@ class TestRaggedTensor(unittest.TestCase):
         b = a.clone()
 
         assert a == b
-        a.data[0] = 10
+        a.values[0] = 10
 
         assert a != b
 
@@ -181,7 +181,7 @@ class TestRaggedTensor(unittest.TestCase):
                                    dtype=torch.int32,
                                    device=device)
                 b_1 = "row_ids1"
-                b_2 = a.data
+                b_2 = a.values
 
                 assert torch.all(torch.eq(b[0], b_0))
                 assert b[1] == b_1
@@ -203,7 +203,7 @@ class TestRaggedTensor(unittest.TestCase):
                                    dtype=torch.int32,
                                    device=device)  # noqa
                 b_3 = "row_ids2"
-                b_4 = a.data
+                b_4 = a.values
 
                 assert torch.all(torch.eq(b[0], b_0))
                 assert b[1] == b_1

--- a/k2/python/tests/ragged_test.py
+++ b/k2/python/tests/ragged_test.py
@@ -48,8 +48,8 @@ class TestRagged(unittest.TestCase):
             ragged_int = k2.RaggedTensor(s).to(device)
             print(ragged_int)
             assert torch.all(
-                torch.eq(ragged_int.data, torch.tensor([1, 2, 3],
-                                                       device=device)))
+                torch.eq(ragged_int.values, torch.tensor([1, 2, 3],
+                         device=device)))
             assert ragged_int.dim0 == 2
             assert torch.all(
                 torch.eq(ragged_int.shape.row_splits(1),

--- a/k2/python/tests/ragged_test.py
+++ b/k2/python/tests/ragged_test.py
@@ -49,7 +49,7 @@ class TestRagged(unittest.TestCase):
             print(ragged_int)
             assert torch.all(
                 torch.eq(ragged_int.values, torch.tensor([1, 2, 3],
-                         device=device)))
+                                                         device=device)))
             assert ragged_int.dim0 == 2
             assert torch.all(
                 torch.eq(ragged_int.shape.row_splits(1),

--- a/k2/python/tests/remove_epsilon_test.py
+++ b/k2/python/tests/remove_epsilon_test.py
@@ -352,7 +352,7 @@ class TestRemoveEpsilonDeviceFillers(unittest.TestCase):
         self.assertTrue(k2.is_rand_equivalent(fsa, dest, log_semiring))
 
         print("After removing epsilons: ", dest)
-        assert torch.where(dest.foo.data == filler)[0].numel() == 0
+        assert torch.where(dest.foo.values == filler)[0].numel() == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. support indexing 2-axes RaggedTensor
![image](https://user-images.githubusercontent.com/11765074/133105143-1d9c4cee-bbfb-4d4c-b185-ad0017f1aae3.png)

2. support slicing for RaggedTensor
![image](https://user-images.githubusercontent.com/11765074/133105038-8fd6733e-309a-44c9-a2c3-8f16ec285e42.png)

3. remove `remove_axis` in indexing RaggedTensor with RaggedTensor.
4. change `RaggedTensor.data` to `RaggedTensor.values`.