### PR TITLE
Fix gradient of the sum operator for ragged tensors

### DIFF
--- a/k2/python/csrc/torch/v2/autograd/sum.h
+++ b/k2/python/csrc/torch/v2/autograd/sum.h
@@ -81,6 +81,7 @@ class SumFunction : public torch::autograd::Function<SumFunction> {
 
     auto grad_output = grad_outputs[0];
     // note: stride may be zero
+    // see https://github.com/k2-fsa/k2/pull/1101
     int32_t stride = grad_output.stride(0);
 
     auto opts = torch::TensorOptions()

--- a/k2/python/csrc/torch/v2/autograd/sum.h
+++ b/k2/python/csrc/torch/v2/autograd/sum.h
@@ -80,6 +80,8 @@ class SumFunction : public torch::autograd::Function<SumFunction> {
     torch::Tensor row_ids = saved[0];
 
     auto grad_output = grad_outputs[0];
+    // note: stride may be zero
+    int32_t stride = grad_output.stride(0);
 
     auto opts = torch::TensorOptions()
                     .dtype(grad_output.dtype())
@@ -98,7 +100,7 @@ class SumFunction : public torch::autograd::Function<SumFunction> {
       K2_EVAL(
           c, n, set_grad, (int32_t idx01)->void {
             int32_t idx0 = row_ids_data[idx01];
-            ans_data[idx01] = grad_output_data[idx0];
+            ans_data[idx01] = grad_output_data[idx0 * stride];
           });
     });
 


### PR DESCRIPTION
@glynpu posted the following code
```python3
#!/usr/bin/env python3
import k2
import _k2
import k2.ragged as k2r
import torch

print(k2.__file__)
print(_k2.__file__)
dtype = torch.float32
device = torch.device("cpu")
a = k2r.RaggedTensor([[3, 4], [3, 4], [5]], dtype=dtype)
a = a.to(device)
a.requires_grad_(True)
b = a.sum()
z = b.sum()
z.backward()

print(a, b, z, a.grad)
```
`a.grad` gives unexpected results:
```
RaggedTensor([[3, 4],
              [3, 4],
              [5]], dtype=torch.float32) tensor([7., 7., 5.], grad_fn=<SumFunction>>) tensor(19., grad_fn=<SumBackward0>) tensor([1.0
000e+00, 1.0000e+00, 4.5778e-41, 4.5778e-41, 1.6652e+32])
```

The reason is that `b.sum().grad` is a tensor with stride == 0, which is not handled by the code.
We rarely see a tensor with stride == 0, though we have seen such a case before.

This PR fixes that.