### PR TITLE
Support a[b[i]] where both a and b are ragged tensors.

### DIFF
--- a/k2/python/csrc/torch/v2/any.cu
+++ b/k2/python/csrc/torch/v2/any.cu
@@ -89,6 +89,7 @@ void PybindRaggedAny(py::module &m) {
           RaggedAny ragged = self.Index(/*axis*/ 0, i);
           return py::cast(ragged);
         } else {
+          DeviceGuard guard(self.any.Context());
           K2_CHECK_EQ(self.any.NumAxes(), 2);
           Array1<int32_t> row_split = self.any.RowSplits(1).To(GetCpuContext());
           const int32_t *row_split_data = row_split.Data();
@@ -121,6 +122,25 @@ void PybindRaggedAny(py::module &m) {
         return self.Arange(/*axis*/ 0, istart, istop);
       },
       py::arg("key"), kRaggedAnyGetItemSliceDoc);
+
+  any.def(
+      "__getitem__",
+      [](RaggedAny &self, torch::Tensor key) -> RaggedAny {
+        // key is a 1-d torch tensor with dtype torch.int32
+        DeviceGuard guard(self.any.Context());
+        Array1<int32_t> indexes = FromTorch<int32_t>(key);
+        Dtype t = self.any.GetDtype();
+        FOR_REAL_AND_INT32_TYPES(t, T, {
+          Ragged<T> ans =
+              k2::Index<T>(self.any.Specialize<T>(), /*axis*/ 0, indexes,
+                           /*value_indexes*/ nullptr);
+
+          return RaggedAny(ans.Generic());
+        });
+        // Unreachable code
+        return {};
+      },
+      py::arg("key"), kRaggedAnyGetItem1DTensorDoc);
 
   any.def("index",
           static_cast<RaggedAny (RaggedAny::*)(RaggedAny &)>(&RaggedAny::Index),

--- a/k2/python/csrc/torch/v2/doc/any.h
+++ b/k2/python/csrc/torch/v2/doc/any.h
@@ -692,6 +692,59 @@ Returns:
   only contains the sublists within the range.
 )doc";
 
+static constexpr const char *kRaggedAnyGetItem1DTensorDoc = R"doc(
+Slice a ragged tensor along axis 0 using a 1-D torch.int32 tensor.
+
+**Example 1**:
+
+  >>> import k2
+  >>> a = k2.RaggedTensor([[1, 2, 0], [0, 1], [2, 3]])
+  >>> b = k2.RaggedTensor([[10, 20], [300], [-10, 0, -1], [-2, 4, 5]])
+  >>> a[0]
+  tensor([1, 2, 0], dtype=torch.int32)
+  >>> b[a[0]]
+  RaggedTensor([[300],
+                [-10, 0, -1],
+                [10, 20]], dtype=torch.int32)
+  >>> a[1]
+  tensor([0, 1], dtype=torch.int32)
+  >>> b[a[1]]
+  RaggedTensor([[10, 20],
+                [300]], dtype=torch.int32)
+  >>> a[2]
+  tensor([2, 3], dtype=torch.int32)
+  >>> b[a[2]]
+  RaggedTensor([[-10, 0, -1],
+                [-2, 4, 5]], dtype=torch.int32)
+
+**Example 2**:
+
+  >>> import torch
+  >>> import k2
+  >>> a = k2.RaggedTensor([ [[1], [2, 3], [0]], [[], [2]], [[10, 20]] ])
+  >>> i = torch.tensor([0, 2, 1, 0], dtype=torch.int32)
+  >>> a[i]
+  RaggedTensor([[[1],
+                 [2, 3],
+                 [0]],
+                [[10, 20]],
+                [[],
+                 [2]],
+                [[1],
+                 [2, 3],
+                 [0]]], dtype=torch.int32)
+
+Args:
+  key:
+    A 1-D torch.int32 tensor containing the indexes to select along
+    axis 0.
+
+Return:
+  Return a new ragged tensor with the same number of axes as ``self`` but
+  only contains the specified sublists.
+
+)doc";
+
 static constexpr const char *kRaggedAnyCloneDoc = R"doc(
 Return a copy of this tensor.
 

--- a/k2/python/tests/ragged_tensor_test.py
+++ b/k2/python/tests/ragged_tensor_test.py
@@ -227,7 +227,7 @@ class TestRaggedTensor(unittest.TestCase):
 
                 assert torch.all(torch.eq(b, expected_sum))
 
-    def test_getitem(self):
+    def test_getitem_scalar(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 a = k2r.RaggedTensor(
@@ -243,6 +243,44 @@ class TestRaggedTensor(unittest.TestCase):
                 b = a[1]
                 expected = k2r.RaggedTensor("[[3] [5]]", dtype=dtype).to(device)
                 assert b == expected
+
+    def test_getitem_1d_tensor(self):
+        for device in self.devices:
+            for dtype in self.dtypes:
+                a = k2r.RaggedTensor([[1, 2, 0], [0, 1], [2, 3]], device=device)
+                b = k2.RaggedTensor(
+                    #   0        1        2             3
+                    [[10, 20], [300], [-10, 0, -1], [-2, 4, 5]],
+                    dtype=dtype,
+                    device=device,
+                )
+
+                # for a[0]
+                index = torch.tensor(
+                    [1, 2, 0], dtype=torch.int32, device=device
+                )
+                assert torch.all(torch.eq(a[0], index))
+                expected = k2.RaggedTensor(
+                    [[300], [-10, 0, -1], [10, 20]], dtype=dtype, device=device
+                )
+
+                assert b[a[0]] == expected
+
+                # for a[1]
+                index = torch.tensor([0, 1], dtype=torch.int32, device=device)
+                assert torch.all(torch.eq(a[1], index))
+                expected = k2.RaggedTensor(
+                    [[10, 20], [300]], dtype=dtype, device=device
+                )
+                assert b[a[1]] == expected
+
+                # for a[2]
+                index = torch.tensor([2, 3], dtype=torch.int32, device=device)
+                assert torch.all(torch.eq(a[2], index))
+                expected = k2.RaggedTensor(
+                    [[-10, 0, -1], [-2, 4, 5]], dtype=dtype, device=device
+                )
+                assert b[a[2]] == expected
 
     def test_getstate_2axes(self):
         for device in self.devices:


### PR DESCRIPTION
```python3
**Example 1**:
  >>> import k2
  >>> a = k2.RaggedTensor([[1, 2, 0], [0, 1], [2, 3]])
  >>> b = k2.RaggedTensor([[10, 20], [300], [-10, 0, -1], [-2, 4, 5]])
  >>> a[0]
  tensor([1, 2, 0], dtype=torch.int32)
  >>> b[a[0]]
  RaggedTensor([[300],
                [-10, 0, -1],
                [10, 20]], dtype=torch.int32)
  >>> a[1]
  tensor([0, 1], dtype=torch.int32)
  >>> b[a[1]]
  RaggedTensor([[10, 20],
                [300]], dtype=torch.int32)
  >>> a[2]
  tensor([2, 3], dtype=torch.int32)
  >>> b[a[2]]
  RaggedTensor([[-10, 0, -1],
                [-2, 4, 5]], dtype=torch.int32)
**Example 2**:
  >>> import torch
  >>> import k2
  >>> a = k2.RaggedTensor([ [[1], [2, 3], [0]], [[], [2]], [[10, 20]] ])
  >>> i = torch.tensor([0, 2, 1, 0], dtype=torch.int32)
  >>> a[i]
  RaggedTensor([[[1],
                 [2, 3],
                 [0]],
                [[10, 20]],
                [[],
                 [2]],
                [[1],
                 [2, 3],
                 [0]]], dtype=torch.int32)
```