### PR TITLE
Add abort in log.h

### DIFF
--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -192,9 +192,7 @@ class Logger {
       	abort();
 	// raise(SIGTERM);
       }
-      else {
-     	throw std::runtime_error(kErrMsg);
-      }
+      throw std::runtime_error(kErrMsg);
       // abort();
       //
       // NOTE: abort() will terminate the program immediately without

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -32,7 +32,6 @@
 #define K2_CSRC_LOG_H_
 
 #include <cassert>
-#include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -189,7 +189,7 @@ class Logger {
       }
       fflush(nullptr);
       if (EnableAbort()) {
-      	abort();
+        abort();
 	// raise(SIGTERM);
       }
       throw std::runtime_error(kErrMsg);

--- a/k2/python/k2/version/version.py
+++ b/k2/python/k2/version/version.py
@@ -59,6 +59,7 @@ def main():
     sync_kernels = os.getenv('K2_SYNC_KERNELS', None) is not None
     disable_checks = os.getenv('K2_DISABLE_CHECKS', None) is not None
     max_cpu_mem_allocate = os.getenv('K2_MAX_CPU_MEM_ALLOCATE', 214748364800)
+    k2_abort = os.getenv('K2_ABORT', None) is not None
 
     print(f'''
 k2 version: {version}
@@ -81,6 +82,7 @@ Disable debug: {disable_debug}
 Sync kernels : {sync_kernels}
 Disable checks: {disable_checks}
 Max cpu memory allocate: {max_cpu_mem_allocate}
+k2 abort: {k2_abort}
     ''')
 
 


### PR DESCRIPTION
Now users can set environment variable `K2_ABORT=1`, then it will call `abort()` if a K2_CHECK fails.