### PR TITLE
[WIP] skipping blank frames with fast_beam_search

### DIFF
--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -268,6 +268,7 @@ Renumbering RnntDecodingStreams::DoFisrtPassPruning(
   const double *scores_data = scores_.values.Data(),
                *max_scores_per_stream_data = max_scores_per_stream.Data();
   double beam = config_.beam;
+  double gamma_blank = config_.gamma_blank;
   // "uas" is short for unpruned_arcs_shape
   const int32_t *uas_row_ids3_data = unpruned_arcs_shape.RowIds(3).Data(),
                 *uas_row_splits3_data = unpruned_arcs_shape.RowSplits(3).Data(),
@@ -313,6 +314,12 @@ Renumbering RnntDecodingStreams::DoFisrtPassPruning(
 
         // prune the arcs pointing to the final state.
         if (arc.label == -1) {
+          pass1_keep_data[idx0123] = 0;
+          return;
+        }
+
+        //  blank_prob = exp(logprobs_acc(idx01, 0))
+        if (exp(logprobs_acc(idx01, 0)) > gamma_blank) {
           pass1_keep_data[idx0123] = 0;
           return;
         }

--- a/k2/csrc/rnnt_decode.h
+++ b/k2/csrc/rnnt_decode.h
@@ -50,12 +50,14 @@ namespace rnnt_decoding {
 
 struct RnntDecodingConfig {
   RnntDecodingConfig(int32_t vocab_size, int32_t decoder_history_len,
-                     double beam, int32_t max_states, int32_t max_contexts)
+                     double beam, int32_t max_states, int32_t max_contexts,
+                     double gamma_blank)
       : vocab_size(vocab_size),
         decoder_history_len(decoder_history_len),
         beam(beam),
         max_states(max_states),
-        max_contexts(max_contexts) {
+        max_contexts(max_contexts),
+        gamma_blank(gamma_blank) {
     // num_context_states = pow(vocab_size, decoder_history_len);
   }
 
@@ -89,6 +91,12 @@ struct RnntDecodingConfig {
   // per frame, per stream; the number of contexts will not be allowed to
   // exceed this limit.
   int32_t max_contexts;
+
+  // `gamma_blank`, with range(0, 1], is used to filter out blank frames.
+  // If gamma_blank == 1.0, all frames are kept.
+  // If gamma_blank == 0.0, all frames are filtered out.
+  // Detailed by Algorithm 1 in https://arxiv.org/pdf/2101.06856.pdf
+  double gamma_blank;
 };
 
 struct ArcInfo {

--- a/k2/csrc/rnnt_decode_test.cu
+++ b/k2/csrc/rnnt_decode_test.cu
@@ -43,7 +43,8 @@ TEST(RnntDecodingStreams, Basic) {
     int32_t vocab_size = 6;
     auto config =
         RnntDecodingConfig(vocab_size, 2 /*decoder_history_len*/, 8.0f /*beam*/,
-                           2 /*max_states*/, 3 /*max_contexts*/);
+                           2 /*max_states*/, 3 /*max_contexts*/,
+                           1.0f /*gamma_blank*/);
 
     Array1<int32_t> aux_labels;
     auto trivial_graph = std::make_shared<Fsa>(TrivialGraph(c, 5, &aux_labels));

--- a/k2/python/csrc/torch/rnnt_decode.cu
+++ b/k2/python/csrc/torch/rnnt_decode.cu
@@ -36,9 +36,10 @@ namespace k2 {
 static void PybindRnntDecodingConfig(py::module &m) {
   using PyClass = rnnt_decoding::RnntDecodingConfig;
   py::class_<PyClass> config(m, "RnntDecodingConfig");
-  config.def(py::init<int32_t, int32_t, double, int32_t, int32_t>(),
+  config.def(py::init<int32_t, int32_t, double, int32_t, int32_t, double>(),
              py::arg("vocab_size"), py::arg("decoder_history_len"),
              py::arg("beam"), py::arg("max_states"), py::arg("max_contexts"),
+             py::arg("gamma_blank"),
              R"(
              Construct a RnntDecodingConfig object, it contains the parameters
              needed by rnnt decoding.
@@ -63,13 +64,19 @@ static void PybindRnntDecodingConfig(py::module &m) {
                  `max_contexts` is a limit on the number of distinct contexts
                  that we allow per frame, per stream; the number of contexts
                  will not be allowed to exceed this limit.
+               gamma_blank:
+                  `gamma_blank`, with range(0, 1], is used to filter out blank frames.
+                  If gamma_blank == 1.0, all frames are kept.
+                  If gamma_blank == 0.0, all frames are filtered out.
+                  Detailed by Algorithm 1 in https://arxiv.org/pdf/2101.06856.pdf
              )");
 
   config.def_readwrite("vocab_size", &PyClass::vocab_size)
       .def_readwrite("decoder_history_len", &PyClass::decoder_history_len)
       .def_readwrite("beam", &PyClass::beam)
       .def_readwrite("max_states", &PyClass::max_states)
-      .def_readwrite("max_contexts", &PyClass::max_contexts);
+      .def_readwrite("max_contexts", &PyClass::max_contexts)
+      .def_readwrite("gamma_blank", &PyClass::gamma_blank);
 
   config.def("__str__", [](const PyClass &self) -> std::string {
     std::ostringstream os;
@@ -79,6 +86,7 @@ static void PybindRnntDecodingConfig(py::module &m) {
        << "  beam : " << self.beam << "\n"
        << "  max_states : " << self.max_states << "\n"
        << "  max_contexts : " << self.max_contexts << "\n"
+       << "  gamma_blank: " << self.gamma_blank << "\n"
        << "}";
     return os.str();
   });


### PR DESCRIPTION
This pr is about skipping blank frames based on fast_beam_search.  
It's similar to https://github.com/k2-fsa/icefall/pull/472  except that one is based on greedy_search_batch.

When prob_blank > gamma_blank, only epsilon self-loop (the arc for blank) is kept.  

WER with different gamma_blank:

gamma_blank|test-clean|test-other
--|--|--
0.1|3.83|7.11
0.2|2.64|5.56
0.3|2.34|5.06
0.4|2.23|4.95
0.5|2.16|4.84
0.6|2.13|4.79
0.7|2.11|4.76
0.8|2.11|4.75
0.9|2.11|4.75
1.0|2.11|4.75
baseline no blank skipping|2.11|4.75
