### PR TITLE
test K2_TRANS_EXCSUM

### DIFF
--- a/k2/csrc/eval.h
+++ b/k2/csrc/eval.h
@@ -35,8 +35,6 @@
 #include "k2/csrc/context.h"
 #include "k2/csrc/log.h"
 
-// Caution: see also utils.h where there is EvalWithRedirect that's very related
-// to this.
 namespace k2 {
 
 

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -139,7 +139,7 @@ Here is an example:
       c, dim, ans_data, lambda_multiple2, (int32_t i)->int32_t{ return i*2; });
 @endcode
 
-`ans` will be {0, 2, 6, 12}
+`ans` will be {0, 0, 2, 6}
  */
 #define K2_TRANS_EXCSUM(context, dim, ans_data, lambda_name, ...)              \
   do {                                                                         \

--- a/k2/csrc/macros_test.cu
+++ b/k2/csrc/macros_test.cu
@@ -62,7 +62,31 @@ namespace k2 {
   }
 }
 
+/*static*/ void TestTransExcsum() {
+  for (auto &c : {GetCpuContext(), GetCudaContext()}) {
+    int32_t dim = 5;
+
+    Array1<int32_t> ans(c, dim + 1);
+    int32_t *ans_data = ans.Data();
+
+    // In lambda_square/lambda_multiple2,
+    // "i" is the index of "ans", NOT the value "ans[i]".
+    // So after executing following two "K2_TRANS_EXCSUM" statements,
+    // the resulting "ans[i]" is NOT dependent on the original "ans[i]" value.
+    K2_TRANS_EXCSUM(
+        c, dim, ans_data, lambda_square,
+        (int32_t i)->int32_t{ return i * i; });
+    CheckArrayData(ans, std::vector<int32_t>{0, 0, 1, 5, 14, 30});
+
+    K2_TRANS_EXCSUM(
+        c, dim, ans_data, lambda_multiple2,
+        (int32_t i)->int32_t{ return i * 2; });
+    CheckArrayData(ans, std::vector<int32_t>{0, 0, 2, 6, 12, 20});
+  }
+}
+
 TEST(Macros, Eval) { TestEval(); }
 TEST(Macros, Eval2) { TestEval2(); }
+TEST(Macros, TransExcsum) { TestTransExcsum(); }
 
 }  // namespace k2

--- a/k2/csrc/moderngpu.h
+++ b/k2/csrc/moderngpu.h
@@ -23,6 +23,7 @@
 #include "moderngpu/context.hxx"
 #include "moderngpu/kernel_load_balance.hxx"
 #include "moderngpu/kernel_mergesort.hxx"
+#include "moderngpu/kernel_scan.hxx"
 #include "moderngpu/kernel_segsort.hxx"
 #include "moderngpu/kernel_sortedsearch.hxx"
 #endif

--- a/k2/csrc/ragged_inl.h
+++ b/k2/csrc/ragged_inl.h
@@ -25,7 +25,7 @@
 #define K2_CSRC_RAGGED_INL_H_
 
 #ifndef IS_IN_K2_CSRC_RAGGED_H_
-#error "this file is supposed to be included only by ragged_ops.h"
+#error "this file is supposed to be included only by ragged.h"
 #endif
 
 


### PR DESCRIPTION
1. fix comment error of "K2_TRANS_EXCSUM" in k2/csrc/macros.h
2. add a test for it in k2/csrc/macros_test.cu
3. include "kernel_scan.hxx" into k2/csrc/moderngpu.h  to fix following compilation  error
 ```
[ 46%] Building CUDA object k2/csrc/CMakeFiles/cu_macros_test.dir/macros_test.cu.o
/ceph-ly/open-source/k2/k2/csrc/macros_test.cu(74): error: namespace "mgpu" has no member "transform_scan"
```

   It seems that macro "K2_TRANS_EXCSUM" is not being used except this new added unit test.
   So this compilation error is not met before.

 4. BTW, the comment related to "EvalWithRedirect" seems obsolete since it  is already removed by https://github.com/k2-fsa/k2/pull/727/files#diff-dc2a6f83d656522a88ebe371fdb539a836fd1f9b2655f924a5b70e248f26caecL445