### PR TITLE
Silencing the cmake check upon `setup.py --version`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ cmake_path = shutil.which('cmake')
 if cmake_path is None:
     raise Exception('Please install CMake before you proceed.')
 
-print(f'cmake_path: {cmake_path}')
 
 ret = check_call(['cmake', '--version'], stdout=DEVNULL, stderr=DEVNULL)
 if ret != 0:
@@ -98,6 +97,8 @@ def cmake_extension(name, *args, **kwargs) -> setuptools.Extension:
 class BuildExtension(build_ext):
 
     def build_extension(self, ext: setuptools.extension.Extension):
+        print(f'cmake_path: {cmake_path}')
+
         # build/temp.linux-x86_64-3.8
         os.makedirs(self.build_temp, exist_ok=True)
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ import glob
 import os
 import setuptools
 import shutil
+from subprocess import DEVNULL, check_call
 import sys
 
 from pathlib import Path
@@ -65,7 +66,7 @@ if cmake_path is None:
 
 print(f'cmake_path: {cmake_path}')
 
-ret = os.system('cmake --version')
+ret = check_call(['cmake', '--version'], stdout=DEVNULL, stderr=DEVNULL)
 if ret != 0:
     raise Exception('Failed to get CMake version')
 


### PR DESCRIPTION
In `setup.py`, the cmake version is checked with a call to `os.system()`:
https://github.com/k2-fsa/k2/blob/6ccbe9c28f69aa3d897a4bedc7d879fe0ec7f5f3/setup.py#L68
The output of `os.system()` is printed to stdout or stderr. In this case, the version string is printed to stderr.

This causes issues with programs that check the k2 version automatically with `python setup.py --version`:
```bash
$ python setup.py --version
cmake_path: /usr/bin/cmake
cmake version 3.23.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
1.17.dev20220713+cuda11.7.torch1.12.0
```

In this pull request, I changed the `os.system()` call to a `subprocess.check_call()` that is silenced.

Also, there is an additional print statement with the cmake version (`cmake_path: /usr/bin/cmake`) that prints to stdout.
I moved this to `build_extension()`, that is started upon installation.


I bumped into this issue when installing k2 from the script of the [k2 AUR package](https://aur.archlinux.org/packages/python-k2-git). This script checks the version script; this script does not accept multi-line version strings.
```bash
python-k2-git$ makepkg -s ; makepkg --printsrcinfo > .SRCINFO
==> Making package: python-k2-git 1.15.1-1 (Wed Jul 13 23:17:17 2022)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Updating python-k2-git git repo...
==> Validating source files with md5sums...
    python-k2-git ... Skipped
==> Extracting sources...
  -> Creating working copy of python-k2-git git repo...
Reset branch 'makepkg'
==> Starting pkgver()...
==> ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace.
==> ERROR: pkgver() generated an invalid version: cmake version 3.23.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
cmake_path: /usr/bin/cmake
1.17
```

@csukuangfj 