### PR TITLE
Fix k2.ragged.create_ragged_shape2

### DIFF
--- a/k2/python/csrc/torch/v2/doc/ragged_shape.h
+++ b/k2/python/csrc/torch/v2/doc/ragged_shape.h
@@ -509,9 +509,11 @@ the overall concepts, please see comments in k2/csrc/utils.h.
 
 Args:
   row_splits:
-    Optionally, a torch.Tensor with dtype=torch.int32 and one axis
+    Optional. A 1-D torch.Tensor with dtype torch.int32.
+    If ``None``, you have to specify ``row_ids``.
   row_ids:
-    Optionally, a torch.Tensor with dtype=torch.int32 and one axis.
+    Optional. A 1-D torch.Tensor with dtype torch.int32.
+    If ``None``, you have to specify ``row_splits``.
   cached_tot_size:
     The number of elements (length of row_ids, even if row_ids
     is not provided); would be identical to the last element of row_splits,

--- a/k2/python/csrc/torch/v2/ragged_shape.cu
+++ b/k2/python/csrc/torch/v2/ragged_shape.cu
@@ -232,8 +232,8 @@ void PybindRaggedShape(py::module &m) {
 
   m.def(
       "create_ragged_shape2",
-      [](torch::optional<torch::Tensor> row_splits,
-         torch::optional<torch::Tensor> row_ids,
+      [](torch::optional<torch::Tensor> row_splits = torch::nullopt,
+         torch::optional<torch::Tensor> row_ids = torch::nullopt,
          int32_t cached_tot_size = -1) -> RaggedShape {
         if (!row_splits.has_value() && !row_ids.has_value())
           K2_LOG(FATAL) << "Both row_splits and row_ids are None";
@@ -257,7 +257,7 @@ void PybindRaggedShape(py::module &m) {
             row_splits.has_value() ? &array_row_splits : nullptr,
             row_ids.has_value() ? &array_row_ids : nullptr, cached_tot_size);
       },
-      py::arg("row_splits"), py::arg("row_ids"),
+      py::arg("row_splits") = py::none(), py::arg("row_ids") = py::none(),
       py::arg("cached_tot_size") = -1, kCreateRaggedShape2Doc);
 
   m.def("random_ragged_shape", &RandomRaggedShape, "RandomRaggedShape",

--- a/k2/python/tests/ragged_shape_test.py
+++ b/k2/python/tests/ragged_shape_test.py
@@ -121,6 +121,22 @@ class TestRaggedShape(unittest.TestCase):
             prod2 = k2.RaggedTensor(abshape2, b.values)
             assert prod == prod2
 
+    def test_create_ragged_shape2_with_row_splits(self):
+        for device in self.devices:
+            row_splits = torch.tensor([0, 1, 3],
+                                      dtype=torch.int32,
+                                      device=device)
+            shape = k2.ragged.create_ragged_shape2(row_splits=row_splits)
+            expected_shape = k2.RaggedShape('[[x] [x x]]').to(device)
+            assert shape == expected_shape
+
+    def test_create_ragged_shape2_with_row_ids(self):
+        for device in self.devices:
+            row_ids = torch.tensor([0, 1, 1], dtype=torch.int32, device=device)
+            shape = k2.ragged.create_ragged_shape2(row_ids=row_ids)
+            expected_shape = k2.RaggedShape('[[x] [x x]]').to(device)
+            assert shape == expected_shape
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before the fix, we have to specify both `row_splits` and `row_ids`
while calling `k2.create_ragged_shape2` even if one of them is `None`. 

The reason is that during the wrapping we did not specify the default value for `row_splits`
and `row_ids`.

After this fix, we only need to specify one of them.