### PR TITLE
Fix ArrayOfRagged

### DIFF
--- a/k2/csrc/array_of_ragged.cu
+++ b/k2/csrc/array_of_ragged.cu
@@ -72,7 +72,7 @@ Array1OfRaggedShape::Array1OfRaggedShape(RaggedShape *srcs, int32_t num_srcs,
   row_ids_ = row_ids_.To(c_);
 
   if (populate_meta_) {
-    // Initialize meat_row_splits_
+    // Initialize meta_row_splits_
     // We populate this on CPU and transfer to GPU.
     meta_row_splits_ =
         Array2<int32_t>(GetCpuContext(), num_axes_, num_srcs_ + 1);

--- a/k2/csrc/array_of_ragged.cu
+++ b/k2/csrc/array_of_ragged.cu
@@ -22,8 +22,9 @@
 
 namespace k2 {
 
-Array1OfRaggedShape::Array1OfRaggedShape(RaggedShape *srcs, int32_t num_srcs) :
-  num_srcs_(num_srcs) {
+Array1OfRaggedShape::Array1OfRaggedShape(RaggedShape *srcs, int32_t num_srcs,
+                                         bool populate_meta)
+    : num_srcs_(num_srcs), populate_meta_(populate_meta) {
   K2_CHECK_GT(num_srcs, 0);
   K2_CHECK(srcs);
 
@@ -44,8 +45,8 @@ Array1OfRaggedShape::Array1OfRaggedShape(RaggedShape *srcs, int32_t num_srcs) :
   // row_ids_ are populated on CPU, although the operator() of Array2 is a
   // __host__ and __device__ function. Bear in mind, we cannot access the
   // GPU data on CPU.
-  row_splits_ = Array2<const int32_t *>(GetCpuContext(),
-                                        num_axes_ - 1, num_srcs_);
+  row_splits_ =
+      Array2<const int32_t *>(GetCpuContext(), num_axes_ - 1, num_srcs_);
   row_ids_ = Array2<const int32_t *>(GetCpuContext(), num_axes_ - 1, num_srcs_);
 
   // Notice: no matter the return value of TotSize() is from 'cached_tot_size'
@@ -69,60 +70,60 @@ Array1OfRaggedShape::Array1OfRaggedShape(RaggedShape *srcs, int32_t num_srcs) :
 
   row_splits_ = row_splits_.To(c_);
   row_ids_ = row_ids_.To(c_);
-  tot_sizes_ = tot_sizes_.To(c_);
 
+  if (populate_meta_) {
+    // Initialize meat_row_splits_
+    // We populate this on CPU and transfer to GPU.
+    meta_row_splits_ =
+        Array2<int32_t>(GetCpuContext(), num_axes_, num_srcs_ + 1);
+    offsets_ = Array2<int32_t>(GetCpuContext(), num_axes_ + 1, num_srcs_ + 1);
 
-  // Initialize meat_row_splits_
-  // We populate this on CPU and transfer to GPU.
-  meta_row_splits_ = Array2<int32_t>(GetCpuContext(), num_axes_, num_srcs_ + 1);
-  offsets_ = Array2<int32_t>(GetCpuContext(), num_axes_ + 1, num_srcs_ + 1);
+    auto meta_row_splits_acc = meta_row_splits_.Accessor(),
+         offsets_acc = offsets_.Accessor();
 
-  auto meta_row_splits_acc = meta_row_splits_.Accessor(),
-       offsets_acc = offsets_.Accessor();
-
-  // Initialize the 1st row of offsets_, which contains 0,1,2,...
-  for (int32_t col = 0; col <= num_srcs_; ++col) {
-    offsets_acc(0, col) = col;
-  }
-  // Initialize the 1st col of meta_row_splits_ and offsets_
-  for (int32_t row = 0; row < num_axes_; ++row) {
-    meta_row_splits_acc(row, 0) = 0;
-    offsets_acc(row + 1, 0) = 0;
-  }
-
-  // The meta_row_splits_ is the cumulative sum of the tot-sizes of the
-  // individual arrays.
-  for (int32_t i = 0; i < num_axes_; ++i) {
-    for (int32_t j = 1; j <= num_srcs_; ++j) {
-      meta_row_splits_acc(i, j) = meta_row_splits_acc(i, j - 1) +
-                                  srcs[j - 1].TotSize(i);
-      offsets_acc(i + 1, j) = meta_row_splits_acc(i, j);
+    // Initialize the 1st row of offsets_, which contains 0,1,2,...
+    for (int32_t col = 0; col <= num_srcs_; ++col) {
+      offsets_acc(0, col) = col;
     }
-  }
+    // Initialize the 1st col of meta_row_splits_ and offsets_
+    for (int32_t row = 0; row < num_axes_; ++row) {
+      meta_row_splits_acc(row, 0) = 0;
+      offsets_acc(row + 1, 0) = 0;
+    }
 
-  // Initialize meta_row_ids_
-  // Elements are in [0, NumSrcs() - 1]
-  meta_row_ids_.resize(num_axes_);
-
-  for (int32_t axis = 0; axis < num_axes_; ++axis) {
-    // The length equals to TotSize(axis)
-    meta_row_ids_.at(axis) = Array1<int32_t>(
-        GetCpuContext(), meta_row_splits_acc(axis, num_srcs_));
-    int32_t *meta_row_ids_data = meta_row_ids_[axis].Data();
-
-    int32_t cur_row_start = meta_row_splits_acc(axis, 0);
-    for (int32_t src = 0; src < num_srcs_; ++src) {
-      int32_t next_row_start = meta_row_splits_acc(axis, src + 1);
-      for (; cur_row_start < next_row_start; ++cur_row_start) {
-        meta_row_ids_data[cur_row_start] = src;
+    // The meta_row_splits_ is the cumulative sum of the tot-sizes of the
+    // individual arrays.
+    for (int32_t i = 0; i < num_axes_; ++i) {
+      for (int32_t j = 1; j <= num_srcs_; ++j) {
+        meta_row_splits_acc(i, j) =
+            meta_row_splits_acc(i, j - 1) + srcs[j - 1].TotSize(i);
+        offsets_acc(i + 1, j) = meta_row_splits_acc(i, j);
       }
     }
-    meta_row_ids_[axis] = meta_row_ids_[axis].To(c_);
+
+    // Initialize meta_row_ids_
+    // Elements are in [0, NumSrcs() - 1]
+    meta_row_ids_.resize(num_axes_);
+
+    for (int32_t axis = 0; axis < num_axes_; ++axis) {
+      // The length equals to TotSize(axis)
+      meta_row_ids_.at(axis) = Array1<int32_t>(
+          GetCpuContext(), meta_row_splits_acc(axis, num_srcs_));
+      int32_t *meta_row_ids_data = meta_row_ids_[axis].Data();
+
+      int32_t cur_row_start = meta_row_splits_acc(axis, 0);
+      for (int32_t src = 0; src < num_srcs_; ++src) {
+        int32_t next_row_start = meta_row_splits_acc(axis, src + 1);
+        for (; cur_row_start < next_row_start; ++cur_row_start) {
+          meta_row_ids_data[cur_row_start] = src;
+        }
+      }
+      meta_row_ids_[axis] = meta_row_ids_[axis].To(c_);
+    }
+
+    meta_row_splits_ = meta_row_splits_.To(c_);
+    offsets_ = offsets_.To(c_);
   }
-
-  meta_row_splits_ = meta_row_splits_.To(c_);
-  offsets_ = offsets_.To(c_);
 }
-
 
 }  // namespace k2

--- a/k2/csrc/array_of_ragged_test.cu
+++ b/k2/csrc/array_of_ragged_test.cu
@@ -39,7 +39,8 @@ void TestArray1OfRaggedConstruct() {
                           0 /*min_num_elements*/, 100 /*max_num_elements*/)
               .To(c, true /*copy_all*/));
     }
-    auto array_of_ragged = Array1OfRagged<T>(raggeds.data(), num_srcs);
+    auto array_of_ragged =
+        Array1OfRagged<T>(raggeds.data(), num_srcs, true /*populate_meta*/);
     for (int32_t j = 1; j < num_axes; ++j) {
       const int32_t **row_splits = array_of_ragged.shape.RowSplits(j);
       const int32_t **row_ids = array_of_ragged.shape.RowIds(j);


### PR DESCRIPTION
Add an argument of whether to populate `meta_row_splits_` and `meta_row_ids`,  because it will be an integer overflow when num_srcs is large, for example, the multi-stream rnnt decoding which will have hundreds of streams, and each stream has a big decoding graph.