### PR TITLE
Fix parsing FSA in openfst format.

### DIFF
--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -200,14 +200,12 @@ static Fsa K2FsaFromStream(std::istringstream &is,
     return ans;
 }
 
-// `expected` must not be whitespace.  expect (read) `expected, set failbit if
-// not.
+// `expected` must not be whitespace.  expect (read) `expected
 void ExpectChar(std::istream &is, char expected) {
   is >> std::ws;
   char ch;
   is >> ch;
-  if (ch != expected)
-    is.setstate(std::ios::failbit);
+  K2_CHECK_EQ(ch, expected);
 }
 
 
@@ -291,7 +289,7 @@ class OpenFstStreamReader {
       line_is >> cost;
       if (!line_is.eof()) line_is >> std::ws;
     }
-    if (!line_is.eof() || line_is.fail() || src_state < 0 || dest_state < 0) {
+    if (!line_is.eof() || src_state < 0 || dest_state < 0) {
       K2_LOG(FATAL) << "Invalid line: " << line << ", eof=" << line_is.eof()
                     << ", fail=" << line_is.fail()
                     << ", src_state=" << src_state

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -263,7 +263,7 @@ class OpenFstStreamReader {
     int32_t src_state, dest_state, label;
     line_is >> src_state >> dest_state >> label;
     if (!line_is.good()) {
-      // Our only hope of parsing othis is that `line` was empty, or a
+      // Our only hope of parsing this is that `line` was empty, or a
       // final-state; try that.
       if (!ProcessFinalProbOrEmpty(line)) {
         K2_LOG(FATAL) << "Invalid line: " << line;
@@ -291,9 +291,8 @@ class OpenFstStreamReader {
       line_is >> cost;
       if (!line_is.eof()) line_is >> std::ws;
     }
-    if (!line_is.eof() || line_is.fail() || src_state < 0 || dest_state < 0) {
+    if (!line_is.eof() || src_state < 0 || dest_state < 0) {
       K2_LOG(FATAL) << "Invalid line: " << line << ", eof=" << line_is.eof()
-                    << ", fail=" << line_is.fail()
                     << ", src_state=" << src_state
                     << ", dest_state=" << dest_state;
     }

--- a/k2/csrc/fsa_utils.cu
+++ b/k2/csrc/fsa_utils.cu
@@ -262,7 +262,7 @@ class OpenFstStreamReader {
     std::istringstream line_is(line);
     int32_t src_state, dest_state, label;
     line_is >> src_state >> dest_state >> label;
-    if (!line_is.good()) {
+    if (line_is.fail()) {
       // Our only hope of parsing this is that `line` was empty, or a
       // final-state; try that.
       if (!ProcessFinalProbOrEmpty(line)) {
@@ -291,8 +291,9 @@ class OpenFstStreamReader {
       line_is >> cost;
       if (!line_is.eof()) line_is >> std::ws;
     }
-    if (!line_is.eof() || src_state < 0 || dest_state < 0) {
+    if (!line_is.eof() || line_is.fail() || src_state < 0 || dest_state < 0) {
       K2_LOG(FATAL) << "Invalid line: " << line << ", eof=" << line_is.eof()
+                    << ", fail=" << line_is.fail()
                     << ", src_state=" << src_state
                     << ", dest_state=" << dest_state;
     }


### PR DESCRIPTION
```
!line_is.eof() || line_is.fail()
```

I think checking whether it is `EOF` is enough.

Fixes https://github.com/k2-fsa/icefall/issues/459

@danpovey @pkufool 

Do you think it is safe to remove the condition `line_is.fail()`?

References:
- https://en.cppreference.com/w/cpp/io/basic_ios/fail
- https://en.cppreference.com/w/cpp/io/ios_base/iostate