### PR TITLE
Wrap MonotonicLowerBound

### DIFF
--- a/k2/csrc/dtype.h
+++ b/k2/csrc/dtype.h
@@ -277,6 +277,38 @@ struct DtypeOf {
     }                                                                    \
   } while (0)
 
+#define FOR_REAL_AND_INT_TYPES(DtypeValue, TypeName, ...)                \
+  do {                                                                   \
+    switch (DtypeValue) {                                                \
+      case kFloatDtype: {                                                \
+        using TypeName = float;                                          \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      case kDoubleDtype: {                                               \
+        using TypeName = double;                                         \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      case kInt32Dtype: {                                                \
+        using TypeName = int32_t;                                        \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      case kInt64Dtype: {                                                \
+        using TypeName = int64_t;                                        \
+        __VA_ARGS__;                                                     \
+        break;                                                           \
+      }                                                                  \
+      default:                                                           \
+        K2_LOG(FATAL)                                                    \
+            << "Dtype " << TraitsOf(DtypeValue).Name()                   \
+            << " not covered in switch statement. Op not supported for " \
+               "this type?";                                             \
+        break;                                                           \
+    }                                                                    \
+  } while (0)
+
 #define FOR_REAL_TYPES(DtypeValue, TypeName, ...)                        \
   do {                                                                   \
     switch (DtypeValue) {                                                \

--- a/k2/python/csrc/torch.cu
+++ b/k2/python/csrc/torch.cu
@@ -24,6 +24,7 @@
 
 #if defined(K2_USE_PYTORCH)
 
+#include "k2/python/csrc/torch/array_ops.h"
 #include "k2/python/csrc/torch/arc.h"
 #include "k2/python/csrc/torch/discounted_cum_sum.h"
 #include "k2/python/csrc/torch/fsa.h"
@@ -36,6 +37,7 @@
 #include "k2/python/csrc/torch/v2/k2.h"
 
 void PybindTorch(py::module &m) {
+  PybindArrayOps(m);
   PybindArc(m);
   PybindDiscountedCumSum(m);
   PybindFsa(m);

--- a/k2/python/csrc/torch.cu
+++ b/k2/python/csrc/torch.cu
@@ -24,8 +24,8 @@
 
 #if defined(K2_USE_PYTORCH)
 
-#include "k2/python/csrc/torch/array_ops.h"
 #include "k2/python/csrc/torch/arc.h"
+#include "k2/python/csrc/torch/array_ops.h"
 #include "k2/python/csrc/torch/discounted_cum_sum.h"
 #include "k2/python/csrc/torch/fsa.h"
 #include "k2/python/csrc/torch/fsa_algo.h"
@@ -37,8 +37,8 @@
 #include "k2/python/csrc/torch/v2/k2.h"
 
 void PybindTorch(py::module &m) {
-  PybindArrayOps(m);
   PybindArc(m);
+  PybindArrayOps(m);
   PybindDiscountedCumSum(m);
   PybindFsa(m);
   PybindFsaAlgo(m);

--- a/k2/python/csrc/torch/CMakeLists.txt
+++ b/k2/python/csrc/torch/CMakeLists.txt
@@ -1,7 +1,7 @@
 # please keep the list sorted
 set(torch_srcs
-  array_ops.cu
   arc.cu
+  array_ops.cu
   discounted_cum_sum.cu
   fsa.cu
   fsa_algo.cu

--- a/k2/python/csrc/torch/CMakeLists.txt
+++ b/k2/python/csrc/torch/CMakeLists.txt
@@ -1,5 +1,6 @@
 # please keep the list sorted
 set(torch_srcs
+  array_ops.cu
   arc.cu
   discounted_cum_sum.cu
   fsa.cu

--- a/k2/python/csrc/torch/array_ops.cu
+++ b/k2/python/csrc/torch/array_ops.cu
@@ -34,7 +34,7 @@ static void PybindMonotonicLowerBound(py::module &m) {
         Dtype t = ScalarTypeToDtype(src.scalar_type());
         ContextPtr c = GetContext(src);
         DeviceGuard guard(c);
-        FOR_REAL_AND_INT32_TYPES(t, T, {
+        FOR_REAL_AND_INT_TYPES(t, T, {
           if (src.dim() == 1) {
             Array1<T> src_array = FromTorch<T>(src);
             Array1<T> dest_array = src_array;

--- a/k2/python/csrc/torch/array_ops.cu
+++ b/k2/python/csrc/torch/array_ops.cu
@@ -1,0 +1,81 @@
+/**
+ * @brief python wrappers for array_ops.h
+ *
+ * @copyright
+ * Copyright      2021  Xiaomi Corp.       (authors: Wei Kang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "k2/csrc/array_ops.h"
+#include "k2/csrc/device_guard.h"
+#include "k2/python/csrc/torch/array_ops.h"
+#include "k2/python/csrc/torch/torch_util.h"
+
+namespace k2 {
+
+static void PybindMonotonicLowerBound(py::module &m) {
+  m.def(
+      "monotonic_lower_bound",
+      [](torch::Tensor src, bool inplace = false) -> torch::Tensor {
+        Dtype t = ScalarTypeToDtype(src.scalar_type());
+        ContextPtr c = GetContext(src);
+        FOR_REAL_AND_INT32_TYPES(
+            t, T, {
+              if (src.dim() == 1) {
+                Array1<T> src_array = FromTorch<T>(src);
+                Array1<T> dest_array = src_array;
+                if (!inplace) {
+                  dest_array = Array1<T>(c, src_array.Dim());
+                }
+                MonotonicLowerBound(src_array, &dest_array);
+                return ToTorch<T>(dest_array);
+              } else if (src.dim() == 2) {
+                Array2<T> src_array = FromTorch<T>(src, Array2Tag{});
+                Array2<T> dest_array = src_array;
+                if (!inplace) {
+                  dest_array = Array2<T>(c, src_array.Dim0(), src_array.Dim1());
+                }
+                for (int32_t i = 0; i < src_array.Dim0(); ++i) {
+                  Array1<T> row = dest_array.Row(i);
+                  MonotonicLowerBound(src_array.Row(i), &row);
+                }
+                return ToTorch<T>(dest_array);
+              } else {
+                K2_LOG(FATAL)
+                    << "Only support 1 dimension and 2 dimension tensor, given "
+                       "dimension : "
+                    << src.dim();
+                return torch::Tensor();
+              }
+            });
+        // Unreachable code, to make compiler happy
+        return torch::Tensor();
+      },
+      py::arg("src"), py::arg("inplace") = false);
+}
+
+}  // namespace k2
+
+void PybindArrayOps(py::module &m) {
+  using namespace k2;
+  PybindMonotonicLowerBound(m);
+}

--- a/k2/python/csrc/torch/array_ops.h
+++ b/k2/python/csrc/torch/array_ops.h
@@ -1,0 +1,30 @@
+/**
+ * @brief python wrappers for array_ops.h
+ *
+ * @copyright
+ * Copyright      2021  Xiaomi Corp.       (author: Wei Kang)
+ *
+ * @copyright
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef K2_PYTHON_CSRC_TORCH_ARRAY_OPS_H_
+#define K2_PYTHON_CSRC_TORCH_ARRAY_OPS_H_
+
+#include "k2/python/csrc/torch.h"
+
+void PybindArrayOps(py::module &m);
+
+#endif  // K2_PYTHON_CSRC_TORCH_ARRAY_OPS_H_

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -64,6 +64,7 @@ from .utils import create_fsa_vec
 from .utils import create_sparse
 from .utils import is_rand_equivalent
 from .utils import get_best_matching_stats
+from .utils import monotonic_lower_bound
 from .utils import to_dot
 from .utils import to_str
 from .utils import to_str_simple

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -785,10 +785,21 @@ def get_best_matching_stats(
 
 def monotonic_lower_bound(src: torch.Tensor,
                           inplace: bool = False) -> torch.Tensor:
-    '''Compute a monotonically increasing lower bound on the array `src`.
+    """Compute a monotonically increasing lower bound on the array `src`.
+    The basic idea is: we traverse the array in reverse order, and update
+    current element with the following statement,
+
+        min_value = min(src[i], min_value)
+        dest[i] = min_value
+
+    we initialize the min_value with `inf`, so the last element always keeps
+    the same. See the examples below, if the input tensor is
+    `[0, 2, 1, 3, 6, 5, 8]`, the output tensor will be `[0, 1, 1, 3, 5, 5, 8]`,
+    i.e. we traverse it in reverse order and guarantee that
+    `dest[i] <= dest[i+1]`.
 
     Note: Only support 1 dimension and 2 dimensions tentor with dtype equals to
-      `torch.int32`,`torch.float` and `torch.float64`.
+      `torch.int32`,`torch.int64`, `torch.float` or `torch.float64`.
 
     >>> import k2
     >>> import torch
@@ -822,7 +833,8 @@ def monotonic_lower_bound(src: torch.Tensor,
     Args:
       src:
         The source tensor, MUST be a 1 dimension or 2 dimensions tensor with
-        dtype equals to `torch.int32`,`torch.float` and `torch.float64`.
+        dtype equals to `torch.int32`,`torch.int64`,`torch.float` or
+        `torch.float64`.
       inplace:
         True to modify the source tensor inplace, Fasle to return another
         tensor.
@@ -831,5 +843,5 @@ def monotonic_lower_bound(src: torch.Tensor,
       Returns a tensor which is monotonic(i.e. satisfiy `dest[i] <= dest[i+1]`),
       the returned tensor shares the same underlying memory with the source
       tensor if inplace is True.
-    '''
+    """
     return _k2.monotonic_lower_bound(src, inplace)

--- a/k2/python/k2/utils.py
+++ b/k2/python/k2/utils.py
@@ -694,8 +694,8 @@ def random_fsa_vec(min_num_fsas: int = 1,
 
 
 def get_best_matching_stats(
-        tokens: k2.RaggedTensor, scores: torch.Tensor, counts: torch.Tensor,
-        eos: int, min_token: int, max_token: int, max_order: int
+    tokens: k2.RaggedTensor, scores: torch.Tensor, counts: torch.Tensor,
+    eos: int, min_token: int, max_token: int, max_order: int
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:  # noqa
     '''For "query" sentences, this function gets the mean and variance of
     scores from the best matching words-in-context in a set of provided "key"
@@ -781,3 +781,55 @@ def get_best_matching_stats(
     '''
     return _k2.get_best_matching_stats(tokens, scores, counts, eos, min_token,
                                        max_token, max_order)
+
+
+def monotonic_lower_bound(src: torch.Tensor,
+                          inplace: bool = False) -> torch.Tensor:
+    '''Compute a monotonically increasing lower bound on the array `src`.
+
+    Note: Only support 1 dimension and 2 dimensions tentor with dtype equals to
+      `torch.int32`,`torch.float` and `torch.float64`.
+
+    >>> import k2
+    >>> import torch
+    >>> src = torch.tensor([0, 2, 1, 3, 6, 5, 8], dtype=torch.int32)
+    >>> k2.monotonic_lower_bound(src)
+    tensor([0, 1, 1, 3, 5, 5, 8], dtype=torch.int32)
+    >>> src
+    tensor([0, 2, 1, 3, 6, 5, 8], dtype=torch.int32)
+    >>> k2.monotonic_lower_bound(src, inplace=True)
+    tensor([0, 1, 1, 3, 5, 5, 8], dtype=torch.int32)
+    >>> src
+    tensor([0, 1, 1, 3, 5, 5, 8], dtype=torch.int32)
+    >>> src = torch.randint(20, (3, 6), dtype=torch.int32)
+    >>> src
+    tensor([[12, 18,  5,  4, 18, 17],
+            [11, 14, 14,  3, 10,  4],
+            [19,  3,  8, 13,  7, 19]], dtype=torch.int32)
+    >>> k2.monotonic_lower_bound(src)
+    tensor([[ 4,  4,  4,  4, 17, 17],
+            [ 3,  3,  3,  3,  4,  4],
+            [ 3,  3,  7,  7,  7, 19]], dtype=torch.int32)
+    >>> k2.monotonic_lower_bound(src, inplace=True)
+    tensor([[ 4,  4,  4,  4, 17, 17],
+            [ 3,  3,  3,  3,  4,  4],
+            [ 3,  3,  7,  7,  7, 19]], dtype=torch.int32)
+    >>> src
+    tensor([[ 4,  4,  4,  4, 17, 17],
+            [ 3,  3,  3,  3,  4,  4],
+            [ 3,  3,  7,  7,  7, 19]], dtype=torch.int32)
+
+    Args:
+      src:
+        The source tensor, MUST be a 1 dimension or 2 dimensions tensor with
+        dtype equals to `torch.int32`,`torch.float` and `torch.float64`.
+      inplace:
+        True to modify the source tensor inplace, Fasle to return another
+        tensor.
+
+    Returns:
+      Returns a tensor which is monotonic(i.e. satisfiy `dest[i] <= dest[i+1]`),
+      the returned tensor shares the same underlying memory with the source
+      tensor if inplace is True.
+    '''
+    return _k2.monotonic_lower_bound(src, inplace)

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ endfunction()
 set(py_test_files
   add_epsilon_self_loops_test.py
   arc_sort_test.py
+  array_ops_test.py
   cat_test.py
   compose_arc_maps_test.py
   closure_test.py

--- a/k2/python/tests/array_ops_test.py
+++ b/k2/python/tests/array_ops_test.py
@@ -28,35 +28,35 @@ import k2
 
 
 class TestArrayOps(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
-        cls.devices = [torch.device('cpu')]
+        cls.devices = [torch.device("cpu")]
         if torch.cuda.is_available() and k2.with_cuda:
-            cls.devices.append(torch.device('cuda', 0))
+            cls.devices.append(torch.device("cuda", 0))
             if torch.cuda.device_count() > 1:
                 torch.cuda.set_device(1)
-                cls.devices.append(torch.device('cuda', 1))
+                cls.devices.append(torch.device("cuda", 1))
 
-        cls.dtypes = [torch.int32, torch.float32, torch.float64]
+        cls.dtypes = [torch.int32, torch.int64, torch.float32, torch.float64]
 
     def test_monotonic_lower_bound(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 # simple case
-                src = torch.tensor([2, 1, 3, 7, 5, 8, 20, 15],
-                                   dtype=dtype,
-                                   device=device)
-                expected = torch.tensor([1, 1, 3, 5, 5, 8, 15, 15],
-                                        dtype=dtype,
-                                        device=device)
+                src = torch.tensor(
+                    [2, 1, 3, 7, 5, 8, 20, 15], dtype=dtype, device=device
+                )
+                expected = torch.tensor(
+                    [1, 1, 3, 5, 5, 8, 15, 15], dtype=dtype, device=device
+                )
                 dest = k2.monotonic_lower_bound(src)
                 assert torch.allclose(dest, expected)
                 assert torch.allclose(
                     src,
-                    torch.tensor([2, 1, 3, 7, 5, 8, 20, 15],
-                                 dtype=dtype,
-                                 device=device))
+                    torch.tensor(
+                        [2, 1, 3, 7, 5, 8, 20, 15], dtype=dtype, device=device
+                    ),
+                )
                 k2.monotonic_lower_bound(src, inplace=True)
                 assert torch.allclose(src, expected)
 
@@ -77,5 +77,5 @@ class TestArrayOps(unittest.TestCase):
                 assert torch.allclose(src, expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/k2/python/tests/array_ops_test.py
+++ b/k2/python/tests/array_ops_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright      2021  Xiaomi Corporation (author: Wei kang)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R array_ops_test_py
+
+import unittest
+
+import random
+import torch
+import k2
+
+
+class TestArrayOps(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.devices = [torch.device('cpu')]
+        if torch.cuda.is_available() and k2.with_cuda:
+            cls.devices.append(torch.device('cuda', 0))
+            if torch.cuda.device_count() > 1:
+                torch.cuda.set_device(1)
+                cls.devices.append(torch.device('cuda', 1))
+
+        cls.dtypes = [torch.int32, torch.float32, torch.float64]
+
+    def test_monotonic_lower_bound(self):
+        for device in self.devices:
+            for dtype in self.dtypes:
+                # simple case
+                src = torch.tensor([2, 1, 3, 7, 5, 8, 20, 15],
+                                   dtype=dtype,
+                                   device=device)
+                expected = torch.tensor([1, 1, 3, 5, 5, 8, 15, 15],
+                                        dtype=dtype,
+                                        device=device)
+                dest = k2.monotonic_lower_bound(src)
+                assert torch.allclose(dest, expected)
+                assert torch.allclose(
+                    src,
+                    torch.tensor([2, 1, 3, 7, 5, 8, 20, 15],
+                                 dtype=dtype,
+                                 device=device))
+                k2.monotonic_lower_bound(src, inplace=True)
+                assert torch.allclose(src, expected)
+
+                # random case
+                src = torch.randint(100, (10, 100), dtype=dtype, device=device)
+                dest = k2.monotonic_lower_bound(src)
+                expected = torch.zeros_like(src, device=torch.device("cpu"))
+                dest = dest.to("cpu")
+                for i in range(src.shape[0]):
+                    min_value = 101
+                    for j in range(src.shape[1] - 1, -1, -1):
+                        min_value = min(dest[i][j], min_value)
+                        expected[i][j] = min_value
+                assert torch.allclose(dest, expected)
+
+                k2.monotonic_lower_bound(src, inplace=True)
+                src = src.to("cpu")
+                assert torch.allclose(src, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Will be used to calculate pruning bounds in RNNT pruning.

Examples:
```
>>> import k2
>>> import torch
>>> src = torch.tensor([0, 2, 1, 3, 6, 5, 8], dtype=torch.int32)
>>> k2.monotonic_lower_bound(src)
tensor([0, 1, 1, 3, 5, 5, 8], dtype=torch.int32)
>>> src
tensor([0, 2, 1, 3, 6, 5, 8], dtype=torch.int32)
>>> k2.monotonic_lower_bound(src, inplace=True)
tensor([0, 1, 1, 3, 5, 5, 8], dtype=torch.int32)
>>> src
tensor([0, 1, 1, 3, 5, 5, 8], dtype=torch.int32)
>>> src = torch.randint(20, (3, 6), dtype=torch.int32)
>>> src
tensor([[12, 18,  5,  4, 18, 17],
        [11, 14, 14,  3, 10,  4],
        [19,  3,  8, 13,  7, 19]], dtype=torch.int32)
>>> k2.monotonic_lower_bound(src)
tensor([[ 4,  4,  4,  4, 17, 17],
        [ 3,  3,  3,  3,  4,  4],
        [ 3,  3,  7,  7,  7, 19]], dtype=torch.int32)
>>> k2.monotonic_lower_bound(src, inplace=True)
tensor([[ 4,  4,  4,  4, 17, 17],
        [ 3,  3,  3,  3,  4,  4],
        [ 3,  3,  7,  7,  7, 19]], dtype=torch.int32)
>>> src
tensor([[ 4,  4,  4,  4, 17, 17],
        [ 3,  3,  3,  3,  4,  4],
        [ 3,  3,  7,  7,  7, 19]], dtype=torch.int32)
```