### PR TITLE
shortest_path for non connected fst

### DIFF
--- a/k2/python/tests/shortest_path_test.py
+++ b/k2/python/tests/shortest_path_test.py
@@ -166,6 +166,24 @@ class TestShortestPath(unittest.TestCase):
 
             assert torch.all(torch.eq(expected_labels, best_path.labels))
 
+    def test_nonconnected_fst(self):
+        # Non-connected because of no arc from state-3 to state-4.
+        s = '''
+            0 1 1 9
+            1 2 2 8
+            2 3 3 7
+            4 5 5 6
+            5 6 6 5
+            6 7 8 4
+            7 8 -1 0
+            8
+        '''
+        for device in self.devices:
+            fsa = k2.Fsa.from_str(s).to(device)
+            fsa = k2.create_fsa_vec([fsa])
+            best_path = k2.shortest_path(fsa, use_double_scores=False)
+            assert best_path.num_arcs == 0
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix issue https://github.com/k2-fsa/k2/issues/1078
May also fix issue  https://github.com/k2-fsa/k2/issues/1077
Current k2.shortest_path in master branch "requires" connected input fsa. While in issue https://github.com/k2-fsa/k2/issues/1078, the input fst is not(Thanks to @jiaji-huang for providing the test input).

BTW, in icefall inputs of k2.shortest_path are always connected, so this "bug" is not triggered before:

https://github.com/k2-fsa/icefall/blob/6af5a82d8f9c9c38e3c87eaaab706b292c15bd9b/icefall/decode.py#L371-L375