### PR TITLE
Fix displaying python version when building conda packages

### DIFF
--- a/.github/workflows/build-conda-cpu-macos.yml
+++ b/.github/workflows/build-conda-cpu-macos.yml
@@ -113,5 +113,5 @@ jobs:
       - name: Upload generated files
         uses: actions/upload-artifact@v2
         with:
-          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-${{ matrix.os }}
+          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-macos-10.15
           path: /usr/local/miniconda/envs/k2/conda-bld/osx-64/*.tar.bz2

--- a/.github/workflows/build-conda-cpu-ubuntu.yml
+++ b/.github/workflows/build-conda-cpu-ubuntu.yml
@@ -113,5 +113,5 @@ jobs:
       - name: Upload generated files
         uses: actions/upload-artifact@v2
         with:
-          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-${{ matrix.os }}
+          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-ubuntu-18.04
           path: /usr/share/miniconda/envs/k2/conda-bld/linux-64/*.tar.bz2

--- a/.github/workflows/build-conda-cpu-windows.yml
+++ b/.github/workflows/build-conda-cpu-windows.yml
@@ -108,5 +108,5 @@ jobs:
       - name: Upload Wheel
         uses: actions/upload-artifact@v2
         with:
-          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-${{ matrix.os }}-cpu
+          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-windows-2019-cpu
           path: c:/Miniconda/envs/k2/conda-bld/win-64/*.tar.bz2

--- a/.github/workflows/build-conda-cuda-ubuntu.yml
+++ b/.github/workflows/build-conda-cuda-ubuntu.yml
@@ -125,3 +125,13 @@ jobs:
         run: |
           export K2_BUILD_TYPE=$K2_BUILD_TYPE
           ./scripts/build_conda.sh
+
+      - name: Display generated files
+        run: |
+          ls -lh /usr/share/miniconda/envs/k2/conda-bld/linux-64
+
+      - name: Upload generated files
+        uses: actions/upload-artifact@v2
+        with:
+          name: torch-${{ matrix.torch }}-cuda-${{ matrix.cuda }}-python-${{ matrix.python-version }}-ubuntu-18.04
+          path: /usr/share/miniconda/envs/k2/conda-bld/linux-64/*.tar.bz2

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -55,7 +55,7 @@ cd $k2_dir
 export K2_ROOT_DIR=$k2_dir
 echo "K2_ROOT_DIR: $K2_ROOT_DIR"
 
-K2_PYTHON_VERSION=$(python3 -c "import sys; print(sys.version[:3])")
+K2_PYTHON_VERSION=$(python3 -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
 
 if [ -z $K2_CUDA_VERSION ]; then
   echo "env var K2_CUDA_VERSION is not set, defaults to 10.1"

--- a/scripts/build_conda_cpu.sh
+++ b/scripts/build_conda_cpu.sh
@@ -45,7 +45,7 @@ echo "K2_ROOT_DIR: $K2_ROOT_DIR"
 
 which python
 python -m torch.utils.collect_env
-K2_PYTHON_VERSION=$(python -c "import sys; print(sys.version[:3])")
+K2_PYTHON_VERSION=$(python -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
 
 if [ -z $K2_TORCH_VERSION ]; then
   echo "env var K2_TORCH_VERSION is not set, defaults to 1.7.1"


### PR DESCRIPTION
The previous code can handle python versions like 3.8, 3.9 and 3.x; but it cannot handle python versions like 3.10, 3.xx.

This PR fixes that.