### PR TITLE
Fix precision

### DIFF
--- a/k2/csrc/math.h
+++ b/k2/csrc/math.h
@@ -29,11 +29,15 @@ namespace k2 {
 
 // Currently, only used in k2/csrc/rnnt_decode.cu
 // See https://github.com/k2-fsa/k2/pull/951#issuecomment-1096650842
-#ifndef _MSC_VER
-#define K2_POW pow
-#else
-#define K2_POW powf
-#endif
+__host__ __device__ __forceinline__ int64_t Pow(int64_t base, int64_t exponent) {
+  int64_t exp = 0;
+  int64_t result = 1;
+  while(exp < exponent) {
+    result *= base;
+    exp++;
+  }
+  return result;
+}
 
 /*
   Returns index of highest bit set, in range -1..30.

--- a/k2/csrc/math.h
+++ b/k2/csrc/math.h
@@ -29,10 +29,12 @@ namespace k2 {
 
 // Currently, only used in k2/csrc/rnnt_decode.cu
 // See https://github.com/k2-fsa/k2/pull/951#issuecomment-1096650842
-__host__ __device__ __forceinline__ int64_t Pow(int64_t base, int64_t exponent) {
+__host__ __device__ __forceinline__ int64_t Pow(int64_t base,
+                                                int64_t exponent) {
+  K2_CHECK_GE(exponent, 0);
   int64_t exp = 0;
   int64_t result = 1;
-  while(exp < exponent) {
+  while (exp < exponent) {
     result *= base;
     exp++;
   }
@@ -118,12 +120,12 @@ int32_t RandIntGeometric(int32_t min, int32_t max);
  type, but for types float and double it "fixes" the broken behavior of
  the C++ standard w.r.t. infinity allowing infinities to be parsed.
 */
-template<class T> struct InputFixer {
+template <class T>
+struct InputFixer {
   T t;
   // cast operator
   operator T() const { return t; }
 };
-
 
 namespace internal {
 template <typename Real>
@@ -131,16 +133,16 @@ Real FixedRead(std::istream &is);
 }
 
 template <typename T>
-inline std::istream &operator >>(std::istream &is, InputFixer<T> &f) {
+inline std::istream &operator>>(std::istream &is, InputFixer<T> &f) {
   return is >> f.t;
 }
 template <>
-inline std::istream &operator >>(std::istream &is, InputFixer<float> &f) {
+inline std::istream &operator>>(std::istream &is, InputFixer<float> &f) {
   f.t = internal::FixedRead<float>(is);
   return is;
 }
 template <>
-inline std::istream &operator >>(std::istream &is, InputFixer<double> &f) {
+inline std::istream &operator>>(std::istream &is, InputFixer<double> &f) {
   f.t = internal::FixedRead<double>(is);
   return is;
 }

--- a/k2/csrc/math.h
+++ b/k2/csrc/math.h
@@ -27,6 +27,14 @@
 
 namespace k2 {
 
+// Currently, only used in k2/csrc/rnnt_decode.cu
+// See https://github.com/k2-fsa/k2/pull/951#issuecomment-1096650842
+#ifndef _MSC_VER
+#define K2_POW pow
+#else
+#define K2_POW powf
+#endif
+
 /*
   Returns index of highest bit set, in range -1..30.
   HighestBitSet(0) = -1,

--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -159,8 +159,8 @@ void RnntDecodingStreams::GetContexts(RaggedShape *shape,
         int64_t state_value = states_values_data[state_idx01x],
                 context_state = state_value / num_graph_states,
                 exp = decoder_history_len - col,
-                state = context_state % (int64_t)K2_POW(vocab_size, exp);
-        state = state / (int64_t)K2_POW(vocab_size, exp - 1);
+                state = context_state % Pow(vocab_size, exp);
+        state = state / Pow(vocab_size, exp - 1);
         contexts_acc(row, col) = state;
       });
 }
@@ -540,7 +540,7 @@ void RnntDecodingStreams::Advance(const Array2<float> &logprobs) {
           // can be done with `358 % 10^2`, then we append 6 to 58, that can be
           // done with `58 * 10 + 6`.
           context_state = this_context_state %
-                          (int64_t)K2_POW(vocab_size, decoder_history_len - 1);
+                          Pow(vocab_size, decoder_history_len - 1);
           context_state = context_state * vocab_size + arc.label;
         }
 

--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -159,8 +159,8 @@ void RnntDecodingStreams::GetContexts(RaggedShape *shape,
         int64_t state_value = states_values_data[state_idx01x],
                 context_state = state_value / num_graph_states,
                 exp = decoder_history_len - col,
-                state = context_state % (int64_t)powf(vocab_size, exp);
-        state = state / (int64_t)powf(vocab_size, exp - 1);
+                state = context_state % (int64_t)pow(vocab_size, exp);
+        state = state / (int64_t)pow(vocab_size, exp - 1);
         contexts_acc(row, col) = state;
       });
 }
@@ -540,7 +540,7 @@ void RnntDecodingStreams::Advance(const Array2<float> &logprobs) {
           // can be done with `358 % 10^2`, then we append 6 to 58, that can be
           // done with `58 * 10 + 6`.
           context_state = this_context_state %
-                          (int64_t)powf(vocab_size, decoder_history_len - 1);
+                          (int64_t)pow(vocab_size, decoder_history_len - 1);
           context_state = context_state * vocab_size + arc.label;
         }
 

--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -159,8 +159,8 @@ void RnntDecodingStreams::GetContexts(RaggedShape *shape,
         int64_t state_value = states_values_data[state_idx01x],
                 context_state = state_value / num_graph_states,
                 exp = decoder_history_len - col,
-                state = context_state % (int64_t)pow(vocab_size, exp);
-        state = state / (int64_t)pow(vocab_size, exp - 1);
+                state = context_state % (int64_t)K2_POW(vocab_size, exp);
+        state = state / (int64_t)K2_POW(vocab_size, exp - 1);
         contexts_acc(row, col) = state;
       });
 }
@@ -540,7 +540,7 @@ void RnntDecodingStreams::Advance(const Array2<float> &logprobs) {
           // can be done with `358 % 10^2`, then we append 6 to 58, that can be
           // done with `58 * 10 + 6`.
           context_state = this_context_state %
-                          (int64_t)pow(vocab_size, decoder_history_len - 1);
+                          (int64_t)K2_POW(vocab_size, decoder_history_len - 1);
           context_state = context_state * vocab_size + arc.label;
         }
 


### PR DESCRIPTION
Something wrong with the precision if changing `pow` to `powf` (using `powf` to support windows build, see https://github.com/k2-fsa/k2/pull/946/files#diff-b7474255c771be7e6f33ddf04f0e5c9cb7c0588ccb7151713699d46841bc9e18) , the WER of test-clean increases from 2.72% -> 82.3%.

I have not figured out the root cause,  **do not merge**.