### PR TITLE
Fix FSAVec TOPSORTED properity and RaggedTensor out-of-range bug.

### DIFF
--- a/k2/csrc/tensor.cu
+++ b/k2/csrc/tensor.cu
@@ -147,7 +147,7 @@ Tensor::Tensor(ContextPtr c, Dtype type, const std::vector<int32_t> &dims)
 }
 
 Tensor::Tensor(Dtype type, const Shape &shape, RegionPtr region,
-               int32_t byte_offset)
+               size_t byte_offset)
     : impl_(std::make_shared<TensorImpl>()) {
   int64_t begin_elem, end_elem;
   shape.GetReachableElems(&begin_elem, &end_elem);

--- a/k2/csrc/tensor.h
+++ b/k2/csrc/tensor.h
@@ -176,7 +176,7 @@ class Tensor {
   Tensor(ContextPtr c, Dtype type, const std::vector<int32_t> &dims);
 
   // Create Tensor backed by existing memory.
-  Tensor(Dtype type, const Shape &shape, RegionPtr region, int32_t byte_offset);
+  Tensor(Dtype type, const Shape &shape, RegionPtr region, size_t byte_offset);
 
   Tensor(const Tensor &other) = default;
   Tensor &operator=(const Tensor &other) = default;

--- a/k2/python/k2/fsa_properties.py
+++ b/k2/python/k2/fsa_properties.py
@@ -23,7 +23,7 @@ import _k2
 
 VALID = 0x01  # Valid from a formatting perspective
 NONEMPTY = 0x02  # Nonempty as in, has at least one arc.
-TOPSORTED = 0x04,  # FSA is top-sorted, but possibly with
+TOPSORTED = 0x04  # FSA is top-sorted, but possibly with
 # self-loops, dest_state >= src_state
 TOPSORTED_AND_ACYCLIC = 0x08  # Fsa is topsorted, dest_state > src_state
 ARC_SORTED = 0x10  # Fsa is arc-sorted: arcs leaving a state are are sorted by


### PR DESCRIPTION
Remove extra commas after 'TOPSORTED' properity.
Fix RaggedTensor constructer parameter 'byte_offset' out-of-range bug.