### PR TITLE
[Not for merge] Out-of-range bug of FSA or RaggedTensor index representation

### DIFF
--- a/k2/csrc/dtype.h
+++ b/k2/csrc/dtype.h
@@ -277,6 +277,38 @@ struct DtypeOf {
     }                                                                    \
   } while (0)
 
+#define FOR_REAL_AND_INT_TYPES(DtypeValue, TypeName, ...)                \
+  do {                                                                   \
+    switch (DtypeValue) {                                                \
+      case kFloatDtype: {                                                \
+        using TypeName = float;                                          \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      case kDoubleDtype: {                                               \
+        using TypeName = double;                                         \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      case kInt32Dtype: {                                                \
+        using TypeName = int32_t;                                        \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      case kInt64Dtype: {                                                \
+        using TypeName = int64_t;                                        \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      default:                                                           \
+        K2_LOG(FATAL)                                                    \
+            << "Dtype " << TraitsOf(DtypeValue).Name()                   \
+            << " not covered in switch statement. Op not supported for " \
+               "this type?";                                             \
+        break;                                                           \
+    }                                                                    \
+  } while (0)
+
 #define FOR_REAL_TYPES(DtypeValue, TypeName, ...)                        \
   do {                                                                   \
     switch (DtypeValue) {                                                \

--- a/k2/csrc/hash.h
+++ b/k2/csrc/hash.h
@@ -55,14 +55,43 @@ unsigned long long int __forceinline__ __host__ __device__ AtomicCAS(
   How class Hash works:
 
     - It can function as a map from key=uint32_t to value=uint32_t, or from
-      key=uint64_t to value=uint64_t where you choose NUM_KEY_BITS and
-      `key` must have only up to NUM_KEY_BITS set and `value` must have
-      only up to (64-NUM_KEY_BITS) set.  You decide NUM_KEY_BITS when
-      you call Hash::Accessor<NUM_KEY_BITS>()
-    - You can store any (key,value) pair except the pair where all the bits of
+      key=uint64_t to value=uint64_t, but you cannot use all 64 bits in the
+      key and value because we compress both of them into a single 64-bit
+      integer. There are several different modes of using this hash,
+      depending which accessor objects you use.  The modes are:
+
+        - Use Accessor<NUM_KEY_BITS> with num_key_bits known at compile time;
+          the number of values bits will be 64 - NUM_KEY_BITS.
+        - Use GenericAccessor, which is like Accessor but the number of
+          key bits is not known at compile time; and they both must still
+          sum to 64.
+        - Use PackedAccessor, which allows you to have the number of key
+          plus value bits greater than 64; the rest of the bits are
+          implicit in groups of buckets (the number of buckets must
+          be >= 32 * 1 << (num_key_bits + num_value_bits - 64).
+
+    - You must decide the number of key and value bits, and the number of
+      buckets, when you create the hash, but you can resize it (manually)
+      and when you resize it you can change the number of key and value bits.
+
+   Some constraints:
+    - You can store any (key,value) pair allowed by the number of key and value
+      bits, except the pair where all the bits of
       both and key and value are set [that is used to mean "nothing here"]
-    - The number of buckets is a power of 2 provided by the user to the constructor;
-      currently no resizing is supported.
+    - The number of buckets must always be a power of 2.
+    - When deleting values from the hash you must delete them all at
+      once (necessary because there is no concept of a "tombstone".
+
+   Some notes on usage:
+
+   You use it by: constructing it, obtaining its Accessor with GetAccessor()
+   with appropriate template args depending on your chosen accessor type; and
+   inside kernels (or host code), calling functions Insert(), Find() or Delete()
+   of the Accessor object.  Resizing is not automatic; it is the user's
+   responsibility to make sure the hash does not get too full (which could cause
+   assertion failures in kernels, and will be very slow).
+
+   Some implementation notes:
     - When accessing hash[key], we use bucket_index == key % num_buckets,
       bucket_inc = 1 | (((key * 2) / num_buckets) ^ key).
     - If the bucket at `bucket_index` is occupied, we look in locations
@@ -72,15 +101,7 @@ unsigned long long int __forceinline__ __host__ __device__ AtomicCAS(
       being odd ensures we eventually try all locations (of course for
       reasonable hash occupancy levels, we shouldn't ever have to try
       more than two or three).
-    - When deleting values from the hash you must delete them all at
-      once (necessary because there is no concept of a "tombstone".
 
-  You use it by: constructing it, obtaining its Accessor with
-  GetAccessor<NUM_KEY_BITS>(), and inside kernels (or host code), calling
-  functions Insert(), Find() or Delete() of the Accessor object.  There is no
-  resizing; sizing it correctly is the caller's responsibility and if the hash
-  gets full the code will just loop forever (of course it will get extremely
-  slow before it reaches that point).
 */
 class Hash {
  public:
@@ -94,10 +115,14 @@ class Hash {
      @param [in] num_key_bits   Number of bits in the key of the hash;
                 must satisfy 0 < num_key_bits < 64, and keys used must
                 be less than (1<<num_key_bits)-1.
-     @param [in] num_value_bits  Number of bits in the value of the hash.
-                If not specified it defaults to 64 - num_key_bits; in future
-                we'll allow more bits than that, by making some bits of
-                the key implicit in the bucket index.
+     @param [in] num_value_bits  Number of bits in the value of the hash;
+                if not specified, will be set to 64 - num_key_bits.  There
+                are constraints on the num_value_bits, it interacts with
+                which accessor you use.  For Accessor<> or GenericAccessor,
+                we require that num_key_bits + num_value_bits == 64.
+                For PackedAccessor we allow that num_key_bits + num_value_bits > 64,
+                but with the constraint that
+                  (num_buckets >> (64 - num_key_bits - num_value_bits)) >= 32
   */
   Hash(ContextPtr c,
        int32_t num_buckets,

--- a/k2/csrc/tensor.cu
+++ b/k2/csrc/tensor.cu
@@ -147,7 +147,7 @@ Tensor::Tensor(ContextPtr c, Dtype type, const std::vector<int32_t> &dims)
 }
 
 Tensor::Tensor(Dtype type, const Shape &shape, RegionPtr region,
-               int32_t byte_offset)
+               size_t byte_offset)
     : impl_(std::make_shared<TensorImpl>()) {
   int64_t begin_elem, end_elem;
   shape.GetReachableElems(&begin_elem, &end_elem);

--- a/k2/csrc/tensor.h
+++ b/k2/csrc/tensor.h
@@ -176,7 +176,7 @@ class Tensor {
   Tensor(ContextPtr c, Dtype type, const std::vector<int32_t> &dims);
 
   // Create Tensor backed by existing memory.
-  Tensor(Dtype type, const Shape &shape, RegionPtr region, int32_t byte_offset);
+  Tensor(Dtype type, const Shape &shape, RegionPtr region, size_t byte_offset);
 
   Tensor(const Tensor &other) = default;
   Tensor &operator=(const Tensor &other) = default;

--- a/k2/python/csrc/torch.cu
+++ b/k2/python/csrc/torch.cu
@@ -25,6 +25,7 @@
 #if defined(K2_USE_PYTORCH)
 
 #include "k2/python/csrc/torch/arc.h"
+#include "k2/python/csrc/torch/array_ops.h"
 #include "k2/python/csrc/torch/discounted_cum_sum.h"
 #include "k2/python/csrc/torch/fsa.h"
 #include "k2/python/csrc/torch/fsa_algo.h"
@@ -37,6 +38,7 @@
 
 void PybindTorch(py::module &m) {
   PybindArc(m);
+  PybindArrayOps(m);
   PybindDiscountedCumSum(m);
   PybindFsa(m);
   PybindFsaAlgo(m);

--- a/k2/python/csrc/torch/CMakeLists.txt
+++ b/k2/python/csrc/torch/CMakeLists.txt
@@ -1,6 +1,7 @@
 # please keep the list sorted
 set(torch_srcs
   arc.cu
+  array_ops.cu
   discounted_cum_sum.cu
   fsa.cu
   fsa_algo.cu

--- a/k2/python/csrc/torch/array_ops.cu
+++ b/k2/python/csrc/torch/array_ops.cu
@@ -1,0 +1,73 @@
+/**
+ * @brief python wrappers for array_ops.h
+ *
+ * @copyright
+ * Copyright      2021  Xiaomi Corp.       (authors: Wei Kang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "k2/csrc/array_ops.h"
+#include "k2/csrc/device_guard.h"
+#include "k2/python/csrc/torch/array_ops.h"
+#include "k2/python/csrc/torch/torch_util.h"
+
+namespace k2 {
+
+static void PybindMonotonicLowerBound(py::module &m) {
+  m.def(
+      "monotonic_lower_bound",
+      [](torch::Tensor src, bool inplace = false) -> torch::Tensor {
+        Dtype t = ScalarTypeToDtype(src.scalar_type());
+        ContextPtr c = GetContext(src);
+        DeviceGuard guard(c);
+        FOR_REAL_AND_INT_TYPES(t, T, {
+          if (src.dim() == 1) {
+            Array1<T> src_array = FromTorch<T>(src);
+            Array1<T> dest_array = src_array;
+            if (!inplace) {
+              dest_array = Array1<T>(c, src_array.Dim());
+            }
+            MonotonicLowerBound(src_array, &dest_array);
+            return ToTorch<T>(dest_array);
+          } else if (src.dim() == 2) {
+            Array2<T> src_array = FromTorch<T>(src, Array2Tag{});
+            Array2<T> dest_array = src_array;
+            if (!inplace) {
+              dest_array = Array2<T>(c, src_array.Dim0(), src_array.Dim1());
+            }
+            for (int32_t i = 0; i < src_array.Dim0(); ++i) {
+              Array1<T> row = dest_array.Row(i);
+              MonotonicLowerBound(src_array.Row(i), &row);
+            }
+            return ToTorch<T>(dest_array);
+          } else {
+            K2_LOG(FATAL)
+                << "Only support 1 dimension and 2 dimensions tensor, given "
+                   "dimension : "
+                << src.dim();
+            return torch::Tensor();
+          }
+        });
+        // Unreachable code, to make compiler happy
+        return torch::Tensor();
+      },
+      py::arg("src"), py::arg("inplace") = false);
+}
+
+}  // namespace k2
+
+void PybindArrayOps(py::module &m) { k2::PybindMonotonicLowerBound(m); }

--- a/k2/python/csrc/torch/array_ops.h
+++ b/k2/python/csrc/torch/array_ops.h
@@ -1,0 +1,30 @@
+/**
+ * @brief python wrappers for array_ops.h
+ *
+ * @copyright
+ * Copyright      2021  Xiaomi Corp.       (author: Wei Kang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef K2_PYTHON_CSRC_TORCH_ARRAY_OPS_H_
+#define K2_PYTHON_CSRC_TORCH_ARRAY_OPS_H_
+
+#include "k2/python/csrc/torch.h"
+
+void PybindArrayOps(py::module &m);
+
+#endif  // K2_PYTHON_CSRC_TORCH_ARRAY_OPS_H_

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -64,6 +64,7 @@ from .utils import create_fsa_vec
 from .utils import create_sparse
 from .utils import is_rand_equivalent
 from .utils import get_best_matching_stats
+from .utils import monotonic_lower_bound
 from .utils import to_dot
 from .utils import to_str
 from .utils import to_str_simple

--- a/k2/python/k2/fsa_properties.py
+++ b/k2/python/k2/fsa_properties.py
@@ -23,7 +23,7 @@ import _k2
 
 VALID = 0x01  # Valid from a formatting perspective
 NONEMPTY = 0x02  # Nonempty as in, has at least one arc.
-TOPSORTED = 0x04,  # FSA is top-sorted, but possibly with
+TOPSORTED = 0x04  # FSA is top-sorted, but possibly with
 # self-loops, dest_state >= src_state
 TOPSORTED_AND_ACYCLIC = 0x08  # Fsa is topsorted, dest_state > src_state
 ARC_SORTED = 0x10  # Fsa is arc-sorted: arcs leaving a state are are sorted by

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ endfunction()
 set(py_test_files
   add_epsilon_self_loops_test.py
   arc_sort_test.py
+  array_ops_test.py
   cat_test.py
   compose_arc_maps_test.py
   closure_test.py

--- a/k2/python/tests/array_ops_test.py
+++ b/k2/python/tests/array_ops_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright      2021  Xiaomi Corporation (author: Wei kang)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R array_ops_test_py
+
+import unittest
+
+import random
+import torch
+import k2
+
+
+class TestArrayOps(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.devices = [torch.device("cpu")]
+        if torch.cuda.is_available() and k2.with_cuda:
+            cls.devices.append(torch.device("cuda", 0))
+            if torch.cuda.device_count() > 1:
+                torch.cuda.set_device(1)
+                cls.devices.append(torch.device("cuda", 1))
+
+        cls.dtypes = [torch.int32, torch.int64, torch.float32, torch.float64]
+
+    def test_monotonic_lower_bound(self):
+        for device in self.devices:
+            for dtype in self.dtypes:
+                # simple case
+                src = torch.tensor(
+                    [2, 1, 3, 7, 5, 8, 20, 15], dtype=dtype, device=device
+                )
+                expected = torch.tensor(
+                    [1, 1, 3, 5, 5, 8, 15, 15], dtype=dtype, device=device
+                )
+                dest = k2.monotonic_lower_bound(src)
+                assert torch.allclose(dest, expected)
+                assert torch.allclose(
+                    src,
+                    torch.tensor(
+                        [2, 1, 3, 7, 5, 8, 20, 15], dtype=dtype, device=device
+                    ),
+                )
+                k2.monotonic_lower_bound(src, inplace=True)
+                assert torch.allclose(src, expected)
+
+                # random case
+                src = torch.randint(100, (10, 100), dtype=dtype, device=device)
+                dest = k2.monotonic_lower_bound(src)
+                expected = torch.zeros_like(src, device=torch.device("cpu"))
+                dest = dest.to("cpu")
+                for i in range(src.shape[0]):
+                    min_value = 101
+                    for j in range(src.shape[1] - 1, -1, -1):
+                        min_value = min(dest[i][j], min_value)
+                        expected[i][j] = min_value
+                assert torch.allclose(dest, expected)
+
+                k2.monotonic_lower_bound(src, inplace=True)
+                src = src.to("cpu")
+                assert torch.allclose(src, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Just to point out that when constructing large FST graph or RaggedTensor, there will be numerical out-of-range by using int32_t for index or offset representation in k2 frameworks.

One of the impact of this bug is that the framework can not be applied to large-scale speech recognition decoding graph construction, (example can be found [here](https://github.com/k2-fsa/icefall/issues/132)).

The commits in this PR is only to fix a small bug in Tensor construction. However, there are still a lot of modifications related to index representation that need to be made in the future.