### PR TITLE
Refactor FsaClass.

### DIFF
--- a/k2/torch/bin/decode.cu
+++ b/k2/torch/bin/decode.cu
@@ -268,7 +268,8 @@ int main(int argc, char *argv[]) {
   } else {
     K2_LOG(INFO) << "Load " << FLAGS_hlg;
     decoding_graph = k2::LoadFsa(FLAGS_hlg, device);
-    K2_CHECK(decoding_graph.HasAttr("aux_labels"));
+    K2_CHECK(decoding_graph.HasTensorAttr("aux_labels") ||
+             decoding_graph.HasRaggedTensorAttr("aux_labels"));
   }
 
   if (method == DecodingMethod::kNgramRescroing ||

--- a/k2/torch/csrc/decode.cu
+++ b/k2/torch/csrc/decode.cu
@@ -37,31 +37,30 @@ FsaClass GetLattice(torch::Tensor nnet_output, FsaClass &decoding_graph,
 }
 
 Ragged<int32_t> GetTexts(FsaClass &lattice) {
-  K2_CHECK(lattice.HasAttr("aux_labels"));
-  Ragged<int32_t> ragged_aux_labels;
-  torch::IValue aux_labels = lattice.GetAttr("aux_labels");
-  if (aux_labels.isTensor()) {
-    Array1<int32_t> aux_labels_array =
-        Array1FromTorch<int32_t>(aux_labels.toTensor());
+  if (lattice.HasTensorAttr("aux_labels")) {
+    torch::Tensor aux_labels = lattice.GetTensorAttr("aux_labels");
+    Array1<int32_t> aux_labels_array = Array1FromTorch<int32_t>(aux_labels);
     RaggedShape aux_labels_shape = RemoveAxis(lattice.fsa.shape, 1);
-    ragged_aux_labels = Ragged<int32_t>(aux_labels_shape, aux_labels_array);
+    auto ragged_aux_labels =
+        Ragged<int32_t>(aux_labels_shape, aux_labels_array);
+    return RemoveValuesLeq(ragged_aux_labels, 0);
   } else {
-    K2_CHECK(IsRaggedInt(aux_labels));
-    Ragged<int32_t> in_ragged_aux_labels = ToRaggedInt(aux_labels);
+    K2_CHECK(lattice.HasRaggedTensorAttr("aux_labels"));
+
+    auto aux_labels = lattice.GetRaggedTensorAttr("aux_labels");
     RaggedShape aux_labels_shape =
-        ComposeRaggedShapes(lattice.fsa.shape, in_ragged_aux_labels.shape);
+        ComposeRaggedShapes(lattice.fsa.shape, aux_labels.shape);
     aux_labels_shape = RemoveAxis(aux_labels_shape, 1);
     aux_labels_shape = RemoveAxis(aux_labels_shape, 1);
-    ragged_aux_labels =
-        Ragged<int32_t>(aux_labels_shape, in_ragged_aux_labels.values);
+    auto ragged_aux_labels =
+        Ragged<int32_t>(aux_labels_shape, aux_labels.values);
+    return RemoveValuesLeq(ragged_aux_labels, 0);
   }
-  ragged_aux_labels = RemoveValuesLeq(ragged_aux_labels, 0);
-  return ragged_aux_labels;
 }
 
 void WholeLatticeRescoring(FsaClass &G, float ngram_lm_scale,
                            FsaClass *lattice) {
-  K2_CHECK(lattice->HasAttr("lm_scores"));
+  K2_CHECK(lattice->HasTensorAttr("lm_scores"));
 
   torch::Tensor am_scores =
       lattice->Scores() - lattice->GetTensorAttr("lm_scores");
@@ -69,7 +68,7 @@ void WholeLatticeRescoring(FsaClass &G, float ngram_lm_scale,
 
   // Now, lattice contains only acoustic scores, we will attach LM scores
   // from the given n-gram LM
-  lattice->DeleteAttr("lm_scores");
+  lattice->DeleteTensorAttr("lm_scores");
 
   K2_CHECK_EQ(G.NumAttrs(), 1)
       << "G is expected to contain only 1 attribute: lm_scores.";

--- a/k2/torch/csrc/deserialization.h
+++ b/k2/torch/csrc/deserialization.h
@@ -27,16 +27,6 @@
 
 namespace k2 {
 
-// A helper class to construct a Ragged<int32_t> from an archive
-//
-// TODO(fangjun): Move it to .cu file as it is an implementation detail.
-struct RaggedIntHelper : public Ragged<int32_t>,
-                         public torch::CustomClassHolder {
-  using k2::Ragged<int32_t>::Ragged;
-  explicit RaggedIntHelper(const Ragged<int32_t> &ragged)
-      : Ragged<int32_t>(ragged) {}
-};
-
 /** Read a file saved in Python by `torch.save()`.
 
   Unlike torch::jit::pickle_load(), this function can also handle

--- a/k2/torch/csrc/deserialization_test.cu
+++ b/k2/torch/csrc/deserialization_test.cu
@@ -26,6 +26,9 @@
 
 namespace k2 {
 
+// defined in k2/torch/csrc/deserialization.cu
+Ragged<int32_t> ToRaggedInt(torch::IValue value);
+
 static void TestDictOfTensorIntStr(const std::string &dir_name) {
   std::string filename = dir_name + "/d1.pt";
   {

--- a/k2/torch/csrc/fsa_class.cu
+++ b/k2/torch/csrc/fsa_class.cu
@@ -37,11 +37,7 @@ namespace k2 {
 FsaClass FsaClass::FromUnaryFunctionTensor(FsaClass &src, const FsaOrVec &arcs,
                                            torch::Tensor arc_map) {
   FsaClass dest(arcs);
-  // Check the validation of the fsa, will trigger a fatal error if the fsa
-  // is not valid.
-  dest.Properties();
-  dest.CopyTensorAttrs(src, arc_map);
-  dest.CopyRaggedTensorAttrs(src, arc_map);
+  dest.CopyAttrs(src, arc_map);
   return dest;
 }
 
@@ -63,9 +59,8 @@ void FsaClass::CopyTensorAttrs(FsaClass &src, torch::Tensor arc_map) {
 void FsaClass::CopyRaggedTensorAttrs(FsaClass &src, torch::Tensor arc_map) {
   Array1<int32_t> indexes_array = Array1FromTorch<int32_t>(arc_map);
   for (auto &iter : src.ragged_tensor_attrs) {
-    Ragged<int32_t> ans =
-        Index<int32_t>(iter.second, /*axis*/ 0, indexes_array, nullptr);
-    SetRaggedTensorAttr(iter.first, ans);
+    auto value = Index<int32_t>(iter.second, 0, indexes_array, nullptr);
+    SetRaggedTensorAttr(iter.first, value);
   }
 }
 
@@ -102,14 +97,13 @@ int32_t FsaClass::Properties() {
     }
     if ((properties & kFsaPropertiesValid) != kFsaPropertiesValid) {
       K2_LOG(FATAL) << "Fsa is not valid, properties are : " << properties
-                    << " = " << FsaPropertiesAsString(properties)
-                    << ", arcs are : " << fsa;
+                    << " = " << FsaPropertiesAsString(properties);
     }
   }
   return properties;
 }
 
-torch::Tensor FsaClass::Labels() /*const*/ {
+torch::Tensor FsaClass::Labels() {
   auto device = DeviceFromContext(fsa.Context());
   auto scalar_type = caffe2::TypeMeta::Make<int32_t>();
   // an Arc has 4 members
@@ -132,148 +126,6 @@ void FsaClass::SetLabels(torch::Tensor labels) {
   K2_CHECK(ContextFromTensor(labels)->IsCompatible(*fsa.Context()));
   Labels().copy_(labels);
   properties = 0;  // Clear cached properties as we changed the labels
-}
-
-void FsaClass::SetAttr(const std::string &name, torch::IValue value) {
-  if (name == "scores") {
-    K2_CHECK(value.isTensor());
-    SetScores(value.toTensor());
-    return;
-  }
-
-  if (name == "labels") {
-    K2_CHECK(value.isTensor());
-    SetLabels(value.toTensor());
-    return;
-  }
-
-  if (HasAttr(name)) DeleteAttr(name);
-
-  if (value.isTensor()) {
-    SetTensorAttr(name, value.toTensor());
-  } else if (IsRaggedInt(value)) {
-    SetRaggedTensorAttr(name, ToRaggedInt(value));
-  } else {
-    K2_LOG(FATAL) << "Unsupported type: " << value.tagKind()
-                  << " for attribute '" << name
-                  << "'.\nExpect torch::Tensor or Ragged<int32_t>";
-  }
-  all_attr_names.insert(name);
-}
-
-torch::IValue FsaClass::GetAttr(const std::string &name) /*const*/ {
-  if (name == "scores") {
-    return torch::IValue(Scores());
-  }
-
-  if (name == "labels") {
-    return torch::IValue(Labels());
-  }
-
-  if (!HasAttr(name)) {
-    std::ostringstream os;
-    os << "No such attribute '" << name << "'";
-    throw std::runtime_error(os.str().c_str());
-  }
-
-  {
-    auto it = tensor_attrs.find(name);
-    if (it != tensor_attrs.end()) {
-      return torch::IValue(it->second);
-    }
-  }
-
-  {
-    auto it = ragged_tensor_attrs.find(name);
-    if (it != ragged_tensor_attrs.end()) {
-      return ToIValue(it->second);
-    }
-  }
-  // Unreachable code
-  K2_LOG(FATAL) << "Attribute not found, name : " << name;
-  return torch::IValue();
-}
-
-void FsaClass::DeleteAttr(const std::string &name) {
-  {
-    auto it = all_attr_names.find(name);
-    if (it != all_attr_names.end()) {
-      all_attr_names.erase(it);
-    } else {
-      std::ostringstream os;
-      os << "No such attribute '" << name << "'";
-      throw std::runtime_error(os.str().c_str());
-    }
-  }
-
-  {
-    // Were we allowed to use C++ 17, could we use the following statement:
-    // if (auto it = tensor_attrs.find(name); it != tensor_attrs.end()) {
-    auto it = tensor_attrs.find(name);
-    if (it != tensor_attrs.end()) {
-      tensor_attrs.erase(it);
-      return;
-    }
-  }
-
-  {
-    auto it = ragged_tensor_attrs.find(name);
-    if (it != ragged_tensor_attrs.end()) {
-      ragged_tensor_attrs.erase(it);
-      return;
-    }
-  }
-}
-
-bool FsaClass::HasAttr(const std::string &name) const {
-  // we treat labels & scores as attributes, though they don't store in
-  // attribute containers.
-  if (name == "scores" || name == "labels") return true;
-  return all_attr_names.count(name) > 0;
-}
-
-FsaClass FsaClass::ToOtherContext(const ContextPtr &context) const {
-  K2_CHECK(!context->IsCompatible(*fsa.Context()));
-  FsaClass dest(fsa.To(context));
-  auto device = DeviceFromContext(context);
-  for (const auto &iter : tensor_attrs) {
-    dest.SetTensorAttr(iter.first, iter.second.to(device));
-  }
-  for (const auto &iter : ragged_tensor_attrs) {
-    dest.SetRaggedTensorAttr(iter.first, iter.second.To(context));
-  }
-  return dest;
-}
-
-FsaClass FsaClass::To(torch::Device device) const {
-  ContextPtr context = fsa.Context();
-  if (device.is_cpu()) {
-    // CPU -> CPU
-    if (context->GetDeviceType() == kCpu) return *this;
-
-    // CUDA -> CPU
-    DeviceGuard guard(context);
-    return this->ToOtherContext(GetCpuContext());
-  }
-
-  K2_CHECK(device.is_cuda()) << device.str();
-
-  int32_t device_index = device.index();
-
-  if (context->GetDeviceType() == kCuda &&
-      context->GetDeviceId() == device_index)
-    // CUDA to CUDA, and it's the same device
-    return *this;
-
-  // CPU to CUDA
-  // or from one GPU to another GPU
-  DeviceGuard guard(device_index);
-  return this->ToOtherContext(GetCudaContext(device_index));
-}
-
-FsaClass FsaClass::To(const std::string &device) const {
-  torch::Device d(device);
-  return this->To(d);
 }
 
 }  // namespace k2

--- a/k2/torch/csrc/utils.cu
+++ b/k2/torch/csrc/utils.cu
@@ -158,18 +158,4 @@ torch::Tensor TensorToTorch(Tensor &tensor) {
       [saved_region = tensor.GetRegion()](void *) {}, options);
 }
 
-bool IsRaggedInt(torch::IValue value) {
-  return value.type() ==
-         torch::getCustomClassType<torch::intrusive_ptr<RaggedIntHelper>>();
-}
-
-Ragged<int32_t> ToRaggedInt(torch::IValue value) {
-  auto ragged_int_holder = value.toCustomClass<RaggedIntHelper>();
-  return *ragged_int_holder;
-}
-
-torch::IValue ToIValue(const Ragged<int32_t> &ragged) {
-  return torch::make_custom_class<RaggedIntHelper>(ragged);
-}
-
 }  // namespace k2

--- a/k2/torch/csrc/utils.h
+++ b/k2/torch/csrc/utils.h
@@ -212,22 +212,6 @@ torch::Tensor IndexSelect(torch::Tensor src, torch::Tensor index,
   return TensorToTorch(ans);
 }
 
-/** Whether the torch IValue contains a Ragged<int32_t> instance.
-
-    @param value  The given torch IValue.
-    @return Return true if the given value contains a Ragged<int32_t> instance,
-            otherwise fasle.
- */
-bool IsRaggedInt(torch::IValue value);
-
-/** Dispatch a torch IValue to a Ragged<int32_t>
- */
-Ragged<int32_t> ToRaggedInt(torch::IValue value);
-
-/** Wrap a Ragged<int32_t> to a torch IValue.
- */
-torch::IValue ToIValue(const Ragged<int32_t> &ragged);
-
 }  // namespace k2
 
 #endif  // K2_TORCH_CSRC_UTILS_H_


### PR DESCRIPTION
Since FSAs in decoding contain only one or two attributes, we
don't need to use an IValue to add one more indirection. Just
check the type of the attribute and process it accordingly.

Also, we usually know the type of the attribute in advance.