### PR TITLE
Print verbose logs when failed to parse FSAs.

### DIFF
--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -292,7 +292,10 @@ class OpenFstStreamReader {
       if (!line_is.eof()) line_is >> std::ws;
     }
     if (!line_is.eof() || line_is.fail() || src_state < 0 || dest_state < 0) {
-      K2_LOG(FATAL) << "Invalid line: " << line;
+      K2_LOG(FATAL) << "Invalid line: " << line << ", eof=" << line_is.eof()
+                    << ", fail=" << line_is.fail()
+                    << ", src_state=" << src_state
+                    << ", dest_state=" << dest_state;
     }
     AddArc({src_state, dest_state, label, -cost},
            aux_labels, ragged_labels);


### PR DESCRIPTION
See https://github.com/k2-fsa/icefall/issues/393#issuecomment-1147496035
and
https://github.com/k2-fsa/icefall/issues/459#issuecomment-1173182076