### PR TITLE
fix evaluating kFsaPropertiesValid

### DIFF
--- a/k2/torch/csrc/fsa_class.cu
+++ b/k2/torch/csrc/fsa_class.cu
@@ -104,7 +104,7 @@ int32_t FsaClass::Properties() {
     } else {
       GetFsaVecBasicProperties(fsa, nullptr, &properties);
     }
-    if (properties & kFsaPropertiesValid != kFsaPropertiesValid) {
+    if (!(properties & kFsaPropertiesValid)) {
       K2_LOG(FATAL) << "Fsa is not valid, properties are : " << properties
                     << " = " << FsaPropertiesAsString(properties)
                     << ", arcs are : " << fsa;


### PR DESCRIPTION
maybe "properties & kFsaPropertiesValid != kFsaPropertiesValid" is wrong? referring C++ Operator Precedence