### PR TITLE
fix error "UnicodeDecodeError: 'ascii' codec can't decode byte"

### DIFF
--- a/k2/python/k2/symbol_table.py
+++ b/k2/python/k2/symbol_table.py
@@ -127,7 +127,7 @@ class SymbolTable(Generic[Symbol]):
           An instance of :class:`SymbolTable`.
 
         '''
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             return SymbolTable.from_str(f.read().strip())
 
     def to_str(self) -> str:


### PR DESCRIPTION
When I tried to load Chinese tokens.txt, sometimes I would get this error "UnicodeDecodeError: 'ascii' codec can't decode byte".