### PR TITLE
Release v1.16.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ message(STATUS "Enabled languages: ${languages}")
 
 project(k2 ${languages})
 
-set(K2_VERSION "1.15.1")
+set(K2_VERSION "1.16")
 
 # ----------------- Supported build types for K2 project -----------------
 set(K2_ALLOWABLE_BUILD_TYPES Debug Release RelWithDebInfo MinSizeRel)


### PR DESCRIPTION
From v1.16, you can include k2 as a third party library in other projects.