### PR TITLE
Fix pruning bounds

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,7 @@ per-file-ignores =
     # line too long E501
     # line break before operator  W503
     k2/python/k2/rnnt_loss.py: E501, W503
+    k2/python/k2/version/version.py: E501
     k2/python/tests/rnnt_loss_test.py: W503
     k2/python/tests/rnnt_decode_test.py: W503
 exclude =

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -97,6 +97,7 @@ from .rnnt_loss import get_rnnt_logprobs_joint
 from .rnnt_loss import get_rnnt_logprobs_pruned
 from .rnnt_loss import get_rnnt_logprobs_smoothed
 from .rnnt_loss import get_rnnt_prune_ranges
+from .rnnt_loss import get_rnnt_prune_ranges_deprecated  # for testing purpose
 from .rnnt_loss import rnnt_loss
 from .rnnt_loss import rnnt_loss_pruned
 from .rnnt_loss import rnnt_loss_simple

--- a/k2/python/k2/rnnt_loss.py
+++ b/k2/python/k2/rnnt_loss.py
@@ -593,12 +593,7 @@ def get_rnnt_prune_ranges(
     # T1 == T here means we are using the modified version of transducer,
     # the third constrain becomes `s_begin[i + 1] - s_begin[i] < 2`, because
     # it only emits one symbol per frame.
-    # If S == s_range, the s_begin only contains zeros and padding values, no
-    # need to adjust them.
-    if S != s_range:
-        s_begin = _adjust_pruning_lower_bound(
-            s_begin, 2 if T1 == T else s_range
-        )
+    s_begin = _adjust_pruning_lower_bound(s_begin, 2 if T1 == T else s_range)
 
     ranges = s_begin.reshape((B, T, 1)).expand((B, T, s_range)) + torch.arange(
         s_range, device=px_grad.device
@@ -722,12 +717,7 @@ def get_rnnt_prune_ranges_deprecated(
     # T1 == T here means we are using the modified version of transducer,
     # the third constrain becomes `s_begin[i + 1] - s_begin[i] < 2`, because
     # it only emits one symbol per frame.
-    # If S == s_range, the s_begin only contains zeros and padding values, no
-    # need to adjust them.
-    if S != s_range:
-        s_begin = _adjust_pruning_lower_bound(
-            s_begin, 2 if T1 == T else s_range
-        )
+    s_begin = _adjust_pruning_lower_bound(s_begin, 2 if T1 == T else s_range)
 
     ranges = s_begin.reshape((B, T, 1)).expand((B, T, s_range)) + torch.arange(
         s_range, device=px_grad.device

--- a/k2/python/tests/rnnt_loss_test.py
+++ b/k2/python/tests/rnnt_loss_test.py
@@ -68,7 +68,11 @@ def generate_mask(S: int, ranges: torch.Tensor) -> torch.Tensor:
     assert torch.all(ranges < S)
     B, T, s_range = ranges.shape
     mask = torch.cat(
-        [torch.zeros(B, T, s_range), torch.ones(B, T, S - s_range)], dim=2
+        [
+            torch.zeros((B, T, s_range), device=ranges.device),
+            torch.ones((B, T, S - s_range), device=ranges.device),
+        ],
+        dim=2,
     )
     index = (
         torch.arange(S, device=ranges.device)

--- a/k2/python/tests/rnnt_loss_test.py
+++ b/k2/python/tests/rnnt_loss_test.py
@@ -28,6 +28,59 @@ import random
 import torch
 
 
+def generate_mask(S: int, ranges: torch.Tensor) -> torch.Tensor:
+    """
+    Generate a boolean tensor of shape (B, T, S), where the elements with
+    indexes in tensor ranges are False, others are True.
+
+    Example:
+    >>> ranges = torch.tensor(
+            [[[0, 1, 2],
+              [1, 2, 3],
+              [1, 2, 3],
+              [2, 3, 4],
+              [2, 3, 4],
+              [2, 3, 4]]]
+        )
+    >>> print (ranges)
+    tensor([[[0, 1, 2],
+         [1, 2, 3],
+         [1, 2, 3],
+         [2, 3, 4],
+         [2, 3, 4],
+         [2, 3, 4]]])
+    >>> mask = generate_mask(5, ranges)
+    >>> print (mask)
+    tensor([[[False, False, False,  True,  True],
+         [ True, False, False, False,  True],
+         [ True, False, False, False,  True],
+         [ True,  True, False, False, False],
+         [ True,  True, False, False, False],
+         [ True,  True, False, False, False]]])
+
+    Args:
+      S:
+        The expected size of third dimension of returned tensor.
+      ranges:
+        A index tensor with shape (B, T, s_range), all its elements must
+        satisfy `0 <= ranges[:] < S`.
+    """
+    assert torch.all(ranges < S)
+    B, T, s_range = ranges.shape
+    mask = torch.cat(
+        [torch.zeros(B, T, s_range), torch.ones(B, T, S - s_range)], dim=2
+    )
+    index = (
+        torch.arange(S, device=ranges.device)
+        .view((1, S))
+        .repeat((T, 1))
+        .repeat((B, 1, 1))
+    )
+    index = (index - ranges[:, :, 0].reshape(B, T, 1)) % S
+    mask = torch.gather(mask, 2, index).bool()
+    return mask
+
+
 class TestRnntLoss(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -120,11 +173,11 @@ class TestRnntLoss(unittest.TestCase):
             )
             assert torch.allclose(m, expected.to(device))
 
-            probs = am.unsqueeze(2) + lm.unsqueeze(1)
+            logits = am.unsqueeze(2) + lm.unsqueeze(1)
 
             # test rnnt_loss
             m = k2.rnnt_loss(
-                logits=probs,
+                logits=logits,
                 symbols=symbols,
                 termination_symbol=termination_symbol,
                 boundary=None,
@@ -137,7 +190,7 @@ class TestRnntLoss(unittest.TestCase):
                 import torchaudio.functional
 
                 m = torchaudio.functional.rnnt_loss(
-                    logits=probs,
+                    logits=logits,
                     targets=symbols.int(),
                     logit_lengths=torch.tensor(
                         [T] * B, dtype=torch.int32, device=device
@@ -176,9 +229,9 @@ class TestRnntLoss(unittest.TestCase):
             )
             assert torch.allclose(m, expected.to(device))
 
-            probs = am.unsqueeze(2) + lm.unsqueeze(1)
+            logits = am.unsqueeze(2) + lm.unsqueeze(1)
             m = k2.rnnt_loss(
-                logits=probs,
+                logits=logits,
                 symbols=symbols,
                 termination_symbol=termination_symbol,
                 boundary=None,
@@ -255,9 +308,9 @@ class TestRnntLoss(unittest.TestCase):
                 )
                 assert torch.allclose(m, expected.to(device))
 
-                probs = am.unsqueeze(2) + lm.unsqueeze(1)
+                logits = am.unsqueeze(2) + lm.unsqueeze(1)
                 m = k2.rnnt_loss(
-                    logits=probs,
+                    logits=logits,
                     symbols=symbols,
                     termination_symbol=termination_symbol,
                     boundary=boundary,
@@ -270,7 +323,7 @@ class TestRnntLoss(unittest.TestCase):
                     import torchaudio.functional
 
                     m = torchaudio.functional.rnnt_loss(
-                        logits=probs,
+                        logits=logits,
                         targets=symbols.int(),
                         logit_lengths=boundary[:, 3].int(),
                         target_lengths=boundary[:, 2].int(),
@@ -292,9 +345,9 @@ class TestRnntLoss(unittest.TestCase):
                 )
                 assert torch.allclose(m, expected.to(device))
 
-                probs = am.unsqueeze(2) + lm.unsqueeze(1)
+                logits = am.unsqueeze(2) + lm.unsqueeze(1)
                 m = k2.rnnt_loss(
-                    logits=probs,
+                    logits=logits,
                     symbols=symbols,
                     termination_symbol=termination_symbol,
                     boundary=boundary,
@@ -345,27 +398,27 @@ class TestRnntLoss(unittest.TestCase):
                 symbols = symbols_.to(device)
                 boundary = boundary_.to(device)
 
-                logprobs = am.unsqueeze(2) + lm.unsqueeze(1)
-                logprobs.requires_grad_()
+                logits = am.unsqueeze(2) + lm.unsqueeze(1)
+                logits.requires_grad_()
                 k2_loss = k2.rnnt_loss(
-                    logits=logprobs,
+                    logits=logits,
                     symbols=symbols,
                     termination_symbol=termination_symbol,
                     boundary=boundary,
                 )
-                k2_grad = torch.autograd.grad(k2_loss, logprobs)
+                k2_grad = torch.autograd.grad(k2_loss, logits)
                 k2_grad = k2_grad[0]
 
-                logprobs2 = logprobs.detach().clone().float()
-                logprobs2.requires_grad_()
+                logits2 = logits.detach().clone().float()
+                logits2.requires_grad_()
                 torch_loss = torchaudio.functional.rnnt_loss(
-                    logits=logprobs2,
+                    logits=logits2,
                     targets=symbols.int(),
                     logit_lengths=boundary[:, 3].int(),
                     target_lengths=boundary[:, 2].int(),
                     blank=termination_symbol,
                 )
-                torch_grad = torch.autograd.grad(torch_loss, logprobs2)
+                torch_grad = torch.autograd.grad(torch_loss, logits2)
                 torch_grad = torch_grad[0]
 
                 assert torch.allclose(k2_loss, torch_loss, atol=1e-2, rtol=1e-2)
@@ -450,22 +503,23 @@ class TestRnntLoss(unittest.TestCase):
                 lm = lm_.to(device)
                 symbols = symbols_.to(device)
                 boundary = boundary_.to(device)
-                t_am = am.unsqueeze(2).float()
-                t_lm = lm.unsqueeze(1).float()
-                t_prob = t_am + t_lm
+
+                logits = am.unsqueeze(2) + lm.unsqueeze(1)
+                logits = logits.float()
 
                 # nonlinear transform
-                t_prob = torch.sigmoid(t_prob)
+                logits = torch.sigmoid(logits)
                 k2_loss = k2.rnnt_loss(
-                    logits=t_prob,
+                    logits=logits,
                     symbols=symbols,
                     termination_symbol=terminal_symbol,
                     boundary=boundary,
                     modified=modified,
+                    reduction="none",
                 )
 
                 print(
-                    f"unpruned rnnt loss with modified {modified} : {k2_loss}"
+                    f"Unpruned rnnt loss with modified {modified} : {k2_loss}"
                 )
 
                 # pruning
@@ -488,15 +542,16 @@ class TestRnntLoss(unittest.TestCase):
                         s_range=r,
                     )
                     # (B, T, r, C)
-                    am_p, lm_p = k2.do_rnnt_pruning(am=am, lm=lm, ranges=ranges)
+                    pruned_am, pruned_lm = k2.do_rnnt_pruning(
+                        am=am, lm=lm, ranges=ranges
+                    )
 
-                    t_prob_p = am_p + lm_p
-
+                    logits = pruned_am + pruned_lm
                     # nonlinear transform
-                    t_prob_p = torch.sigmoid(t_prob_p)
+                    logits = torch.sigmoid(logits)
 
                     pruned_loss = k2.rnnt_loss_pruned(
-                        logits=t_prob_p,
+                        logits=logits,
                         symbols=symbols,
                         ranges=ranges,
                         termination_symbol=terminal_symbol,
@@ -504,7 +559,194 @@ class TestRnntLoss(unittest.TestCase):
                         modified=modified,
                         reduction="none",
                     )
-                    print(f"pruning loss with range {r} : {pruned_loss}")
+                    print(f"Pruned loss with range {r} : {pruned_loss}")
+
+    # Test the sequences that only have small number of symbols,
+    # at this circumstance, the s_range would be greater than S, which will
+    # raise errors (like, nan or inf loss) in our previous versions.
+    def test_rnnt_loss_pruned_small_symbols_number(self):
+        B = 2
+        T = 20
+        S = 3
+        C = 10
+
+        frames = torch.randint(S + 1, T, (B,))
+        seq_lengths = torch.randint(1, S, (B,))
+        T = torch.max(frames)
+        S = torch.max(seq_lengths)
+
+        am_ = torch.randn((B, T, C), dtype=torch.float64)
+        lm_ = torch.randn((B, S + 1, C), dtype=torch.float64)
+        symbols_ = torch.randint(0, C, (B, S))
+        terminal_symbol = C - 1
+
+        boundary_ = torch.zeros((B, 4), dtype=torch.int64)
+        boundary_[:, 2] = seq_lengths
+        boundary_[:, 3] = frames
+
+        print(f"B = {B}, T = {T}, S = {S}, C = {C}")
+
+        for modified in [True, False]:
+            for device in self.devices:
+                # normal rnnt
+                am = am_.to(device)
+                lm = lm_.to(device)
+                symbols = symbols_.to(device)
+                boundary = boundary_.to(device)
+
+                logits = am.unsqueeze(2) + lm.unsqueeze(1)
+                logits = logits.float()
+
+                # nonlinear transform
+                logits = torch.sigmoid(logits)
+
+                k2_loss = k2.rnnt_loss(
+                    logits=logits,
+                    symbols=symbols,
+                    termination_symbol=terminal_symbol,
+                    boundary=boundary,
+                    modified=modified,
+                    reduction="none",
+                )
+
+                print(
+                    f"Unpruned rnnt loss with modified {modified} : {k2_loss}"
+                )
+
+                # pruning
+                k2_simple_loss, (px_grad, py_grad) = k2.rnnt_loss_simple(
+                    lm=lm,
+                    am=am,
+                    symbols=symbols,
+                    termination_symbol=terminal_symbol,
+                    boundary=boundary,
+                    modified=modified,
+                    return_grad=True,
+                    reduction="none",
+                )
+
+                S0 = 2
+                if modified:
+                    S0 = 1
+
+                for r in range(S0, S + 2):
+                    ranges = k2.get_rnnt_prune_ranges(
+                        px_grad=px_grad,
+                        py_grad=py_grad,
+                        boundary=boundary,
+                        s_range=r,
+                    )
+                    # (B, T, r, C)
+                    pruned_am, pruned_lm = k2.do_rnnt_pruning(
+                        am=am, lm=lm, ranges=ranges
+                    )
+
+                    logits = pruned_am + pruned_lm
+
+                    # nonlinear transform
+                    logits = torch.sigmoid(logits)
+
+                    pruned_loss = k2.rnnt_loss_pruned(
+                        logits=logits,
+                        symbols=symbols,
+                        ranges=ranges,
+                        termination_symbol=terminal_symbol,
+                        boundary=boundary,
+                        modified=modified,
+                        reduction="none",
+                    )
+                    print(f"Pruned loss with range {r} : {pruned_loss}")
+
+    # Test more exact pruning bounds.
+    # In our previous versions we use a less exact method to generate
+    # pruning bounds which is different from the method we
+    # publish in our paper(https://arxiv.org/pdf/2206.13236.pdf).
+    # This tests the difference between these two methods.
+    # We won't do any assertion in this test, just printing out the losses,
+    # because we can not 100% sure that the new method is better than the old
+    # one all the time, both of them are local optimal bounds.
+    def test_prune_ranges(self):
+        B = 5
+        T = 100
+        S = 50
+        C = 50
+
+        frames = torch.randint(S + 1, T, (B,))
+        seq_lengths = torch.randint(1, S, (B,))
+        T = torch.max(frames)
+        S = torch.max(seq_lengths)
+
+        am_ = torch.rand((B, T, C), dtype=torch.float64)
+        lm_ = torch.rand((B, S + 1, C), dtype=torch.float64)
+        symbols_ = torch.randint(0, C, (B, S))
+        terminal_symbol = C - 1
+
+        boundary_ = torch.zeros((B, 4), dtype=torch.int64)
+        boundary_[:, 2] = seq_lengths
+        boundary_[:, 3] = frames
+
+        for device in self.devices:
+            am = am_.to(device)
+            lm = lm_.to(device)
+            symbols = symbols_.to(device)
+            boundary = boundary_.to(device)
+
+            k2_simple_loss, (px_grad, py_grad) = k2.rnnt_loss_simple(
+                lm=lm,
+                am=am,
+                symbols=symbols,
+                termination_symbol=terminal_symbol,
+                boundary=boundary,
+                return_grad=True,
+                reduction="none",
+            )
+
+            for r in range(2, 20, 5):
+                # (B, T, S + 1, C)
+                logits = am.unsqueeze(2) + lm.unsqueeze(1)
+                logits = logits.float()
+
+                new_ranges = k2.get_rnnt_prune_ranges(
+                    px_grad=px_grad,
+                    py_grad=py_grad,
+                    boundary=boundary,
+                    s_range=r,
+                )
+
+                mask = generate_mask(S + 1, new_ranges).unsqueeze(3)
+
+                logits_new = logits.masked_fill(mask, 0.0)
+
+                loss = k2.rnnt_loss(
+                    logits=logits_new,
+                    symbols=symbols,
+                    termination_symbol=terminal_symbol,
+                    boundary=boundary,
+                    reduction="none",
+                )
+
+                print(f"Pruned with new ranges {r} : {loss}")
+
+                old_ranges = k2.get_rnnt_prune_ranges_deprecated(
+                    px_grad=px_grad,
+                    py_grad=py_grad,
+                    boundary=boundary,
+                    s_range=r,
+                )
+
+                mask = generate_mask(S + 1, old_ranges).unsqueeze(3)
+
+                logits_old = logits.masked_fill(mask, 0.0)
+
+                loss = k2.rnnt_loss(
+                    logits=logits_old,
+                    symbols=symbols,
+                    termination_symbol=terminal_symbol,
+                    boundary=boundary,
+                    reduction="none",
+                )
+
+                print(f"Pruned with old ranges {r} : {loss}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes the issue of returning nan or inf loss (posted at https://github.com/danpovey/fast_rnnt/issues/10).
It also updates the method to generate pruning bounds (i.e. the method we wrote in our pruned rnn-t paper). I did some experiments on April, but fogot to submit the code, sorry! About the new pruning bounds, I think we can not 100% gurantee it would be better than the old one, as both of them are local optimal bounds.