### PR TITLE
Fix building on macOS.

### DIFF
--- a/k2/python/csrc/CMakeLists.txt
+++ b/k2/python/csrc/CMakeLists.txt
@@ -35,3 +35,16 @@ target_link_libraries(_k2 PRIVATE fsa)
 target_include_directories(_k2 PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(_k2 PRIVATE ${CMAKE_BINARY_DIR})
 set_target_properties(_k2 PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+
+if(APPLE)
+  # See https://github.com/k2-fsa/k2/issues/836
+  # This block adds the directory of _k2.cpython-*.so to runpath
+  # so that there is no need to use DYLD_LIBRARY_PATH on macOS
+  execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGE_DIR
+  )
+  message(STATUS "PYTHON_SITE_PACKAGE_DIR: ${PYTHON_SITE_PACKAGE_DIR}")
+  target_link_libraries(_k2 PRIVATE "-Wl,-rpath,${PYTHON_SITE_PACKAGE_DIR}")
+endif()


### PR DESCRIPTION
Fixes #836 and replaces #837

There is no `$ORIGIN` on macOS. This PR adds the directory where the final `_k2.cpython-*.so` resides to the runpath so that the dynamic loader can locate where the dependent libraries are. I've tested it on kaldifeat and it works. Will revert #837 in a separate PR.