### PR TITLE
Support using k2 in sherpa without installation

### DIFF
--- a/k2/csrc/CMakeLists.txt
+++ b/k2/csrc/CMakeLists.txt
@@ -255,6 +255,17 @@ if(K2_USE_PYTORCH)
   endif()
 endif()
 
+file(MAKE_DIRECTORY
+  DESTINATION
+    ${PROJECT_BINARY_DIR}/include/k2
+)
+
+file(COPY
+  torch_api.h
+  DESTINATION
+    ${PROJECT_BINARY_DIR}/include/k2
+)
+
 install(TARGETS k2_log k2_torch_api context
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )


### PR DESCRIPTION
Previously, we have to use `python3 setup.py install` to install k2 so that we can use it in `sherpa`.

The disadvantage is that we can install only one version of k2 inside a virtual environment.

With this PR, we can use
```bash
cd sherpa
mkdir build
cd build
K2_INSTALL_PREFIX=/path/to/k2/build cmake ..
make -j 
```