### PR TITLE
Fix Stack

### DIFF
--- a/k2/csrc/ragged_test.cu
+++ b/k2/csrc/ragged_test.cu
@@ -265,10 +265,7 @@ TEST(RaggedShapeOpsTest, UnstackRandom) {
       for (size_t i = 0; i < out.size(); ++i) {
         out_ptr.emplace_back(&(out[i]));
       }
-      // There is a bug in `Stack` for stacking a shape itself,
-      // not urgent, so skipping here.
-      // TODO: Remove this line when the bug fixed.
-      if (out.size() == 1) continue;
+
       auto dest = Stack(axis, out.size(), out_ptr.data());
       dest = RemoveEmptyLists(dest, axis);
 

--- a/k2/csrc/ragged_utils.cu
+++ b/k2/csrc/ragged_utils.cu
@@ -92,7 +92,9 @@ RaggedShape IntersperseRaggedLayer(int32_t layer,
     if (merge_map)
       *(reinterpret_cast<Array1<int32_t>*>(merge_map)) =
           Range(src[0]->Context(), src[0]->TotSize(layer + 1), 0);
-    return *src[0];
+    std::vector<RaggedShapeLayer> layers;
+    layers.emplace_back(src[0]->Layers()[layer]);
+    return RaggedShape(layers);
   }
 
   std::vector<int32_t*> row_splits_ptrs_vec(num_srcs);


### PR DESCRIPTION
closing #921

In my tests, the bug only appears when `num_src==1` and `axis>1`, here `s==*src[0]`, so `ans_layers[axis - 1]` and `ans_layers[axis]` should be buit by `s.Layers()[axis-1]` instead of `s.Layers()[0]`, i.e. https://github.com/k2-fsa/k2/blob/3cc74f19ccc045a7176a8a96a4b24c4af76e9653/k2/csrc/ragged_ops.cu#L1091-L1093
should be
```
  ans_layers[axis - 1] =
      RegularRaggedShape(c, s.TotSize(axis-1) / num_srcs, num_srcs).Layers()[0];
  ans_layers[axis] = s.Layers()[axis-1];
```
But to make the script consistent when `num_src>1`, I turned to modify `IntersperseRaggedLayer()` to let it return `*src.Layers()[axis-1]` when `num_src==1`.

Since I'm new to K2, I'm not sure whether this fix is elegant. Feel free to modify this PR.