### PR TITLE
Fix compilation errors with CUB 1.15.

### DIFF
--- a/cmake/cub.cmake
+++ b/cmake/cub.cmake
@@ -20,8 +20,9 @@ function(download_cub)
 
   include(FetchContent)
 
-  set(cub_URL  "https://github.com/NVlabs/cub/archive/1.10.0.tar.gz")
-  set(cub_HASH "SHA256=8531e09f909aa021125cffa70a250761dfc247f960d7a1a12f65e6651ffb6477")
+  set(cub_URL  "https://github.com/NVlabs/cub/archive/1.15.0.tar.gz")
+  set(cub_HASH "SHA256=1781ee5eb7f00acfee5bff88e3acfc67378f6b3c24281335e18ae19e1f2ff685")
+
 
   FetchContent_Declare(cub
     URL               ${cub_URL}

--- a/k2/csrc/cub.h
+++ b/k2/csrc/cub.h
@@ -30,8 +30,33 @@
 // that k2 and PyTorch use a different copy
 // of CUB.
 
+#ifdef CUB_NS_PREFIX
+#undef CUB_NS_PREFIX
+#endif
+
+#ifdef CUB_NS_POSTFIX
+#undef CUB_NS_POSTFIX
+#endif
+
+#ifdef CUB_NS_QUALIFIER
+#undef CUB_NS_QUALIFIER
+#endif
+
+// see
+// https://github.com/NVIDIA/cub/commit/6631c72630f10e370d93814a59146b12f7620d85
+// The above commit replaced "thrust" with "THRUST_NS_QUALIFIER"
+#ifndef THRUST_NS_QUALIFIER
+#define THRUST_NS_QUALIFIER thrust
+#endif
+
 #define CUB_NS_PREFIX namespace k2 {
 #define CUB_NS_POSTFIX }
+
+// See
+// https://github.com/NVIDIA/cub/commit/6631c72630f10e370d93814a59146b12f7620d85
+// and
+// https://github.com/NVIDIA/cub/pull/350
+#define CUB_NS_QUALIFIER ::k2::cub
 
 #ifdef K2_WITH_CUDA
 #include "cub/cub.cuh"  // NOLINT
@@ -39,5 +64,6 @@
 
 #undef CUB_NS_PREFIX
 #undef CUB_NS_POSTFIX
+#undef CUB_NS_QUALIFIER
 
 #endif  // K2_CSRC_CUB_H_


### PR DESCRIPTION
Fixes #864 

Also, update CUB from 1.10 to 1.15. All tests passed locally compiled with CUDA 10.1

----

From https://github.com/NVIDIA/cub/blob/main/CHANGELOG.md
> CUB 1.15.0 includes a new cub::DeviceSegmentedSort algorithm, which demonstrates up to 5000x speedup compared to cub::DeviceSegmentedRadixSort when sorting a large number of small segments. A new cub::FutureValue<T> helper allows the cub::DeviceScan algorithms to lazily load the initial_value from a pointer. cub::DeviceScan also added ScanByKey functionality.

I think we can resolve https://github.com/k2-fsa/k2/issues/176 with CUB 1.15 and replace the usage of moderngpu
in k2, i.e., replace segmented sort added by https://github.com/k2-fsa/k2/pull/181