### PR TITLE
[Ready] track arc_map_token during rnnt decoding

### DIFF
--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -936,6 +936,7 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
           arc.dest_state = oarc_idx01xx_next - oarc_idx0xxx;
           arc.label = -1;
           arc.score = 0;
+          out_map_data[oarc_idx01234] = -1;
         } else {
           const Arc *graph_arcs_data = graphs_arcs_data[oarc_idx0];
           arc.src_state = oarc_idx0123 - oarc_idx0xxx;
@@ -951,13 +952,12 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
           // make the generated lattice a valid k2 fsa.
           if (arc_info.graph_arc_idx01 == -1 || arc_info.label == -1) {
             arc.label = 0;
-            arc_info.graph_arc_idx01 = -1;
           } else {
             arc.label = graph_arcs_data[arc_info.graph_arc_idx01].label;
           }
           arc.score = arc_info.score;
+          out_map_data[oarc_idx01234] = arc_info.graph_arc_idx01;
         }
-        out_map_data[oarc_idx01234] = arc_info.graph_arc_idx01;
         arcs_out_data[oarc_idx01234] = arc;
         if (arc_map_b != nullptr) {
           t = t - num_padded_frames_data[oarc_idx0];

--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -91,6 +91,7 @@ void RnntDecodingStreams::TerminateAndFlushToStreams() {
   // detach prev_frames_
   std::vector<Ragged<ArcInfo> *> frames_ptr;
   for (size_t i = 0; i < prev_frames_.size(); ++i) {
+    // i is time index
     frames_ptr.emplace_back(prev_frames_[i].get());
   }
   // stack_frames has a shape of [t][stream][state][arc]
@@ -669,8 +670,9 @@ void RnntDecodingStreams::Advance(const Array2<float> &logprobs) {
         pruned_arcs_data[pruned_arc_idx0123] = info;
       });
 
+  // pruned_arcs is indexed [stream][context][src_state][arc].
   prev_frames_.emplace_back(
-      std::make_shared<Ragged<ArcInfo>>(pruned_arcs.RemoveAxis(1)));
+      std::make_shared<Ragged<ArcInfo>>(pruned_arcs));
 }
 
 void RnntDecodingStreams::GatherPrevFrames(
@@ -682,15 +684,17 @@ void RnntDecodingStreams::GatherPrevFrames(
   Array1<int32_t> stream2t_row_splits(GetCpuContext(), num_frames.size() + 1);
 
   for (size_t i = 0; i < num_frames.size(); ++i) {
+    // i is stream index
     stream2t_row_splits.Data()[i] = num_frames[i];
     K2_CHECK_LE(num_frames[i],
                 static_cast<int32_t>(srcs_[i]->prev_frames.size()));
     for (int32_t j = 0; j < num_frames[i]; ++j) {
+      // j is time index
       frames_ptr.push_back(srcs_[i]->prev_frames[j].get());
     }
   }
 
-  // frames has a shape of [t][state][arc],
+  // frames has a shape of [t][context][state][arc],
   // its Dim0() equals std::sum(num_frames)
   auto frames = Stack(0, frames_ptr.size(), frames_ptr.data());
 
@@ -715,6 +719,16 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
                                        bool allow_partial, FsaVec *ofsa,
                                        Array1<int32_t> *out_map) {
   NVTX_RANGE(K2_FUNC);
+  FormatOutput(num_frames, allow_partial, ofsa, out_map,
+               nullptr /* arc_map_token */, RaggedShape());
+}
+
+void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
+                                       bool allow_partial, FsaVec *ofsa,
+                                       Array1<int32_t> *out_map,
+                                       Array1<int32_t> *arc_map_b,
+                                       const RaggedShape &t2s2c_shape) {
+  NVTX_RANGE(K2_FUNC);
   K2_CHECK(!attached_)
       << "You can only get outputs after calling TerminateAndFlushToStreams()";
   K2_CHECK(ofsa);
@@ -728,15 +742,17 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
 
   auto has_final = Array1<bool>(c_, num_streams_, false);
   const ArcInfo *last_frame_arc_data = prev_frames_[frames - 1]->values.Data();
-  const int32_t *lfs_row_ids2_data = last_frame_shape.RowIds(2).Data(),
+  const int32_t *lfs_row_ids3_data = last_frame_shape.RowIds(3).Data(),
+                *lfs_row_ids2_data = last_frame_shape.RowIds(2).Data(),
                 *lfs_row_ids1_data = last_frame_shape.RowIds(1).Data();
   bool *has_final_data = has_final.Data();
 
   K2_EVAL(
       c_, last_frame_shape.NumElements(), lambda_set_has_final,
-      (int32_t idx012) {
-        ArcInfo ai = last_frame_arc_data[idx012];
-        int32_t idx01 = lfs_row_ids2_data[idx012],
+      (int32_t idx0123) {
+        ArcInfo ai = last_frame_arc_data[idx0123];
+        int32_t idx012 = lfs_row_ids3_data[idx0123],
+                idx01 = lfs_row_ids2_data[idx012],
                 idx0 = lfs_row_ids1_data[idx01];
         if (ai.label == -1) has_final_data[idx0] = true;
       });
@@ -746,17 +762,18 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
 
   K2_EVAL(
       c_, last_frame_shape.NumElements(), lambda_set_final_arcs,
-      (int32_t idx012) {
-        ArcInfo ai = last_frame_arc_data[idx012];
-        int32_t idx01 = lfs_row_ids2_data[idx012],
+      (int32_t idx0123) {
+        ArcInfo ai = last_frame_arc_data[idx0123];
+        int32_t idx012 = lfs_row_ids3_data[idx0123],
+                idx01 = lfs_row_ids2_data[idx012],
                 idx0 = lfs_row_ids1_data[idx01];
         if (ai.label == -1) {
-          num_final_arcs_data[idx012] = 1;
+          num_final_arcs_data[idx0123] = 1;
         } else {
           if (allow_partial && !has_final_data[idx0]) {
-            num_final_arcs_data[idx012] = 1;
+            num_final_arcs_data[idx0123] = 1;
           } else {
-            num_final_arcs_data[idx012] = 0;
+            num_final_arcs_data[idx0123] = 0;
           }
         }
       });
@@ -776,15 +793,22 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
         final_arcs_data[idx01] = ai;
       });
 
+  // last_frame_shape has a shape of [stream][context][state][arc]
   final_arcs_shape = ComposeRaggedShapes(last_frame_shape, final_arcs_shape);
-  final_arcs_shape = RemoveAxis(final_arcs_shape, 2);
+  // change final_arcs_shape form [stream][context][state][arc][arc]
+  // Note: the duplacation [arc][arc] is not typo.
+  // to [stream][context][state][arc]
+  final_arcs_shape = RemoveAxis(final_arcs_shape, 3);
 
   // We will append final states behind the last frame, the last_frame_shape
   // is
   /// the shape of the appended states, final states don't have arcs.
-  auto stream_state_shape = RegularRaggedShape(c_, num_streams_, 1);
+  auto stream_context_shape = RegularRaggedShape(c_, num_streams_, 1);
+  auto context_state_shape = RegularRaggedShape(c_, num_streams_, 1);
   auto state_arc_shape =
-      RegularRaggedShape(c_, stream_state_shape.NumElements(), 0);
+      RegularRaggedShape(c_, stream_context_shape.NumElements(), 0);
+  auto stream_state_shape =
+      ComposeRaggedShapes(stream_context_shape, context_state_shape);
   auto last_arcs_shape =
       ComposeRaggedShapes(stream_state_shape, state_arc_shape);
 
@@ -796,7 +820,7 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
   ArcInfo **arcs_data_ptrs_data = arcs_data_ptrs.Data();
 
   {
-    // each of these have 3 axes.
+    // each of these have 4 axes.
     std::vector<RaggedShape *> arcs_shapes(frames + 1);
     for (int32_t t = 0; t < frames - 1; ++t) {
       arcs_shapes[t] = &(prev_frames_[t]->shape);
@@ -807,8 +831,8 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
     arcs_shapes[frames - 1] = &final_arcs_shape;
     arcs_shapes[frames] = &last_arcs_shape;
 
-    // oshape is a 4-axis ragged tensor which is indexed:
-    //   oshape[stream][t][state_idx][arc_idx]
+    // oshape is a 5-axis ragged tensor which is indexed:
+    //   oshape[stream][t][context][state_idx][arc_idx]
     int32_t axis = 1;
     oshape = Stack(axis, frames + 1, arcs_shapes.data(), &oshape_merge_map);
   }
@@ -823,11 +847,44 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
   *out_map = Array1<int32_t>(c_, num_arcs);
   int32_t *out_map_data = out_map->Data();
 
-  int32_t *oshape_row_ids3 = oshape.RowIds(3).Data(),
+  int32_t vocab_size = config_.vocab_size;
+
+  int32_t *oshape_row_ids4 = oshape.RowIds(4).Data(),
+          *oshape_row_ids3 = oshape.RowIds(3).Data(),
           *oshape_row_ids2 = oshape.RowIds(2).Data(),
           *oshape_row_ids1 = oshape.RowIds(1).Data(),
+          *oshape_row_splits3 = oshape.RowSplits(3).Data(),
           *oshape_row_splits2 = oshape.RowSplits(2).Data(),
           *oshape_row_splits1 = oshape.RowSplits(1).Data();
+
+  int32_t arc_map_b_num_elements = 0;
+  // t2s2c_shape is short for time2stream2context_shape
+  const int32_t *t2s2c_shape_row_ids2 = nullptr,
+                *t2s2c_shape_row_ids1 = nullptr,
+                *t2s2c_shape_row_splits2 = nullptr,
+                *t2s2c_shape_row_splits1 = nullptr;
+
+    auto start_offset = Array1<int32_t>(c_, num_frames);
+    int32_t *start_offset_data = start_offset.Data();
+    int32_t T = 0;
+  if (arc_map_b != nullptr) {
+    arc_map_b_num_elements = num_arcs;
+    t2s2c_shape_row_ids2 = t2s2c_shape.RowIds(2).Data(),
+    t2s2c_shape_row_ids1 = t2s2c_shape.RowIds(1).Data(),
+    t2s2c_shape_row_splits2 = t2s2c_shape.RowSplits(2).Data(),
+    t2s2c_shape_row_splits1 = t2s2c_shape.RowSplits(1).Data();
+
+    T = num_frames[0];
+    // Initialize start_offset with num_frames.
+    K2_EVAL(
+        c_, num_streams_, lambda_set_start_offset, (int32_t stream_idx) {
+        start_offset_data[stream_idx] =
+          T - start_offset_data[stream_idx];
+        K2_CHECK_LE(0, start_offset_data[stream_idx]);
+    });
+  }
+  Array1<int32_t> arc_map_token = Array1<int32_t>(c_, arc_map_b_num_elements);
+  int32_t *arc_map_token_data = arc_map_token.Data();
 
   Array1<Arc> arcs_out(c_, num_arcs);
   Arc *arcs_out_data = arcs_out.Data();
@@ -835,16 +892,22 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
   const Arc *const *graphs_arcs_data = graphs_.values.Data();
 
   K2_EVAL(
-      c_, num_arcs, lambda_set_arcs, (int32_t oarc_idx0123) {
-        int32_t oarc_idx012 = oshape_row_ids3[oarc_idx0123],  // state
-            oarc_idx01 = oshape_row_ids2[oarc_idx012],        // frame
-            oarc_idx0 = oshape_row_ids1[oarc_idx01],          // stream
-            oarc_idx0x = oshape_row_splits1[oarc_idx0],
-                oarc_idx0xx = oshape_row_splits2[oarc_idx0x],
-                oarc_idx1 = oarc_idx01 - oarc_idx0x,
-                oarc_idx01x_next = oshape_row_splits2[oarc_idx01 + 1];
+      c_, num_arcs, lambda_set_arcs, (int32_t oarc_idx01234) {
+        int32_t oarc_idx0123 = oshape_row_ids4[oarc_idx01234],   // state
+                oarc_idx012 = oshape_row_ids3[oarc_idx0123],     // context
+                oarc_idx01 = oshape_row_ids2[oarc_idx012],       // frame
+                oarc_idx0 = oshape_row_ids1[oarc_idx01];         // stream
 
-        int32_t m = oshape_merge_map_data[oarc_idx0123],
+        int32_t oarc_idx0x = oshape_row_splits1[oarc_idx0],      // frame
+                oarc_idx0xx = oshape_row_splits2[oarc_idx0x],    // context
+                oarc_idx0xxx = oshape_row_splits3[oarc_idx0xx];  // state
+
+        int32_t oarc_idx01x = oshape_row_splits2[oarc_idx01],
+                oarc_idx01x_next = oshape_row_splits2[oarc_idx01 + 1],
+                oarc_idx01xx_next = oshape_row_splits3[oarc_idx01x_next],
+                oarc_idx1 = oarc_idx01 - oarc_idx0x;
+
+        int32_t m = oshape_merge_map_data[oarc_idx01234],
                 // actually we won't get t == frames
                 // here since those frames have no arcs.
             t = m % (frames + 1),
@@ -860,18 +923,18 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
 
         // all arcs in t == frames - 1 point to final state
         if (t == frames - 1) {
-          arc.src_state = oarc_idx012 - oarc_idx0xx;
-          arc.dest_state = oarc_idx01x_next - oarc_idx0xx;
+          arc.src_state = oarc_idx0123 - oarc_idx0xxx;
+          arc.dest_state = oarc_idx01xx_next - oarc_idx0xxx;
           arc.label = -1;
           arc.score = 0;
         } else {
           const Arc *graph_arcs_data = graphs_arcs_data[oarc_idx0];
-          arc.src_state = oarc_idx012 - oarc_idx0xx;
+          arc.src_state = oarc_idx0123 - oarc_idx0xxx;
 
           // Note: the idx1 w.r.t. the frame's `arcs` is an idx2 w.r.t.
           // `oshape`.
-          int32_t dest_state_idx012 = oarc_idx01x_next + arc_info.dest_state;
-          arc.dest_state = dest_state_idx012 - oarc_idx0xx;
+          int32_t dest_state_idx012 = oarc_idx01xx_next + arc_info.dest_state;
+          arc.dest_state = dest_state_idx012 - oarc_idx0xxx;
 
           // graph_arc_idx01 == -1 means this is a implicit epsilon self-loop
           // arc_info.label == -1 means this is the final arc before last
@@ -885,12 +948,34 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
           }
           arc.score = arc_info.score;
         }
-        out_map_data[oarc_idx0123] = arc_info.graph_arc_idx01;
-        arcs_out_data[oarc_idx0123] = arc;
+        out_map_data[oarc_idx01234] = arc_info.graph_arc_idx01;
+        arcs_out_data[oarc_idx01234] = arc;
+        if (arc_map_b != nullptr) {
+          t = t - start_offset_data[oarc_idx0];
+          int32_t t2s2c_idx0x_stream = t2s2c_shape_row_splits1[t];
+          // oarc_idx0 is for stream
+          int32_t t2s2c_idx01_stream = t2s2c_idx0x_stream + oarc_idx0;
+          int32_t t2s2c_idx0xx_context =
+                    t2s2c_shape_row_splits2[t2s2c_idx01_stream];
+          int32_t oarc_idx2 = oarc_idx012 - oarc_idx01x;
+          int32_t t2s2c_idx012_context = t2s2c_idx0xx_context + oarc_idx2;
+          // Map arc to super_final state to blk.
+          int32_t arc_label = 0;
+          if (arc.label != -1) {
+            arc_label = arc.label;
+          }
+          arc_map_token_data[oarc_idx01234] =
+            t2s2c_idx012_context * vocab_size + arc_label;
+        }
       });
 
-  // Remove axis 1, which corresponds to time.
-  *ofsa = FsaVec(RemoveAxis(oshape, 1), arcs_out);
+  if (arc_map_b != nullptr) {
+    *arc_map_b = std::move(arc_map_token);
+  }
+  // oshape [stream][t][context][state_idx][arc_idx]
+  // Remove axis 1 and 2, which corresponds to time and context.
+  auto oshape1 = RemoveAxis(oshape, 1);
+  *ofsa = FsaVec(RemoveAxis(oshape1, 1), arcs_out);
 }
 
 }  // namespace rnnt_decoding

--- a/k2/csrc/rnnt_decode.cu
+++ b/k2/csrc/rnnt_decode.cu
@@ -956,14 +956,14 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
         arcs_out_data[oarc_idx01234] = arc;
         if (arc_map_b != nullptr) {
           t = t - num_padded_frames_data[oarc_idx0];
-          int32_t t2s2c_idx0x_stream = t2s2c_shape_row_splits1[t];
+          int32_t t2s2c_stream_idx0x = t2s2c_shape_row_splits1[t];
           // oarc_idx0 is for stream.
-          int32_t t2s2c_idx01_stream = t2s2c_idx0x_stream + oarc_idx0;
-          int32_t t2s2c_idx01x_context =
-                    t2s2c_shape_row_splits2[t2s2c_idx01_stream];
+          int32_t t2s2c_stream_idx01 = t2s2c_stream_idx0x + oarc_idx0;
+          int32_t t2s2c_context_idx01x =
+                    t2s2c_shape_row_splits2[t2s2c_stream_idx01];
           // oarc_idx2 is for context.
           int32_t oarc_idx2 = oarc_idx012 - oarc_idx01x;
-          int32_t t2s2c_idx012_context = t2s2c_idx01x_context + oarc_idx2;
+          int32_t t2s2c_context_idx012 = t2s2c_context_idx01x + oarc_idx2;
           // Manually map arc to super_final state(i.e. arc.label == -1)
           // to blank_id == 0.
           int32_t arc_label = 0;
@@ -971,7 +971,7 @@ void RnntDecodingStreams::FormatOutput(const std::vector<int32_t> &num_frames,
             arc_label = arc.label;
           }
           arc_map_token_data[oarc_idx01234] =
-            t2s2c_idx012_context * vocab_size + arc_label;
+            t2s2c_context_idx012 * vocab_size + arc_label;
         }
       });
 

--- a/k2/csrc/rnnt_decode.h
+++ b/k2/csrc/rnnt_decode.h
@@ -195,6 +195,18 @@ class RnntDecodingStreams {
                      each individual streams, mapping current arc in ofsa to
                      original decoding graphs. It may contain -1 which means
                      this arc is a "termination symbol".
+      @param [out] arc_map_b  If non-NULL, it is an Array1 with Dim() equals to
+                     ofsa.NumElements() containing the idx0123 into log_probs
+                     generated during decoding.
+                     If NULL, this part will not be calculated.
+                     Name arc_map_b is borrowed from "intersect*" functions.
+                     In these functions,
+                     arc_map_a usually refers to indexes to fst based graphs,
+                     and arc_map_b usually refers to indexes to dense_fsa,
+                     i.e. log_probs from neural nets.
+      @param [in] t2s2c_shape  The shape of log_probs generated during decoding.
+                     It's short for time2stream2context,
+                     needed to generated arc_map_b.
    */
   void FormatOutput(const std::vector<int32_t> &num_frames, bool allow_partial,
                     FsaVec *ofsa, Array1<int32_t> *out_map,
@@ -202,6 +214,9 @@ class RnntDecodingStreams {
                     const RaggedShape &t2s2c_shape);
 
 
+  /*
+   * The same as above, except arc_map_b is not generated.
+   */
   void FormatOutput(const std::vector<int32_t> &num_frames, bool allow_partial,
                     FsaVec *ofsa, Array1<int32_t> *out_map);
 

--- a/k2/csrc/rnnt_decode.h
+++ b/k2/csrc/rnnt_decode.h
@@ -197,6 +197,12 @@ class RnntDecodingStreams {
                      this arc is a "termination symbol".
    */
   void FormatOutput(const std::vector<int32_t> &num_frames, bool allow_partial,
+                    FsaVec *ofsa, Array1<int32_t> *out_map,
+                    Array1<int32_t> *arc_map_b,
+                    const RaggedShape &t2s2c_shape);
+
+
+  void FormatOutput(const std::vector<int32_t> &num_frames, bool allow_partial,
                     FsaVec *ofsa, Array1<int32_t> *out_map);
 
   /*

--- a/k2/python/csrc/torch/rnnt_decode.cu
+++ b/k2/python/csrc/torch/rnnt_decode.cu
@@ -23,6 +23,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -151,6 +152,23 @@ static void PybindRnntDecodingStreams(py::module &m) {
                 self.FormatOutput(num_frames, allow_partial, &ofsa, &out_map);
                 torch::Tensor out_map_tensor = ToTorch<int32_t>(out_map);
                 return std::make_pair(ofsa, out_map_tensor);
+              });
+
+  streams.def("format_output",
+              [](PyClass &self, std::vector<int32_t> &num_frames,
+                 bool allow_partial, const RaggedShape &t2s2c_shape)
+              -> std::tuple<FsaVec, torch::Tensor, torch::Tensor> {
+                DeviceGuard guard(self.Context());
+                FsaVec ofsa;
+                Array1<int32_t> out_map;
+                Array1<int32_t> arc_map_token;
+                self.FormatOutput(num_frames, allow_partial, &ofsa, &out_map,
+                                  &arc_map_token, t2s2c_shape);
+                torch::Tensor out_map_tensor = ToTorch<int32_t>(out_map);
+                torch::Tensor arc_map_token_tensor =
+                                  ToTorch<int32_t>(arc_map_token);
+                return std::make_tuple(ofsa, out_map_tensor,
+                                       arc_map_token_tensor);
               });
 }
 

--- a/k2/python/k2/rnnt_decode.py
+++ b/k2/python/k2/rnnt_decode.py
@@ -289,10 +289,9 @@ class RnntDecodingStreams(object):
                 log_probs.reshape(-1), arc_map_token, default_value=0.0)
 
             # Decoding graph may contain non-zero scores on arcs.
-            if not torch.all(fsa.scores == scores_tracked_by_autograd):
-                graph_scores = \
-                    fsa.scores.detach() - scores_tracked_by_autograd.detach()
-                scores_tracked_by_autograd = \
-                    scores_tracked_by_autograd + graph_scores
+            graph_scores = \
+                fsa.scores.detach() - scores_tracked_by_autograd.detach()
+            scores_tracked_by_autograd = \
+                scores_tracked_by_autograd + graph_scores
             fsa.scores = scores_tracked_by_autograd
         return fsa

--- a/k2/python/tests/rnnt_decode_test.py
+++ b/k2/python/tests/rnnt_decode_test.py
@@ -137,7 +137,7 @@ class TestRnntDecode(unittest.TestCase):
                                         device=device))
             t2stream2context_shape3 = t2s_shape.compose(s2c_shape).to(device)
 
-            # Follow part is copied from:
+            # Following part is copied from:
             # ofsa = streams.format_output([3, 4, 5],
             #                              log_probs=logprobs_list_tensor,
             #                              t2s2c_shape=t2stream2context_shape3)

--- a/k2/python/tests/rnnt_decode_test.py
+++ b/k2/python/tests/rnnt_decode_test.py
@@ -73,30 +73,28 @@ class TestRnntDecode(unittest.TestCase):
             ofsa = streams.format_output([3, 4, 5])
             print(ofsa)
 
-    def test_with_arc_map_token(self):
+    def test_arc_map_token(self):
         """
         Almost the same with previous test function
         except testing arc_map_token generation.
-        The correctness of this test is not ensured by itself,
-        but relies on following assertion statement
-        in RnntDecodingStreams::format_output
-            `assert torch.all(fsa.scores == scores_tracked_by_autograd)`
-        See more details in k2/python/k2/rnnt_decode.py
         """
 
         for device in self.devices:
             fsa1 = k2.ctc_topo(5, device=device)
+            fsa1.scores.random_(-20, 0).to(device)
             fsa1.attr1 = torch.tensor([1] * fsa1.num_arcs, device=device)
 
             stream1 = k2.RnntDecodingStream(fsa1)
 
             fsa2 = k2.trivial_graph(3, device=device)
+            fsa2.scores.random_(-20, 0).to(device)
             fsa2.attr1 = torch.tensor([2] * fsa2.num_arcs, device=device)
             fsa2.attr2 = torch.tensor([22] * fsa2.num_arcs, device=device)
 
             stream2 = k2.RnntDecodingStream(fsa2)
 
             fsa3 = k2.ctc_topo(3, modified=True, device=device)
+            fsa3.scores.random_(-20, 0).to(device)
             fsa3.attr3 = k2.RaggedTensor(
                 torch.ones((fsa3.num_arcs, 2), dtype=torch.int32, device=device)
                 * 3

--- a/k2/python/tests/rnnt_decode_test.py
+++ b/k2/python/tests/rnnt_decode_test.py
@@ -74,6 +74,16 @@ class TestRnntDecode(unittest.TestCase):
             print(ofsa)
 
     def test_with_arc_map_token(self):
+        """
+        Almost the same with previous test function
+        except testing arc_map_token generation.
+        The correctness of this test is not ensured by itself,
+        but relies on following assertion statement
+        in RnntDecodingStreams::format_output
+            `assert torch.all(fsa.scores == scores_tracked_by_autograd)`
+        See more details in k2/python/k2/rnnt_decode.py
+        """
+
         for device in self.devices:
             fsa1 = k2.ctc_topo(5, device=device)
             fsa1.attr1 = torch.tensor([1] * fsa1.num_arcs, device=device)
@@ -130,7 +140,7 @@ class TestRnntDecode(unittest.TestCase):
                                         device=device))
             t2stream2context_shape3 = t2s_shape.compose(s2c_shape).to(device)
 
-            ofsa = streams.format_output([5, 5, 4],
+            ofsa = streams.format_output([3, 4, 5],
                                          log_probs=logprobs_list_tensor,
                                          t2s2c_shape=t2stream2context_shape3)
             print(ofsa)

--- a/k2/python/tests/rnnt_decode_test.py
+++ b/k2/python/tests/rnnt_decode_test.py
@@ -73,6 +73,68 @@ class TestRnntDecode(unittest.TestCase):
             ofsa = streams.format_output([3, 4, 5])
             print(ofsa)
 
+    def test_with_arc_map_token(self):
+        for device in self.devices:
+            fsa1 = k2.ctc_topo(5, device=device)
+            fsa1.attr1 = torch.tensor([1] * fsa1.num_arcs, device=device)
+
+            stream1 = k2.RnntDecodingStream(fsa1)
+
+            fsa2 = k2.trivial_graph(3, device=device)
+            fsa2.attr1 = torch.tensor([2] * fsa2.num_arcs, device=device)
+            fsa2.attr2 = torch.tensor([22] * fsa2.num_arcs, device=device)
+
+            stream2 = k2.RnntDecodingStream(fsa2)
+
+            fsa3 = k2.ctc_topo(3, modified=True, device=device)
+            fsa3.attr3 = k2.RaggedTensor(
+                torch.ones((fsa3.num_arcs, 2), dtype=torch.int32, device=device)
+                * 3
+            )
+
+            stream3 = k2.RnntDecodingStream(fsa3)
+
+            config = k2.RnntDecodingConfig(10, 2, 3.0, 3, 3)
+            streams = k2.RnntDecodingStreams(
+                [stream1, stream2, stream3], config
+            )
+
+            logprobs_list = []
+            t2stream_row_splits = [0]
+            stream2context_row_splits = [0]
+            num_log_probs = 0
+
+            for i in range(5):
+                shape, context = streams.get_contexts()
+                logprobs = torch.randn(
+                    (context.shape[0], 10), dtype=torch.float32, device=device
+                )
+                logprobs_list.append(logprobs)
+
+                t2stream_row_splits += [shape.tot_size(0) +
+                                        t2stream_row_splits[-1]]
+                stream2context_row_splits += (shape.row_splits(1) +
+                                              num_log_probs)[1:].tolist()
+                num_log_probs = stream2context_row_splits[-1]
+                streams.advance(logprobs)
+
+            streams.terminate_and_flush_to_streams()
+            logprobs_list_tensor = torch.cat(logprobs_list).to(device)
+            t2s_shape = k2.ragged.create_ragged_shape2(
+                row_splits=torch.tensor(t2stream_row_splits,
+                                        dtype=torch.int32,
+                                        device=device))
+            s2c_shape = k2.ragged.create_ragged_shape2(
+                row_splits=torch.tensor(stream2context_row_splits,
+                                        dtype=torch.int32,
+                                        device=device))
+            t2stream2context_shape3 = t2s_shape.compose(s2c_shape).to(device)
+
+            ofsa = streams.format_output([5, 5, 4],
+                                         log_probs=logprobs_list_tensor,
+                                         t2s2c_shape=t2stream2context_shape3)
+            print(ofsa)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Updated on Nov. 30, 2022:
k2.mwer is already merged by https://github.com/k2-fsa/k2/pull/1103

This pr will focus on tracking arc_map_token during decoding.

## Original:

An implementation of MWER, equation 2 of https://arxiv.org/pdf/2106.02302.pdf

Also solving issue https://github.com/k2-fsa/k2/issues/1061

## An example usage is:
1. slightly modification of [fast_beam_search](https://github.com/k2-fsa/icefall/blob/c30b8d3a1c095671d89321323390f8858722bcd1/egs/librispeech/ASR/transducer_stateless/beam_search.py#L226) to return log_probs of each time step.
```

log_probs_list = []
for t in range(T):
    *****(code of decoding)
    log_probs = (logits / temperature).log_softmax(dim=-1) 
    log_probs_list.append(log_probs)
    decoding_streams.advance(log_probs)
decoding_streams.terminate_and_flush_to_streams()
log_probs = torch.cat(log_probs_list) 
lattice, arc_map_token = decoding_streams.format_output(encoder_out_lens.tolist(), allow_partial=False)
return lattice, log_probs, arc_map_token 
```
2. Compute MWER based on the `lattice`, `log_probs`, `arc_map_token` 
```
lattice, log_probs, arc_map_token = fast_beam_search(                                                                                                                       
    model=model,                                                                                                                                                            
    decoding_graph=decoding_graph,                                                                                                                                          
    encoder_out=encoder_out,                                                                                                                                                
    encoder_out_lens=encoder_out_lens,                                                                                                                                      
    beam=beam,                                                                                                                                                              
    max_states=max_states,                                                                                                                                                  
    max_contexts=max_contexts,                                                                                                                                              
    temperature=temperature,                                                                                                                                                
)  
mwer_loss = k2.mwer_loss(nbest_scale, num_paths, log_probs, lattice, arc_map_token, ref_texts)
mwer_loss.backward()
```

## Unittest
Now I only manually check whether the gradient backprogates to the correct tokens, and it seems no obvious bugs.
Need more checks and unittests about this.
```
        # After loss.backward(),
        # users could manually check if the grad go to the right place,
        # An example:
        # By comapring hyps.labels and torch.where(log_probs.grad != 0)[1],
        # at least we could say that gradients seems to backpropate to the correct token,
        # i.e. 0, 15, 33, 10, 101 in following examples.
        # But why does token 95 in hyps.lables fail to get a gradient?
        # hyps.labels
        # >>>  tensor([  0,   0,  15,   0,  -1,   0,   0,  33,   0,  -1,   0,   0,  95,   0,
        #               -1,   0,   0, 101,   0,  -1,   0,   0,  10,   0,   0,  10,   0,  -1,
        #                0,   0,  10,   0,   0,  10,   0,   0,  10,   0,  -1],
        #             device='cuda:0', dtype=torch.int32)
        #
        # torch.where(log_probs.grad != 0)[0]  # corresopnds to context_index
        # >>>  tensor([ 0,  1,  1,  5,  6,  9, 10, 13, 14, 17, 18, 21, 22, 25, 26, 29, 30, 33,
        #               34, 38, 39, 39, 40, 44, 45, 46, 48, 49, 51, 52], device='cuda:0')
        #
        # torch.where(log_probs.grad != 0)[1]  # corresponds to token
        # >>>  tensor([  0,   0,  15,   0,   0,  33,   0,   0,   0,   0,   0,   0,   0,   0,
        #                0,   0,   0,   0,   0,  10,  10, 101,  10,  10,   0,  10,   0,   0,
        #                0,   0], device='cuda:0')
```


