### PR TITLE
remove unused typename

### DIFF
--- a/k2/csrc/eval.h
+++ b/k2/csrc/eval.h
@@ -35,12 +35,10 @@
 #include "k2/csrc/context.h"
 #include "k2/csrc/log.h"
 
-// Caution: see also utils.h where there is EvalWithRedirect that's very related
-// to this.
 namespace k2 {
 
 
-template <typename T, typename LambdaT>
+template <typename LambdaT>
 __global__ void eval_lambda(int32_t n, LambdaT lambda) {
   int32_t i = (blockIdx.y * gridDim.x + blockIdx.x) * blockDim.x + threadIdx.x;
   if (i < n) {
@@ -186,10 +184,10 @@ void SetData(ContextPtrType c, T *data, int32_t n, LambdaT &lambda) {
 }
 
 /*
-  This is a form of Eval() where the lambda takes  two arguments.
+  This is a form of Eval() where the lambda takes two arguments.
 
   Eval2() will evaluate lambda(i, j) for 0 <= i < m and 0 <= j < n,
-  on the appropriate  device (CPU or GPU).  The second index, n,
+  on the appropriate device (CPU or GPU). The second index, n,
   is supposed to be the faster-varying one, the index for which
   threads in the same warp will tend to have different values.
   (Of course this doesn't affect the semantics of the operation).

--- a/k2/csrc/macros.h
+++ b/k2/csrc/macros.h
@@ -139,7 +139,7 @@ Here is an example:
       c, dim, ans_data, lambda_multiple2, (int32_t i)->int32_t{ return i*2; });
 @endcode
 
-`ans` will be {0, 2, 6, 12}
+`ans` will be {0, 0, 2, 6}
  */
 #define K2_TRANS_EXCSUM(context, dim, ans_data, lambda_name, ...)              \
   do {                                                                         \

--- a/k2/csrc/ragged_inl.h
+++ b/k2/csrc/ragged_inl.h
@@ -25,7 +25,7 @@
 #define K2_CSRC_RAGGED_INL_H_
 
 #ifndef IS_IN_K2_CSRC_RAGGED_H_
-#error "this file is supposed to be included only by ragged_ops.h"
+#error "this file is supposed to be included only by ragged.h"
 #endif
 
 


### PR DESCRIPTION
1. remove the unused typename in eval_lambda
2. other fixes are from https://github.com/k2-fsa/k2/pull/990, only fix the comment error and remove the new added test.
As Dan suggested last time: leave the unused macro "TRANS_EXCSUM" in code base in case of we may use it in the future.

So I will also close   https://github.com/k2-fsa/k2/pull/990.