### PR TITLE
Fix out-of-boundary access (read).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ message(STATUS "Enabled languages: ${languages}")
 
 project(k2 ${languages})
 
-set(K2_VERSION "1.9")
+set(K2_VERSION "1.10")
 
 # ----------------- Supported build types for K2 project -----------------
 set(ALLOWABLE_BUILD_TYPES Debug Release RelWithDebInfo MinSizeRel)

--- a/k2/csrc/ragged_utils.cu
+++ b/k2/csrc/ragged_utils.cu
@@ -156,7 +156,7 @@ RaggedShape IntersperseRaggedLayer(int32_t layer,
              row_splits_ptrs_data[src][pos];
         row_splits_data[i] = this_size;
       };
-      EvalDevice(c, new_num_rows + 1, lambda_get_sizes);
+      EvalDevice(c, new_num_rows, lambda_get_sizes);
       ExclusiveSum(row_splits, &row_splits);
     }
   }


### PR DESCRIPTION
Proposed by @danpovey  to fix the following error during decoding:
```
2021-11-02 14:29:01,969 INFO [decode.py:732] num_arcs before pruning: 183728
2021-11-02 14:29:01,969 INFO [decode.py:735] This OOM is not an error. You can ignore it. If your model does not converge well, or --max-duration is too large, or the input sound file is difficult to decode, you w\
ill meet this exception.
2021-11-02 14:29:01,980 INFO [decode.py:745] num_arcs after pruning: 4285
[F] /ceph-dan/k2/k2/csrc/array.h:385:T k2::Array1<T>::operator[](int32_t) const [with T = int; int32_t = int] Check failed: ret == cudaSuccess (700 vs. 0)  Error: an illegal memory access was encountered.


[ Stack-Trace: ]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2_log.so(k2::internal::GetStackTrace()+0x47) [0x7fff7b2913c7]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::Array1<int>::operator[](int) const+0x882) [0x7fff7b57ee82]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::RowSplitsToRowIds(k2::Array1<int> const&, k2::Array1<int>*)+0x97) [0x7fff7b5852f7]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::IntersperseRaggedLayer(int, int, k2::RaggedShape**, k2::Array1<unsigned int>*)+0x149f)\
 [0x7fff7b793bbf]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::Cat(int, int, k2::RaggedShape**, k2::Array1<unsigned int>*)+0x328) [0x7fff7b75ba28]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::Ragged<int> k2::Cat<int>(int, int, k2::Ragged<int>**, k2::Array1<unsigned int>*)+0x11c\
) [0x7fff7b6173ec]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::TopSorter::TopSort(k2::Array1<int>*)+0xaeb) [0x7fff7b87663b]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/libk2context.so(k2::TopSort(k2::Ragged<k2::Arc>&, k2::Ragged<k2::Arc>*, k2::Array1<int>*)+0x19c) [0x7fff7b\
86ae9c]
/ceph-dan/.local/lib/python3.8/site-packages/k2-1.9.dev20211022+cuda10.1.torch1.7.1-py3.8-linux-x86_64.egg/_k2.cpython-38-x86_64-linux-gnu.so(+0x6d581) [0x7fff7c563581]
running:
cd /ceph-dan/icefall/egs/librispeech/ASR
 python conformer_ctc_mix/decode.py --nbest-scale 0.5 --epoch 23 --avg 10 --method attention-decoder --max-duration 20 --num-paths 100 --lang-dir data/lang_bpe_5000
```

The above error happens rarely and is difficult to reproduce. Hope that this PR fixes that.