### PR TITLE
[WIP] A new version of modified rnnt-t

### DIFF
--- a/k2/python/csrc/torch/mutual_information_cpu.cu
+++ b/k2/python/csrc/torch/mutual_information_cpu.cu
@@ -86,7 +86,6 @@ torch::Tensor MutualInformationCpu(torch::Tensor px, torch::Tensor py,
         auto ans_a = ans.accessor<scalar_t, 1>();
 
         int t_offset = (modified ? -1 : 0);
-        float py_scale = (modified ? 2 : 1);
         for (int b = 0; b < B; b++) {
           int s_begin = boundary_a[b][0];
           int t_begin = boundary_a[b][1];
@@ -104,7 +103,7 @@ torch::Tensor MutualInformationCpu(torch::Tensor px, torch::Tensor py,
           }
           for (int t = t_begin + 1; t <= t_end; ++t)
             p_a[b][s_begin][t] =
-                p_a[b][s_begin][t - 1] + py_scale * py_a[b][s_begin][t - 1];
+                p_a[b][s_begin][t - 1] + py_a[b][s_begin][t - 1];
           for (int s = s_begin + 1; s <= s_end; ++s) {
             scalar_t p_s_t1 = p_a[b][s][t_begin];
             for (int t = t_begin + 1; t <= t_end; ++t) {
@@ -115,7 +114,7 @@ torch::Tensor MutualInformationCpu(torch::Tensor px, torch::Tensor py,
               // .. which obtains p_a[b][s][t - 1] from a register.
               p_a[b][s][t] = p_s_t1 = LogAdd<scalar_t>()(
                   p_a[b][s - 1][t + t_offset] + px_a[b][s - 1][t + t_offset],
-                  p_s_t1 + py_scale * py_a[b][s][t - 1]);
+                  p_s_t1 + py_a[b][s][t - 1]);
             }
           }
           ans_a[b] = p_a[b][s_end][t_end];
@@ -176,7 +175,6 @@ std::vector<torch::Tensor> MutualInformationBackwardCpu(
         auto ans_grad_a = ans_grad.accessor<scalar_t, 1>();
         auto boundary_a = boundary.accessor<int64_t, 2>();
         int t_offset = (modified ? -1 : 0);
-        float py_scale = (modified ? 2 : 1);
 
         for (int b = 0; b < B; b++) {
           int s_begin = boundary_a[b][0];
@@ -192,7 +190,7 @@ std::vector<torch::Tensor> MutualInformationBackwardCpu(
               // The statement we are backpropagating here is:
               // p_a[b][s][t] = LogAdd(
               //    p_a[b][s - 1][t + t_offset] + px_a[b][s - 1][t + t_offset],
-              //    p_a[b][s][t - 1] + py_scale * py_a[b][s][t - 1]);
+              //    p_a[b][s][t - 1] + py_a[b][s][t - 1]);
               // .. which obtains p_a[b][s][t - 1] from a register.
               scalar_t term1 = p_a[b][s - 1][t + t_offset] +
                                px_a[b][s - 1][t + t_offset],
@@ -213,17 +211,17 @@ std::vector<torch::Tensor> MutualInformationBackwardCpu(
               }
               px_grad_a[b][s - 1][t + t_offset] = term1_grad;
               p_grad_a[b][s - 1][t + t_offset] = term1_grad;
-              py_grad_a[b][s][t - 1] = py_scale * term2_grad;
-              p_grad_a[b][s][t - 1] += py_scale * term2_grad;
+              py_grad_a[b][s][t - 1] = term2_grad;
+              p_grad_a[b][s][t - 1] += term2_grad;
             }
           }
           for (int t = t_end; t > t_begin; --t) {
             // Backprop for:
             // p_a[b][s_begin][t] =
-            //     p_a[b][s_begin][t - 1] + py_scale * py_a[b][s_begin][t - 1];
+            //     p_a[b][s_begin][t - 1] + py_a[b][s_begin][t - 1];
             scalar_t this_p_grad = p_grad_a[b][s_begin][t];
-            p_grad_a[b][s_begin][t - 1] += py_scale * this_p_grad;
-            py_grad_a[b][s_begin][t - 1] = py_scale * this_p_grad;
+            p_grad_a[b][s_begin][t - 1] += this_p_grad;
+            py_grad_a[b][s_begin][t - 1] = this_p_grad;
           }
           if (!modified) {
             for (int s = s_end; s > s_begin; --s) {

--- a/k2/python/k2/rnnt_loss.py
+++ b/k2/python/k2/rnnt_loss.py
@@ -189,6 +189,8 @@ def get_rnnt_logprobs(
 
     if not modified:
         px = fix_for_boundary(px, boundary)
+    else:
+        px += py[:, 1:, :]
 
     return (px, py)
 
@@ -362,6 +364,8 @@ def get_rnnt_logprobs_joint(
 
     if not modified:
         px = fix_for_boundary(px, boundary)
+    else:
+        px += py[:, 1:, :]
 
     return (px, py)
 
@@ -792,6 +796,8 @@ def get_rnnt_logprobs_pruned(
 
     if not modified:
         px = fix_for_boundary(px, boundary)
+    else:
+        px += py[:, 1:, :]
 
     return (px, py)
 
@@ -1081,6 +1087,8 @@ def get_rnnt_logprobs_smoothed(
 
     if not modified:
         px_interp = fix_for_boundary(px_interp, boundary)
+    else:
+        px_interp += py_interp[:, 1:, :]
 
     return (px_interp, py_interp)
 


### PR DESCRIPTION
The idea from Daniel:

Constrained-RNN-T style paths, which is like Modified RNN-T in that you have to go to next frame when you emit a non-blank system, but this is done by "forcing" you to take the blank transition from the *next* context on the *current* frame, e.g. if we emit c given "a b" context, we are forced to emit "blank" given "b c" context on the current frame.  