### PR TITLE
Fix rpath handling.

### DIFF
--- a/k2/python/csrc/CMakeLists.txt
+++ b/k2/python/csrc/CMakeLists.txt
@@ -37,6 +37,8 @@ target_include_directories(_k2 PRIVATE ${CMAKE_BINARY_DIR})
 set_target_properties(_k2 PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 target_link_libraries(_k2 PRIVATE "-Wl,-rpath,${k2_rpath_origin}/k2/lib")
+target_link_libraries(_k2 PRIVATE "-Wl,-rpath,${k2_rpath_origin}/k2/lib64")
+target_link_libraries(_k2 PRIVATE "-Wl,-rpath,${k2_rpath_origin}/k2/${CMAKE_INSTALL_LIBDIR}")
 
 if(UNIX AND NOT APPLE)
   # It causes errors on macOS


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR is `lib` on some platforms.
However, it is `lib64` on some other platforms.

See https://github.com/k2-fsa/icefall/issues/459