### PR TITLE
Fix 'TypeError' of rnnt_loss_simple function.

### DIFF
--- a/k2/python/k2/mutual_information.py
+++ b/k2/python/k2/mutual_information.py
@@ -53,7 +53,7 @@ class MutualInformationRecursionFunction(torch.autograd.Function):
 
         ans = _k2.mutual_information_forward(px, py, boundary, p)
 
-        px_grad, py_grad = None, None
+        px_grad, py_grad = torch.Tensor(), torch.Tensor()
         if return_grad or px.requires_grad or py.requires_grad:
             ans_grad = torch.ones(B, device=px.device, dtype=px.dtype)
             (px_grad, py_grad) = _k2.mutual_information_backward(


### PR DESCRIPTION
Fix 'TypeError' exception when calling rnnt_loss_simple(..., return_grad=False)  at validation steps.
K2 ENV:
k2 version: 1.13
Build type: Debug
Git SHA1: 854b792368214a2adb4e89cd83f6bc09ddbbcdae
Git date: Sun Feb 20 11:22:31 2022
Cuda used to build k2: 11.1
cuDNN used to build k2: 8.0.5
Python version used to build k2: 3.8
OS used to build k2: Ubuntu 20.04.3 LTS
CMake version: 3.16.3
GCC version: 9.4.0
CMAKE_CUDA_FLAGS:  --compiler-options -rdynamic --compiler-options -lineinfo --expt-extended-lambda -gencode arch=compute_80,code=sm_80 -D_GLIBCXX_USE_CXX11_ABI=0 --compiler-options -Wall --compiler-options -Wno-unknown-pragmas --compiler-options -Wno-strict-overflow
CMAKE_CXX_FLAGS:  -D_GLIBCXX_USE_CXX11_ABI=0 -Wno-strict-overflow
PyTorch version used to build k2: 1.8.1
PyTorch is using Cuda: 11.1
NVTX enabled: True
With CUDA: True
Disable debug: False
Sync kernels : False
Disable checks: False

Exception traceback info likes:
```
Traceback (most recent call last):
File "./pruned_transducer_stateless/train.py", line 796, in <module>
    main()
File "./pruned_transducer_stateless/train.py", line 789, in main
    run(local_rank=0, args=args)                                                                                                                                                         
File "./pruned_transducer_stateless/train.py", line 754, in run
    train_one_epoch(                                                                                                                                                                     
File "./pruned_transducer_stateless/train.py", line 643, in train_one_epoch
    valid_info = compute_validation_loss(                                                                                                                                               
 File "./pruned_transducer_stateless/train.py", line 492, in compute_validation_loss
    loss, loss_info = compute_loss(                                                                                                                                                      
File "./pruned_transducer_stateless/train.py", line 456, in compute_loss
    simple_loss, pruned_loss = model(                                                                                                                                                   
File "/miniconda3/envs/k2-latest/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)                                                                                                                                              
File "/k2/icefall-latest/egs/netease/ASR1800/pruned_transducer_stateless/model.py", line 160, in forward
    pruned_loss = k2.rnnt_loss_pruned(                                                                                                                                                   
File "/k2/k2-latest/lib/python3.8/site-packages/k2/rnnt_loss.py", line 794, in rnnt_loss_pruned
    negated_loss = mutual_information_recursion(px=px, py=py, boundary=boundary)                                                                                                         
File "/miniconda3/envs/k2-latest/lib/python3.8/site-packages/k2/mutual_information.py", line 183, in mutual_information_recursion
    scores, px_grad, py_grad = MutualInformationRecursionFunction.apply(                                                                                                               
TypeError: MutualInformationRecursionFunctionBackward.forward: expected Tensor or tuple of Tensor (got NoneType) for return value 1
```