### PR TITLE
fix: LICENSE location to k2 folder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,6 @@ setuptools.setup(
     packages=['k2', 'k2.ragged', 'k2.sparse', 'k2.version'],
     install_requires=install_requires,
     extras_require={'dev': dev_requirements},
-    data_files=[('', ['LICENSE'])],
     ext_modules=[cmake_extension('_k2')],
     cmdclass={
         'build_ext': BuildExtension,


### PR DESCRIPTION
This pull request puts the LICENSE file in the k2 folder at installation. 

The LICENSE file is included in `data_files`.
https://github.com/k2-fsa/k2/blob/31e1307c3131d03384ef83c33472309d22d2e79d/setup.py#L218

However, when k2 or kaldilm are installed as system package, it is not copied to the k2 folder - instead it is copied to `/usr/LICENSE`. That is because for system installations, setuptools will take `sys.prefix` (e.g., `/usr`) as data_files default path: https://docs.python.org/3/distutils/setupscript.html#installing-additional-files

I found this issue while installing kaldilm, as it caused an installation conflict: kaldilm wanted to write `/usr/LICENSE` but it was already provided by k2.

To reproduce:
```python
sudo python setup.py install
```
.. and then `/usr/LICENSE` should appear.

kaldilm has the same issue @csukuangfj 

Thank you!! :smile: 