### PR TITLE
[Ready] fix index error of shortest_path

### DIFF
--- a/k2/csrc/fsa_algo.cu
+++ b/k2/csrc/fsa_algo.cu
@@ -1089,15 +1089,12 @@ Ragged<int32_t> ShortestPath(FsaVec &fsas,
             // a step with "jobs_per_fsa" arcs.
             cur_num_best_states_this_fsa = next_num_best_states_this_fsa;
             next_num_best_states_this_fsa += jobs_per_fsa;
-            prev_src_state_idx01 = cur_src_state_idx01;
+            prev_src_state_idx01 =
+              arcs_data[cur_index].src_state + begin_state_idx01;
 
             // Try a step with "jobs_per_fsa" arcs.
             cur_index =
-              entering_arcs_powers_acc(log_power, cur_src_state_idx01);
-            cur_dest_state_idx01 =
-              arcs_data[cur_index].dest_state + begin_state_idx01;
-            cur_src_state_idx01 =
-              arcs_data[cur_index].src_state + begin_state_idx01;
+              entering_arcs_powers_acc(log_power, prev_src_state_idx01);
           }
         }
       });

--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -150,6 +150,22 @@ class TestShortestPath(unittest.TestCase):
                          torch.ones(2, device=device)))
             assert fsa3.scores.grad.sum() == 2
 
+    def test_large_fsa(self):
+        num_arcs = 200000
+        num_fsas = 10
+        for device in self.devices:
+            labels = torch.randint(0, 1000, [num_arcs])
+            fsa = k2.linear_fst(labels.tolist(), labels.tolist())
+            fsav = k2.create_fsa_vec([fsa] * num_fsas).to(device)
+            best_path = k2.shortest_path(fsav, use_double_scores=False)
+
+            expected_labels = torch.zeros(num_arcs + 1, dtype=torch.int32)
+            expected_labels[:-1] = labels
+            expected_labels[-1] = -1
+            expected_labels = expected_labels.repeat(num_fsas).to(device)
+
+            assert torch.all(torch.eq(expected_labels, best_path.labels))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixed a bug of shortest_path, which only occasionally triggered by extra large fsas.  (Actually it was introduced by myself).
Related log:
```
[F] /ceph-ly/open-source/linear_fst_k2/k2/k2/csrc/eval.h:259:void k2::Eval2Device(cudaStream_t, int32_t, int32_t, LambdaT&) [wit
h LambdaT = __nv_dl_wrapper_t<__nv_dl_tag<k2::Ragged<int> (*)(k2::Ragged<k2::Arc>&, const k2::Array1<int>&), k2::ShortestPath, 2
>, int, const int*, const int*, int*, k2::Array2Accessor<int>, int, const k2::Arc*, int*, int>; cudaStream_t = CUstream_st*; int
32_t = int] Check failed: e == cudaSuccess (700 vs. 0)  Error: an illegal memory access was encountered. 
```

Here is what was going on:
>
>  https://github.com/k2-fsa/k2/blob/a8559310583ffc4cb71b18fa7a21596e83bb56b3/k2/csrc/fsa_algo.cu#L1095-L1100
>

cur_index would be -1 for the last step. so `arcs_data[cur_index].src_state` would be `arcs_data[-1].src_state`.
But sometimes  the program would not crash when visiting arcs_data[-1], at least with all previous unit tests.
And sometimes the bug code is even working well with this new added large fst.

Now the code in this pr is slightly adjusted to avoid visiting arc_data[-1].

All tests passed on a local machine.
<img width="951" alt="image" src="https://user-images.githubusercontent.com/14951566/184958382-21c95101-44d0-4098-a78e-7036dd80e378.png">


