### PR TITLE
Fix building on Windows.

### DIFF
--- a/k2/python/csrc/CMakeLists.txt
+++ b/k2/python/csrc/CMakeLists.txt
@@ -36,7 +36,9 @@ target_include_directories(_k2 PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(_k2 PRIVATE ${CMAKE_BINARY_DIR})
 set_target_properties(_k2 PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
-target_link_libraries(_k2 PRIVATE "-Wl,-rpath,${k2_rpath_origin}/k2/${CMAKE_INSTALL_LIBDIR}")
+if(NOT WIN32)
+  target_link_libraries(_k2 PRIVATE "-Wl,-rpath,${k2_rpath_origin}/k2/${CMAKE_INSTALL_LIBDIR}")
+endif()
 
 if(UNIX AND NOT APPLE)
   # It causes errors on macOS

--- a/k2/python/csrc/version.cu
+++ b/k2/python/csrc/version.cu
@@ -20,6 +20,8 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include "k2/csrc/log.h"
 #include "k2/csrc/version.h"
 #include "k2/python/csrc/version.h"

--- a/k2/python/csrc/version.cu
+++ b/k2/python/csrc/version.cu
@@ -27,20 +27,20 @@
 void PybindVersion(py::module &m) {
   py::module version = m.def_submodule("version", "k2 version information");
 
-  version.attr("__version__") = k2::kVersion;
-  version.attr("git_sha1") = k2::kGitSha1;
-  version.attr("git_date") = k2::kGitDate;
-  version.attr("cuda_version") = k2::kCudaVersion;
-  version.attr("cudnn_version") = k2::kCudnnVersion;
-  version.attr("python_version") = k2::kPythonVersion;
-  version.attr("build_type") = k2::kBuildType;
-  version.attr("os_type") = k2::kOS;
-  version.attr("cmake_version") = k2::kCMakeVersion;
-  version.attr("gcc_version") = k2::kGCCVersion;
-  version.attr("cmake_cuda_flags") = k2::kCMakeCudaFlags;
-  version.attr("cmake_cxx_flags") = k2::kCMakeCxxFlags;
-  version.attr("torch_version") = k2::kTorchVersion;
-  version.attr("torch_cuda_version") = k2::kTorchCudaVersion;
+  version.attr("__version__") = std::string(k2::kVersion);
+  version.attr("git_sha1") = std::string(k2::kGitSha1);
+  version.attr("git_date") = std::string(k2::kGitDate);
+  version.attr("cuda_version") = std::string(k2::kCudaVersion);
+  version.attr("cudnn_version") = std::string(k2::kCudnnVersion);
+  version.attr("python_version") = std::string(k2::kPythonVersion);
+  version.attr("build_type") = std::string(k2::kBuildType);
+  version.attr("os_type") = std::string(k2::kOS);
+  version.attr("cmake_version") = std::string(k2::kCMakeVersion);
+  version.attr("gcc_version") = std::string(k2::kGCCVersion);
+  version.attr("cmake_cuda_flags") = std::string(k2::kCMakeCudaFlags);
+  version.attr("cmake_cxx_flags") = std::string(k2::kCMakeCxxFlags);
+  version.attr("torch_version") = std::string(k2::kTorchVersion);
+  version.attr("torch_cuda_version") = std::string(k2::kTorchCudaVersion);
   version.attr("enable_nvtx") = k2::kEnableNvtx;
   version.attr("disable_debug") = k2::internal::kDisableDebug;
   version.attr("with_cuda") = k2::kWithCuda;


### PR DESCRIPTION
I was able to build k2 with cuda support on Windows using this PR.
```
python3 -m k2.version
```
gives the following output:
```
k2 version: 1.17
Build type: Release
Git SHA1: 1c396b9aee094cd56867dc5c5bd2fb40074ed126
Git date: Mon Jul 25 10:11:54 2022
Cuda used to build k2: 11.1
cuDNN used to build k2: 8.2.0
Python version used to build k2: 3.8
OS used to build k2: Microsoft Windows 10 专业版  10.0.19042
CMake version: 3.20.3
GCC version: 19.16.27045.0
CMAKE_CUDA_FLAGS: -D_WINDOWS -Xcompiler="/W3 /GR /EHsc" --expt-relaxed-constexpr  -Wno-deprecated-gpu-targets   -lineinfo --expt-exten
ded-lambda -use_fast_math -Xptxas=-w  --expt-extended-lambda -gencode arch=compute_35,code=sm_35  -lineinfo --expt-extended-lambda -us
e_fast_math -Xptxas=-w  --expt-extended-lambda -gencode arch=compute_50,code=sm_50  -lineinfo --expt-extended-lambda -use_fast_math -X
ptxas=-w  --expt-extended-lambda -gencode arch=compute_60,code=sm_60  -lineinfo --expt-extended-lambda -use_fast_math -Xptxas=-w  --ex
pt-extended-lambda -gencode arch=compute_61,code=sm_61  -lineinfo --expt-extended-lambda -use_fast_math -Xptxas=-w  --expt-extended-la
mbda -gencode arch=compute_70,code=sm_70  -lineinfo --expt-extended-lambda -use_fast_math -Xptxas=-w  --expt-extended-lambda -gencode
arch=compute_75,code=sm_75  -lineinfo --expt-extended-lambda -use_fast_math -Xptxas=-w  --expt-extended-lambda -gencode arch=compute_8
0,code=sm_80  -lineinfo --expt-extended-lambda -use_fast_math -Xptxas=-w  --expt-extended-lambda -gencode arch=compute_86,code=sm_86
--compiler-options /wd4005  --compiler-options /wd4018  --compiler-options /wd4067  --compiler-options /wd4068  --compiler-options /wd
4099  --compiler-options /wd4101  --compiler-options /wd4190  --compiler-options /wd4224  --compiler-options /wd4251  --compiler-optio
ns /wd4244  --compiler-options /wd4267  --compiler-options /wd4275  --compiler-options /wd4305  --compiler-options /wd4522  --compiler
-options /wd4551  --compiler-options /wd4624  --compiler-options /wd4700  --compiler-options /wd4722  --compiler-options /wd4819  --co
mpiler-options /wd4838  --compiler-options /wd4996
CMAKE_CXX_FLAGS: /DWIN32 /D_WINDOWS /W3 /GR /EHsc  /wd4005  /wd4018  /wd4067  /wd4068  /wd4099  /wd4101  /wd4190  /wd4224  /wd4251  /w
d4244  /wd4267  /wd4275  /wd4305  /wd4522  /wd4551  /wd4624  /wd4700  /wd4722  /wd4819  /wd4838  /wd4996  /bigobj
PyTorch version used to build k2: 1.8.1
PyTorch is using Cuda: 11.1
NVTX enabled: True
With CUDA: True
Disable debug: True
Sync kernels : False
Disable checks: False
Max cpu memory allocate: 214748364800 bytes (or 200.0 GB)
k2 abort: False
__file__: D:\software\anaconda3\envs\py38\lib\site-packages\k2\version\version.py
_k2.__file__: D:\software\anaconda3\envs\py38\lib\site-packages\_k2.cp38-win_amd64.pyd
```

Waiting for someone to test it on Windows with nvidia GPUs.