### PR TITLE
Fix installation from `pip install`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-k2/python/k2/torch_version.py
 # Build folder
 **/build*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ if(K2_USE_PYTORCH)
     ${CMAKE_SOURCE_DIR}/k2/python/k2/torch_version.py.in
     ${CMAKE_SOURCE_DIR}/k2/python/k2/torch_version.py @ONLY
   )
+  message(STATUS "Generated ${CMAKE_SOURCE_DIR}/k2/python/k2/torch_version.py")
 endif()
 
 if(K2_WITH_CUDA)

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,9 @@ class BuildExtension(build_ext):
                 print(f'Copying {so} to {self.build_lib}/')
                 shutil.copy(f'{so}', f'{self.build_lib}/')
 
+        print(f'Copying {k2_dir}/k2/python/k2/torch_version.py to {self.build_lib}/k2')  # noqa
+        shutil.copy(f'{k2_dir}/k2/python/k2/torch_version.py', f'{self.build_lib}/k2')  # noqa
+
 
 def get_long_description():
     with open('README.md', 'r') as f:


### PR DESCRIPTION
`k2/python/k2/torch_version.py` is generated during CMake. However, `python setup.py install` is not aware of its existence.

This PR copies the file to the expected location after running CMake.