### PR TITLE
Add to_str() to k2.SymbolTable

### DIFF
--- a/k2/python/k2/symbol_table.py
+++ b/k2/python/k2/symbol_table.py
@@ -130,6 +130,17 @@ class SymbolTable(Generic[Symbol]):
         with open(filename, 'r') as f:
             return SymbolTable.from_str(f.read().strip())
 
+    def to_str(self) -> str:
+        '''
+        Returns:
+          Return a string representation of this object. You can pass
+          it to the method ``from_str`` to recreate an identical object.
+        '''
+        s = ''
+        for idx, symbol in sorted(self._id2sym.items()):
+            s += f'{symbol} {idx}\n'
+        return s
+
     def to_file(self, filename: str):
         '''Serialize the SymbolTable to a file.
 
@@ -247,6 +258,16 @@ class SymbolTable(Generic[Symbol]):
 
     def __len__(self) -> int:
         return len(self._id2sym)
+
+    def __eq__(self, other: 'SymbolTable') -> bool:
+        if len(self) != len(other):
+            return False
+
+        for s in self.symbols:
+            if self[s] != other[s]:
+                return False
+
+        return True
 
     @property
     def ids(self) -> List[int]:

--- a/k2/python/tests/symbol_table_test.py
+++ b/k2/python/tests/symbol_table_test.py
@@ -85,6 +85,9 @@ class TestSymbolTable(unittest.TestCase):
         assert merged['e'] == 11
         assert merged[11] == 'e'
 
+        copied = k2.SymbolTable.from_str(merged.to_str())
+        assert merged == copied
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
So that we can convert k2.SymbolTable to the one in OpenFST easily.