### PR TITLE
Fix for CMake 3.10

### DIFF
--- a/cmake/k2Config.cmake.in
+++ b/cmake/k2Config.cmake.in
@@ -62,8 +62,7 @@ foreach(lib IN LISTS K2_LIBRARIES)
       CXX_STANDARD 14
   )
 
-  set_property(TARGET ${lib} PROPERTY INTERFACE_COMPILE_OPTIONS @CMAKE_CXX_FLAGS@)
-  target_compile_definitions(${lib} INTERFACE -DHAVE_K2_TORCH_API_H=1)
+  set_property(TARGET ${lib} PROPERTY INTERFACE_COMPILE_OPTIONS @CMAKE_CXX_FLAGS@ -DHAVE_K2_TORCH_API_H=1)
 endforeach()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
From https://cmake.org/cmake/help/v3.10/command/target_compile_definitions.html

> The named `<target>` must have been created by a command such as [add_executable()](https://cmake.org/cmake/help/v3.10/command/add_executable.html#command:add_executable) or [add_library()](https://cmake.org/cmake/help/v3.10/command/add_library.html#command:add_library) and must not be an [Imported Target](https://cmake.org/cmake/help/v3.10/manual/cmake-buildsystem.7.html#imported-targets).

This PR fixes that by removing `target_compile_definitions()`.