### PR TITLE
Removes arcs with label 0 from the TrivialGraph.

### DIFF
--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -820,9 +820,8 @@ Fsa TrivialGraph(const ContextPtr &c, int32_t max_token,
     Array1<int32_t> *aux_labels) {
   NVTX_RANGE(K2_FUNC);
   K2_CHECK(aux_labels);
-  int32_t num_arcs = max_token + 2;
-  Array1<int32_t> row_splits(
-      c, std::vector<int32_t>{0, max_token + 2, max_token + 2});
+  int32_t num_arcs = max_token + 1;
+  Array1<int32_t> row_splits(c, std::vector<int32_t>{0, num_arcs, num_arcs});
   Array1<int32_t> row_ids(c, num_arcs);
   Array1<Arc> values(c, num_arcs);
   *aux_labels = Array1<int32_t>(c, num_arcs);
@@ -836,10 +835,9 @@ Fsa TrivialGraph(const ContextPtr &c, int32_t max_token,
         arc.score = 0;
         arc.src_state = 0;
         arc.dest_state = 0;
-        arc.label = idx;
-        int32_t aux_label = idx, row_id = 0;
+        arc.label = idx + 1;
+        int32_t aux_label = idx + 1, row_id = 0;
         if (idx == num_arcs - 1) {
-          row_id = 0;
           arc.dest_state = 1;
           arc.label = -1;
           aux_label = -1;

--- a/k2/csrc/fsa_algo.h
+++ b/k2/csrc/fsa_algo.h
@@ -581,20 +581,20 @@ Fsa CtcTopo(const ContextPtr &c, int32_t max_token, bool modified,
 
 /*
   Create a trivial graph which has only two states. On state 0, there are
-  `max_token + 1` self loops(i.e. a loop for each symbol, including blank), and
+  `max_token` self loops(i.e. a loop for each symbol from 1 to max_token), and
   state 1 is the final state.
 
     @param [in] c  The context with which we'll allocate memory for
                    the trivial graph.
     @param [in] max_token  The maximum token ID (inclusive). We assume that
                            token IDs are contiguous (from 1 to `max_token`).
-                           0 represents blank.
     @param [out] aux_labels The output labels of graph will write to this
                             array, will be reallocated. The label and aux_label
                             on each arc are equal
-                            (i.e. aux_labels = Arange(0, max_token + 1);
+                            (i.e. aux_labels = Arange(1, max_token + 1);
 
     @return    Returns the expected trivial graph on the given device.
+               Note the returned graph does not contain arcs with label being 0.
  */
 Fsa TrivialGraph(const ContextPtr &c, int32_t max_token,
                  Array1<int32_t> *aux_labels);

--- a/k2/python/k2/fsa_algo.py
+++ b/k2/python/k2/fsa_algo.py
@@ -1063,21 +1063,22 @@ def ctc_topo(max_token: int,
 
 def trivial_graph(max_token: int,
                   device: Optional[Union[torch.device, str]] = None) -> k2.Fsa:
-    '''
-    Create a trivial graph with only two states. On state 0, there are
-    `max_token + 1` self loops(i.e. a loop for each symbol, including blank),
-    and state 1 is the final state.
+    '''Create a trivial graph which has only two states. On state 0, there are
+    `max_token` self loops(i.e. a loop for each symbol from 1 to max_token), and
+    state 1 is the final state.
 
     Args:
       max_token:
         The maximum token ID (inclusive). We assume that token IDs
-        are contiguous (from 1 to `max_token`). 0 represents blank.
+        are contiguous (from 1 to `max_token`).
       device:
         Optional. It can be either a string (e.g., 'cpu',
         'cuda:0') or a torch.device.
         If it is None, then the returned FSA is on CPU.
 
-    Returns:  Returns the expected trivial graph on the given device.
+    Returns:
+      Returns the expected trivial graph on the given device.
+      Note: The returned graph does not contain arcs with label being 0.
     '''
     ragged_arc, aux_labels = _k2.trivial_graph(max_token, device)
     fsa = Fsa(ragged_arc, aux_labels=aux_labels)


### PR DESCRIPTION
There is an implicit self-loop associated with the decoding graph in RNN-T decoding, so we remove arcs with label 0 from the trivial graph.

Note: It assumes that the blank token has ID 0.