### PR TITLE
Add requirement GCC > 7 to doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ endif()
 if(NOT K2_COMPILER_SUPPORTS_CXX14)
   message(FATAL_ERROR "
     k2 requires a compiler supporting at least C++14.
-    If you are using GCC, please upgrade it to at least version 5.0.
+    If you are using GCC, please upgrade it to at least version 7.0.
     If you are using Clang, please upgrade it to at least version 3.4.")
 endif()
 

--- a/docs/source/installation/from_source.rst
+++ b/docs/source/installation/from_source.rst
@@ -31,7 +31,7 @@ The following versions of Python, CUDA, and PyTorch are known to work.
 
 Before compiling k2, some preparation work has to be done:
 
-  - Have a compiler supporting at least C++14, e.g., GCC >= 5.0, Clang >= 3.4.
+  - Have a compiler supporting at least C++14, e.g., GCC >= 7.0, Clang >= 3.4.
   - Install CMake. CMake 3.11.0 and 3.18.0 are known to work.
   - Install Python3.
   - Install PyTorch.


### PR DESCRIPTION
GCC 5.x works with torch 1.7.1 but when it comes to some recent PyTorch versions, e.g., >= 1.10.x, we have to use
GCC > 7.x.

This PR updates the requirement GCC >= 7 so that users won't get errors when installing k2 from source using latest PyTorch.