### PR TITLE
Add max cpu mem allocation constraint

### DIFF
--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -288,7 +288,7 @@ inline bool DisableChecks() {
    environment variable `K2_MAX_CPU_MEM_ALLOCATE`. Return the default value
    (i.e. 200GB) if the variable does not set.
  */
-inline int32_t MaxCpuMemAllocate() {
+inline int64_t MaxCpuMemAllocate() {
   static std::once_flag init_flag;
   // 200GB in bytes, 200 * 1024 * 1024 * 1024
   static int64_t max_cpu_mem_allocate = 214748364800L;

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -390,7 +390,8 @@ inline K2_CUDA_HOSTDEV LogLevel GetCurrentLogLevel() {
 #define K2_CHECK_CUDA_ERROR(x) \
   K2_CHECK_EQ(x, cudaSuccess) << " Error: " << cudaGetErrorString(x) << ". "
 #else
-#define K2_CHECK_CUDA_ERROR(...) K2_LOG(FATAL) << "K2 compiled without CUDA support"
+#define K2_CHECK_CUDA_ERROR(...) \
+  K2_LOG(FATAL) << "K2 compiled without CUDA support"
 #endif
 
 // The parameter of `K2_CUDA_SAFE_CALL` should be cuda function call or kernel
@@ -412,7 +413,8 @@ inline K2_CUDA_HOSTDEV LogLevel GetCurrentLogLevel() {
 // Use a separate K2_CUDA_SAFE_CALL() for CPU
 // because the kernel invocation syntax <<< >>>
 // is not valid C++
-#define K2_CUDA_SAFE_CALL(...) K2_LOG(FATAL) << "K2 compiled without CUDA support"
+#define K2_CUDA_SAFE_CALL(...) \
+  K2_LOG(FATAL) << "K2 compiled without CUDA support"
 #endif
 
 // ------------------------------------------------------------

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -391,7 +391,7 @@ inline K2_CUDA_HOSTDEV LogLevel GetCurrentLogLevel() {
   K2_CHECK_EQ(x, cudaSuccess) << " Error: " << cudaGetErrorString(x) << ". "
 #else
 #define K2_CHECK_CUDA_ERROR(...) \
-  K2_LOG(FATAL) << "K2 compiled without CUDA support"
+  K2_LOG(FATAL) << "k2 compiled without CUDA support"
 #endif
 
 // The parameter of `K2_CUDA_SAFE_CALL` should be cuda function call or kernel
@@ -414,7 +414,7 @@ inline K2_CUDA_HOSTDEV LogLevel GetCurrentLogLevel() {
 // because the kernel invocation syntax <<< >>>
 // is not valid C++
 #define K2_CUDA_SAFE_CALL(...) \
-  K2_LOG(FATAL) << "K2 compiled without CUDA support"
+  K2_LOG(FATAL) << "k2 compiled without CUDA support"
 #endif
 
 // ------------------------------------------------------------

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -283,6 +283,22 @@ inline bool DisableChecks() {
   return disable_checks;
 }
 
+/*
+   Get the max cpu memory (in bytes) can be allocated at a time through the
+   environment variable `K2_MAX_CPU_MEM_ALLOCATE`. Return the default value
+   (i.e. 200GB) if the variable does not set.
+ */
+inline int32_t MaxCpuMemAllocate() {
+  static std::once_flag init_flag;
+  // 200GB in bytes, 200 * 1024 * 1024 * 1024
+  static int64_t max_cpu_mem_allocate = 214748364800L;
+  std::call_once(init_flag, []() {
+    char *env_str = std::getenv("K2_MAX_CPU_MEM_ALLOCATE");
+    if (env_str != nullptr) max_cpu_mem_allocate = std::atol(env_str);
+  });
+  return max_cpu_mem_allocate;
+}
+
 inline K2_CUDA_HOSTDEV LogLevel GetCurrentLogLevel() {
 #if defined(__CUDA_ARCH__)
   return DEBUG;

--- a/k2/csrc/math.h
+++ b/k2/csrc/math.h
@@ -29,7 +29,7 @@ namespace k2 {
 
 // Currently, only used in k2/csrc/rnnt_decode.cu
 // See https://github.com/k2-fsa/k2/pull/951#issuecomment-1096650842
-__host__ __device__ __forceinline__ int64_t Pow(int64_t base,
+K2_CUDA_HOSTDEV __forceinline__ int64_t Pow(int64_t base,
                                                 int64_t exponent) {
   K2_CHECK_GE(exponent, 0);
   int64_t exp = 0;

--- a/k2/csrc/pytorch_context.cu
+++ b/k2/csrc/pytorch_context.cu
@@ -91,6 +91,9 @@ class PytorchCpuContext : public Context {
   DeviceType GetDeviceType() const override { return kCpu; }
 
   void *Allocate(std::size_t bytes, void **deleter_context) override {
+    int64_t max_bytes = internal::MaxCpuMemAllocate();
+    if (max_bytes != -1) K2_CHECK_LE(static_cast<int64_t>(bytes), max_bytes);
+
     void *p = allocator_->raw_allocate(bytes);
     if (deleter_context != nullptr) *deleter_context = nullptr;
     return p;

--- a/k2/python/k2/version/version.py
+++ b/k2/python/k2/version/version.py
@@ -58,6 +58,7 @@ def main():
     disable_debug = _k2.version.disable_debug
     sync_kernels = os.getenv('K2_SYNC_KERNELS', None) is not None
     disable_checks = os.getenv('K2_DISABLE_CHECKS', None) is not None
+    max_cpu_mem_allocate = os.getenv('K2_MAX_CPU_MEM_ALLOCATE', 214748364800)
 
     print(f'''
 k2 version: {version}
@@ -79,6 +80,7 @@ With CUDA: {with_cuda}
 Disable debug: {disable_debug}
 Sync kernels : {sync_kernels}
 Disable checks: {disable_checks}
+Max cpu memory allocate: {max_cpu_mem_allocate}
     ''')
 
 


### PR DESCRIPTION
```
(rnnt2) kangwei@de-74279-k2-train-1-0307195509-54c966b95f-rtpfq:~/code/k2/build$ K2_MAX_CPU_MEM_ALLOCATE=1024 python
Python 3.8.0 (default, Nov  6 2019, 21:49:08)
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import k2
>>> a = k2.ctc_topo(5)
>>> a = k2.ctc_topo(20)
[F] /ceph-hw/kangwei/code/k2/k2/csrc/pytorch_context.cu:95:virtual void* k2::PytorchCpuContext::Allocate(std::size_t, void**) Check failed: static_cast<int64_
t>(bytes) <= max_bytes (1848 vs. 1024)


[ Stack-Trace: ]
/ceph-hw/kangwei/code/k2/build/lib/libk2_log.so(k2::internal::GetStackTrace()+0x5b) [0x7f743f40582a]
/ceph-hw/kangwei/code/k2/build/lib/libk2context.so(k2::internal::Logger::~Logger()+0x44) [0x7f743f8910ba]
/ceph-hw/kangwei/code/k2/build/lib/libk2context.so(k2::PytorchCpuContext::Allocate(unsigned long, void**)+0x14a) [0x7f743fb97ab2]
/ceph-hw/kangwei/code/k2/build/lib/libk2context.so(k2::NewRegion(std::shared_ptr<k2::Context>, unsigned long)+0xb0) [0x7f743f8d089f]
/ceph-hw/kangwei/code/k2/build/lib/libk2context.so(k2::Array1<int>::Init(std::shared_ptr<k2::Context>, int, k2::Dtype)+0x22a) [0x7f743f895612]
/ceph-hw/kangwei/code/k2/build/lib/libk2context.so(k2::Array1<int>::Array1(std::shared_ptr<k2::Context>, int, k2::Dtype)+0x5f) [0x7f743f893245]
/ceph-hw/kangwei/code/k2/build/lib/libk2context.so(k2::CtcTopo(std::shared_ptr<k2::Context> const&, int, bool, k2::Array1<int>*)+0x492) [0x7f743f8f426e]
/ceph-hw/kangwei/code/k2/build/lib/_k2.cpython-38-x86_64-linux-gnu.so(+0x124a7c) [0x7f74408eca7c]
/ceph-hw/kangwei/code/k2/build/lib/_k2.cpython-38-x86_64-linux-gnu.so(+0x13359d) [0x7f74408fb59d]
/ceph-hw/kangwei/code/k2/build/lib/_k2.cpython-38-x86_64-linux-gnu.so(+0x1319af) [0x7f74408f99af]
/ceph-hw/kangwei/code/k2/build/lib/_k2.cpython-38-x86_64-linux-gnu.so(+0x12feb1) [0x7f74408f7eb1]
```