### PR TITLE
[Ready]minimum word error rate

### DIFF
--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -81,6 +81,8 @@ from .fsa_algo import union
 from .fsa_properties import to_str as properties_to_str
 from .mutual_information import joint_mutual_information_recursion
 from .mutual_information import mutual_information_recursion
+from .mwer_loss import MWERLoss
+from .mwer_loss import mwer_loss
 from .nbest import Nbest
 from .ops import cat
 from .ops import compose_arc_maps

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -1,0 +1,140 @@
+# Copyright (c)  2022  Xiaomi Corporation (authors: Liyong Guo)
+
+from typing import List, Union
+
+import torch
+import k2
+
+
+class MWERLoss(torch.nn.Module):
+    '''Minimum Word Error Rate Loss compuration in k2.
+
+    See equation 2 of https://arxiv.org/pdf/2106.02302.pdf about its definition.
+    '''
+
+    def __init__(self,
+                 temperature: float = 1.0,
+                 use_double_scores: bool = True):
+        '''
+        Args:
+          temperature:
+            Softmax temperature similar to (logits / temperature).log_softmax().
+            For long utterances, the dynamic range of scores will be too large
+            and the posteriors will be mostly 0 or 1.
+            To prevent this it might be a good idea to have an extra argument
+            that functions like a temperature.
+            Something we can scale the logprobs by before doing the softmax.
+          use_double_scores:
+            True to use double precision floating point.
+            False to use single precision.
+        '''
+
+        super().__init__()
+        self.temperature = temperature
+        self.use_double_scores = use_double_scores
+
+    def forward(self,
+                lattice: k2.Fsa,
+                ref_texts: Union[k2.RaggedTensor, List[List[int]]],
+                nbest_scale: float,
+                num_paths: int) -> torch.Tensor:
+        '''Compute the Minimum Word Error loss given
+        a lattice and corresponding ref_texts.
+
+        Args:
+          lattice:
+            An FsaVec with axes [utt][state][arc].
+          ref_texts:
+            It can be one of the following types:
+              - A list of list-of-integers, e..g, `[ [1, 2], [1, 2, 3] ]`
+              - An instance of :class:`k2.RaggedTensor`.
+                Must have `num_axes == 2` and with dtype `torch.int32`.
+          nbest_scale:
+            Scale `lattice.score` before passing it to :func:`k2.random_paths`.
+            A smaller value leads to more unique paths at the risk of being not
+            to sample the path with the best score.''
+          num_paths:
+            Number of paths to **sample** from the lattice
+            using :func:`k2.random_paths`.
+        Returns:
+            Minimum Word Error Rate loss.
+        '''
+
+        nbest = k2.Nbest.from_lattice(
+            lattice=lattice,
+            num_paths=num_paths,
+            use_double_scores=self.use_double_scores,
+            nbest_scale=nbest_scale,
+        )
+
+        hyps = nbest.build_levenshtein_graphs()
+        refs = k2.levenshtein_graph(ref_texts, device=hyps.device)
+        levenshtein_alignment = k2.levenshtein_alignment(
+            refs=refs,
+            hyps=hyps,
+            hyp_to_ref_map=nbest.shape.row_ids(1),
+            sorted_match_ref=True,
+        )
+        tot_scores = levenshtein_alignment.get_tot_scores(
+            use_double_scores=self.use_double_scores, log_semiring=False
+        )
+        # Each path has a corresponding wer.
+        wers = -tot_scores
+
+        # Group each log_prob into [path][arc]
+        ragged_nbest_logp = k2.RaggedTensor(nbest.kept_path.shape,
+                                            nbest.fsa.scores)
+        # Get the probalitity of each path, in log format,
+        # with shape [stream][path].
+        ragged_path_logp = k2.RaggedTensor(
+            nbest.shape, ragged_nbest_logp.sum() / self.temperature)
+
+        # Function `normalize(use_log=True)` equals to apply
+        # `torch.log_softmax(dim=-1)` over each sublist.
+        # TODO(liyong): Implement RaggedTensor.softmax
+        # to replace following two lines?
+        ragged_path_logp_normalized = ragged_path_logp.normalize(use_log=True)
+        prob_normalized = ragged_path_logp_normalized.values.exp()
+        loss = (prob_normalized * wers).sum()
+        return loss
+
+
+def mwer_loss(
+        lattice,
+        ref_texts,
+        nbest_scale=0.5,
+        num_paths=200,
+        temperature=1.0,
+        use_double_scores=True) -> torch.Tensor:
+    '''Compute the Minimum loss given a lattice and corresponding ref_texts.
+
+    Args:
+       lattice:
+         An FsaVec with axes [utt][state][arc].
+       ref_texts:
+         It can be one of the following types:
+           - A list of list-of-integers, e..g, `[ [1, 2], [1, 2, 3] ]`
+           - An instance of :class:`k2.RaggedTensor`.
+             Must have `num_axes == 2` and with dtype `torch.int32`.
+       nbest_scale:
+         Scale `lattice.score` before passing it to :func:`k2.random_paths`.
+         A smaller value leads to more unique paths at the risk of being not
+         to sample the path with the best score.''
+       num_paths:
+         Number of paths to **sample** from the lattice
+         using :func:`k2.random_paths`.
+       temperature:
+         Softmax temperature similar to (logits / temperature).log_softmax().
+         For long utterances, the dynamic range of scores will be too large
+         and the posteriors will be mostly 0 or 1.
+         To prevent this it might be a good idea to have an extra argument
+         that functions like a temperature.
+         Something we can scale the logprobs by before doing the softmax.
+       use_double_scores:
+         True to use double precision floating point.
+         False to use single precision.
+    Returns:
+       Minimum Word Error Rate loss.
+    '''
+    m = MWERLoss(temperature, use_double_scores)
+    return m(lattice, ref_texts, nbest_scale, num_paths)

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -53,7 +53,7 @@ class MWERLoss(torch.nn.Module):
                 lattice: k2.Fsa,
                 ref_texts: Union[k2.RaggedTensor, List[List[int]]],
                 nbest_scale: float,
-                num_paths: int) -> torch.Tensor:
+                num_paths: int) -> Union[torch.Tensor, k2.RaggedTensor]:
         '''Compute the Minimum Word Error loss given
         a lattice and corresponding ref_texts.
 

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -18,12 +18,11 @@ class MWERLoss(torch.nn.Module):
         '''
         Args:
           temperature:
-            Similar to temperature used in (logits / temperature).log_softmax().
             For long utterances, the dynamic range of scores will be too large
             and the posteriors will be mostly 0 or 1.
             To prevent this it might be a good idea to have an extra argument
             that functions like a temperature.
-            Something we can scale the logprobs by before doing the normalization.
+            We scale the logprobs by before doing the normalization.
           use_double_scores:
             True to use double precision floating point.
             False to use single precision.
@@ -124,12 +123,11 @@ def mwer_loss(
          Number of paths to **sample** from the lattice
          using :func:`k2.random_paths`.
        temperature:
-         Similar to temperature used in (logits / temperature).log_softmax().
          For long utterances, the dynamic range of scores will be too large
          and the posteriors will be mostly 0 or 1.
          To prevent this it might be a good idea to have an extra argument
          that functions like a temperature.
-         Something we can scale the logprobs by before doing the normalization.
+         We scale the logprobs by before doing the normalization.
        use_double_scores:
          True to use double precision floating point.
          False to use single precision.

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -52,7 +52,7 @@ class MWERLoss(torch.nn.Module):
           nbest_scale:
             Scale `lattice.score` before passing it to :func:`k2.random_paths`.
             A smaller value leads to more unique paths at the risk of being not
-            to sample the path with the best score.''
+            to sample the path with the best score.
           num_paths:
             Number of paths to **sample** from the lattice
             using :func:`k2.random_paths`.

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -15,8 +15,7 @@ class MWERLoss(torch.nn.Module):
     def __init__(self,
                  temperature: float = 1.0,
                  use_double_scores: bool = True,
-                 reduction: Literal['none', 'mean', 'sum'] = 'sum',
-                 ) -> Union[torch.Tensor, k2.RaggedTensor]:
+                 reduction: Literal['none', 'mean', 'sum'] = 'sum'):
         '''
         Args:
           temperature:
@@ -43,7 +42,7 @@ class MWERLoss(torch.nn.Module):
             'mean': divide above 'sum' by total num paths over the whole batch.
         '''
 
-        assert reduction in ('none', 'mean', 'sum')
+        assert reduction in ('none', 'mean', 'sum'), reduction
         super().__init__()
         self.temperature = temperature
         self.use_double_scores = use_double_scores
@@ -173,6 +172,6 @@ def mwer_loss(lattice,
     Returns:
        Minimum Word Error Rate loss.
     '''
-    assert reduction in ('none', 'mean', 'sum')
+    assert reduction in ('none', 'mean', 'sum'), reduction
     m = MWERLoss(temperature, use_double_scores, reduction)
     return m(lattice, ref_texts, nbest_scale, num_paths)

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -124,12 +124,12 @@ def mwer_loss(
          Number of paths to **sample** from the lattice
          using :func:`k2.random_paths`.
        temperature:
-         Softmax temperature similar to (logits / temperature).log_softmax().
+         similar to temperature used in (logits / temperature).log_softmax().
          For long utterances, the dynamic range of scores will be too large
          and the posteriors will be mostly 0 or 1.
          To prevent this it might be a good idea to have an extra argument
          that functions like a temperature.
-         Something we can scale the logprobs by before doing the softmax.
+         Something we can scale the logprobs by before doing the normalization.
        use_double_scores:
          True to use double precision floating point.
          False to use single precision.

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -40,7 +40,7 @@ class MWERLoss(torch.nn.Module):
                     Then loss_per_utt.shape[0] should be batch_size.
                     See more example usages in 'k2/python/tests/mwer_test.py'
             'sum': sum loss of each path over the whole batch together.
-            'mean': divide above 'sum' by totol num paths over the whole batch.
+            'mean': divide above 'sum' by total num paths over the whole batch.
         '''
 
         assert reduction in ('none', 'mean', 'sum')
@@ -169,7 +169,7 @@ def mwer_loss(lattice,
                  Then loss_per_utt.shape[0] should be batch_size.
                  See more example usages in 'k2/python/tests/mwer_test.py'
          'sum': sum loss of each path over the whole batch together.
-         'mean': divide above 'sum' by totol num paths over the whole batch.
+         'mean': divide above 'sum' by total num paths over the whole batch.
     Returns:
        Minimum Word Error Rate loss.
     '''

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -18,12 +18,12 @@ class MWERLoss(torch.nn.Module):
         '''
         Args:
           temperature:
-            Softmax temperature similar to (logits / temperature).log_softmax().
+            Similar to temperature used in (logits / temperature).log_softmax().
             For long utterances, the dynamic range of scores will be too large
             and the posteriors will be mostly 0 or 1.
             To prevent this it might be a good idea to have an extra argument
             that functions like a temperature.
-            Something we can scale the logprobs by before doing the softmax.
+            Something we can scale the logprobs by before doing the normalization.
           use_double_scores:
             True to use double precision floating point.
             False to use single precision.
@@ -124,7 +124,7 @@ def mwer_loss(
          Number of paths to **sample** from the lattice
          using :func:`k2.random_paths`.
        temperature:
-         similar to temperature used in (logits / temperature).log_softmax().
+         Similar to temperature used in (logits / temperature).log_softmax().
          For long utterances, the dynamic range of scores will be too large
          and the posteriors will be mostly 0 or 1.
          To prevent this it might be a good idea to have an extra argument

--- a/k2/python/k2/mwer_loss.py
+++ b/k2/python/k2/mwer_loss.py
@@ -101,7 +101,7 @@ class MWERLoss(torch.nn.Module):
 
         # Group each log_prob into [path][arc]
         ragged_nbest_logp = k2.RaggedTensor(path_arc_shape, nbest.fsa.scores)
-        # Get the probalitity of each path, in log format,
+        # Get the probability of each path, in log format,
         # with shape [stream][path].
         path_logp = ragged_nbest_logp.sum() / self.temperature
         ragged_path_prob = k2.RaggedTensor(stream_path_shape, path_logp.exp())

--- a/k2/python/k2/nbest.py
+++ b/k2/python/k2/nbest.py
@@ -77,7 +77,10 @@ class Nbest(object):
     of paths, which is also the number of FSAs in `fsa`.
     '''
 
-    def __init__(self, fsa: k2.Fsa, shape: k2.RaggedShape) -> None:
+    def __init__(self,
+                 fsa: k2.Fsa,
+                 shape: k2.RaggedShape,
+                 kept_path: k2.RaggedTensor = None) -> None:
         assert len(fsa.shape) == 3, f'fsa.shape: {fsa.shape}'
         assert shape.num_axes == 2, f'num_axes: {shape.num_axes}'
 
@@ -86,6 +89,7 @@ class Nbest(object):
 
         self.fsa = fsa
         self.shape = shape
+        self.kept_path = kept_path
 
     def __str__(self):
         s = 'Nbest('
@@ -189,7 +193,8 @@ class Nbest(object):
         # Note: fsa.scores is tracked by pytorch autograd,
         # since k2.index_select is based on torch.autograd.Function.
         # Detailed in k2/python/k2/ops.py.
-        fsa.scores = k2.index_select(lattice.scores, kept_path.values)
+        fsa.scores = k2.index_select(lattice.scores,
+                                     kept_path.values.to(lattice.scores.device))
         return Nbest(fsa=fsa, shape=utt_to_path_shape, kept_path=kept_path)
 
     def intersect(self, lats: Fsa) -> 'Nbest':

--- a/k2/python/k2/nbest.py
+++ b/k2/python/k2/nbest.py
@@ -77,10 +77,7 @@ class Nbest(object):
     of paths, which is also the number of FSAs in `fsa`.
     '''
 
-    def __init__(self,
-                 fsa: k2.Fsa,
-                 shape: k2.RaggedShape,
-                 kept_path: k2.RaggedTensor) -> None:
+    def __init__(self, fsa: k2.Fsa, shape: k2.RaggedShape) -> None:
         assert len(fsa.shape) == 3, f'fsa.shape: {fsa.shape}'
         assert shape.num_axes == 2, f'num_axes: {shape.num_axes}'
 
@@ -89,7 +86,6 @@ class Nbest(object):
 
         self.fsa = fsa
         self.shape = shape
-        self.kept_path = kept_path
 
     def __str__(self):
         s = 'Nbest('

--- a/k2/python/k2/nbest.py
+++ b/k2/python/k2/nbest.py
@@ -5,7 +5,7 @@
 # See https://github.com/k2-fsa/snowfall/issues/232 for more details
 #
 import logging
-from typing import List
+from typing import List, Union
 
 import torch
 import _k2
@@ -14,6 +14,52 @@ import k2
 from .fsa import Fsa
 
 # Note: We use `utterance` and `sequence` interchangeably in the comment
+
+
+def _get_texts(
+    best_paths: k2.Fsa, return_ragged: bool = False
+) -> Union[List[List[int]], k2.RaggedTensor]:
+    """Extract the texts (as word IDs) from the best-path FSAs.
+
+    Note:
+        Used by Nbest.build_levenshtein_graphs during MWER computation.
+        Copied from icefall.
+
+    Args:
+      best_paths:
+        A k2.Fsa with best_paths.arcs.num_axes() == 3, i.e.
+        containing multiple FSAs, which is expected to be the result
+        of k2.shortest_path (otherwise the returned values won't
+        be meaningful).
+      return_ragged:
+        True to return a ragged tensor with two axes [utt][word_id].
+        False to return a list-of-list word IDs.
+    Returns:
+      Returns a list of lists of int, containing the label sequences we
+      decoded.
+    """
+    if isinstance(best_paths.aux_labels, k2.RaggedTensor):
+        # remove 0's and -1's.
+        aux_labels = best_paths.aux_labels.remove_values_leq(0)
+        # TODO: change arcs.shape() to arcs.shape
+        aux_shape = best_paths.arcs.shape().compose(aux_labels.shape)
+
+        # remove the states and arcs axes.
+        aux_shape = aux_shape.remove_axis(1)
+        aux_shape = aux_shape.remove_axis(1)
+        aux_labels = k2.RaggedTensor(aux_shape, aux_labels.values)
+    else:
+        # remove axis corresponding to states.
+        aux_shape = best_paths.arcs.shape().remove_axis(1)
+        aux_labels = k2.RaggedTensor(aux_shape, best_paths.aux_labels)
+        # remove 0's and -1's.
+        aux_labels = aux_labels.remove_values_leq(0)
+
+    assert aux_labels.num_axes == 2
+    if return_ragged:
+        return aux_labels
+    else:
+        return aux_labels.tolist()
 
 
 class Nbest(object):
@@ -31,7 +77,10 @@ class Nbest(object):
     of paths, which is also the number of FSAs in `fsa`.
     '''
 
-    def __init__(self, fsa: Fsa, shape: _k2.RaggedShape) -> None:
+    def __init__(self,
+                 fsa: k2.Fsa,
+                 shape: k2.RaggedShape,
+                 kept_path: k2.RaggedTensor) -> None:
         assert len(fsa.shape) == 3, f'fsa.shape: {fsa.shape}'
         assert shape.num_axes == 2, f'num_axes: {shape.num_axes}'
 
@@ -40,12 +89,112 @@ class Nbest(object):
 
         self.fsa = fsa
         self.shape = shape
+        self.kept_path = kept_path
 
     def __str__(self):
         s = 'Nbest('
         s += f'num_seqs:{self.shape.dim0()}, '
         s += f'num_fsas:{self.fsa.shape[0]})'
         return s
+
+    @staticmethod
+    def from_lattice(
+        lattice: k2.Fsa,
+        num_paths: int,
+        use_double_scores: bool = True,
+        nbest_scale: float = 0.5,
+    ) -> "Nbest":
+        """Construct an Nbest object by **sampling** `num_paths` from a lattice.
+
+        Each sampled path is a linear FSA.
+
+        We assume `lattice.labels` contains token IDs and `lattice.aux_labels`
+        contains word IDs.
+
+        Args:
+          lattice:
+            An FsaVec with axes [utt][state][arc].
+          num_paths:
+            Number of paths to **sample** from the lattice
+            using :func:`k2.random_paths`.
+          use_double_scores:
+            True to use double precision in :func:`k2.random_paths`.
+            False to use single precision.
+          nbest_scale:
+            Scale `lattice.score` before passing it to :func:`k2.random_paths`.
+            A smaller value leads to more unique paths at the risk of being not
+            to sample the path with the best score.
+        Returns:
+          Return an Nbest instance.
+        """
+        saved_scores = lattice.scores.clone()
+        lattice.scores *= nbest_scale
+        # path is a ragged tensor with dtype torch.int32.
+        # It has three axes [utt][path][arc_pos]
+        path = k2.random_paths(
+            lattice, num_paths=num_paths, use_double_scores=use_double_scores
+        )
+        lattice.scores = saved_scores
+
+        # word_seq is a k2.RaggedTensor sharing the same shape as `path`
+        # but it contains word IDs. Note that it also contains 0s and -1s.
+        # The last entry in each sublist is -1.
+        # It axes is [utt][path][word_id]
+        if isinstance(lattice.aux_labels, torch.Tensor):
+            word_seq = k2.ragged.index(lattice.aux_labels, path)
+        else:
+            word_seq = lattice.aux_labels.index(path)
+            word_seq = word_seq.remove_axis(word_seq.num_axes - 2)
+        word_seq = word_seq.remove_values_leq(0)
+
+        # Each utterance has `num_paths` paths but some of them transduces
+        # to the same word sequence, so we need to remove repeated word
+        # sequences within an utterance. After removing repeats, each utterance
+        # contains different number of paths
+        #
+        # `new2old` is a 1-D torch.Tensor mapping from the output path index
+        # to the input path index.
+        _, _, new2old = word_seq.unique(
+            need_num_repeats=False, need_new2old_indexes=True
+        )
+
+        # kept_path is a ragged tensor with dtype torch.int32.
+        # It has axes [utt][path][arc_pos]
+        kept_path, _ = path.index(new2old, axis=1, need_value_indexes=False)
+
+        # utt_to_path_shape has axes [utt][path]
+        utt_to_path_shape = kept_path.shape.get_layer(0)
+
+        # Remove the utterance axis.
+        # Now kept_path has only two axes [path][arc_pos]
+        kept_path = kept_path.remove_axis(0)
+
+        # labels is a ragged tensor with 2 axes [path][token_id]
+        # Note that it contains -1s.
+        labels = k2.ragged.index(lattice.labels.contiguous(), kept_path)
+
+        # Remove -1 from labels as we will use it to construct a linear FSA
+        labels = labels.remove_values_eq(-1)
+
+        if isinstance(lattice.aux_labels, k2.RaggedTensor):
+            # lattice.aux_labels is a ragged tensor with dtype torch.int32.
+            # It has 2 axes [arc][word], so aux_labels is also a ragged tensor
+            # with 2 axes [arc][word]
+            aux_labels, _ = lattice.aux_labels.index(
+                indexes=kept_path.values, axis=0, need_value_indexes=False
+            )
+        else:
+            assert isinstance(lattice.aux_labels, torch.Tensor)
+            aux_labels = k2.index_select(lattice.aux_labels, kept_path.values)
+            # aux_labels is a 1-D torch.Tensor. It also contains -1 and 0.
+
+        fsa = k2.linear_fsa(labels)
+        fsa.aux_labels = aux_labels
+        # Note: fsa.scores is tracked by pytorch autograd,
+        # since k2.index_select is based on torch.autograd.Function.
+        # Detailed in k2/python/k2/ops.py.
+        fsa.scores = k2.index_select(lattice.scores, kept_path.values)
+        return Nbest(fsa=fsa, shape=utt_to_path_shape, kept_path=kept_path)
 
     def intersect(self, lats: Fsa) -> 'Nbest':
         '''Intersect this Nbest object with a lattice and get 1-best
@@ -140,6 +289,11 @@ class Nbest(object):
         top_k_shape = k2.ragged.regular_ragged_shape(dim0=self.shape.dim0,
                                                      dim1=k)
         return Nbest(top_k_fsas, top_k_shape)
+
+    def build_levenshtein_graphs(self) -> k2.Fsa:
+        """Return an FsaVec with axes [utt][state][arc]."""
+        word_ids = _get_texts(self.fsa, return_ragged=True)
+        return k2.levenshtein_graph(word_ids)
 
 
 def whole_lattice_rescoring(lats: Fsa, G_with_epsilon_loops: Fsa) -> Fsa:

--- a/k2/python/tests/CMakeLists.txt
+++ b/k2/python/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(py_test_files
   linear_fst_with_self_loops_test.py
   multi_gpu_test.py
   mutual_information_test.py
+  mwer_test.py
   nbest_test.py
   numerical_gradient_check_test.py
   ragged_ops_test.py

--- a/k2/python/tests/mwer_test.py
+++ b/k2/python/tests/mwer_test.py
@@ -65,7 +65,7 @@ class TestMWERLoss(unittest.TestCase):
 
             # assigned to lattice.scores
             prob_lattice = torch.tensor([0.1, 0.5, 0.2,
-                                         0.3, 0.4, 0.5]).repeat(2)
+                                         0.3, 0.4, 0.5]).repeat(2).to(device)
             prob_lattice.requires_grad_()
             logp_lattice = prob_lattice.log()
 

--- a/k2/python/tests/mwer_test.py
+++ b/k2/python/tests/mwer_test.py
@@ -100,8 +100,6 @@ class TestMWERLoss(unittest.TestCase):
             path_1_1_logp = logp[6] + logp[10] + logp[11]
             path_2_1_logp = logp[8] + logp[9] + logp[11]
             path_3_1_logp = logp[8] + logp[10] + logp[11]
-            path_0_0_logp.retain_grad()
-            path_1_0_logp.retain_grad()
 
             den_0_logp = torch.logsumexp(torch.stack([path_0_0_logp,
                                                       path_1_0_logp,

--- a/k2/python/tests/mwer_test.py
+++ b/k2/python/tests/mwer_test.py
@@ -125,9 +125,13 @@ class TestMWERLoss(unittest.TestCase):
                                            prob_2_0, prob_3_0,
                                            prob_0_1, prob_1_1,
                                            prob_2_1, prob_3_1])
-            wers = torch.tensor([1, 1, 2, 2, 2, 2, 2, 2])
+            wers = torch.tensor([1, 1, 2, 2, 2, 2, 2, 2]).to(device)
             loss_expected = (prob_normalized * wers).sum()
             assert torch.isclose(loss, loss_expected.to(loss.dtype))
             loss.backward()
             loss_expected.backward()
             assert torch.allclose(prob.grad, prob_lattice.grad, atol=1e-5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/k2/python/tests/mwer_test.py
+++ b/k2/python/tests/mwer_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#
+# Copyright      2022  Xiaomi Corporation      (authors: Liyong Guo)
+#
+# See ../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R mwer_test_py
+
+import unittest
+
+import k2
+import torch
+
+
+class TestMWERLoss(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.devices = [torch.device('cpu')]
+        if torch.cuda.is_available() and k2.with_cuda:
+            cls.devices.append(torch.device('cuda', 0))
+            if torch.cuda.device_count() > 1:
+                torch.cuda.set_device(1)
+                cls.devices.append(torch.device('cuda', 1))
+
+    def test(self):
+        # Note:
+        #  log(0.1) == -2.3026
+        #  log(0.2) == -1.6094
+        #  log(0.3) == -1.2040
+        #  log(0.4) == -0.9163
+        #  log(0.5) == -0.6931
+        for device in self.devices:
+            s = """
+                0 1 1 10 -2.3026
+                0 1 5 10 -0.6931
+                0 1 2 20 -1.6094
+                1 2 3 30 -1.2040
+                1 2 4 40 -0.9163
+                2 3 -1 -1 -0.6931
+                3
+            """
+            lattice = k2.Fsa.from_str(s, acceptor=False)
+            lattice = k2.Fsa.from_fsas([lattice, lattice])
+
+            # used to verify gradient.
+            prob = torch.tensor([0.1, 0.5, 0.2,
+                                 0.3, 0.4, 0.5]).repeat(2).to(device)
+            prob.requires_grad_()
+            logp = prob.log()
+
+            # assigned to lattice.scores
+            prob_lattice = torch.tensor([0.1, 0.5, 0.2,
+                                         0.3, 0.4, 0.5]).repeat(2)
+            prob_lattice.requires_grad_()
+            logp_lattice = prob_lattice.log()
+
+            lattice.scores = logp_lattice
+
+            refs_texts = [[10], [50]]
+            loss = k2.mwer_loss(lattice, refs_texts,
+                                nbest_scale=1.0, num_paths=200)
+
+            # each lattice has 4 distinct paths
+            # that have different word sequences:
+            # for lattice[0]:
+            # path       scores      path_p    normalized    hyps    refs  wers
+            # 10->30  [0.1 0.3 0.5]  0.015   0.015 / 0.105  [10, 30] [10]   1
+            # 10->40  [0.1 0.4 0.5]  0.020   0.020 / 0.105  [10, 40] [10]   1
+            # 20->30  [0.2 0.3 0.5]  0.030   0.030 / 0.105  [20, 30] [10]   2
+            # 20->40  [0.2 0.4 0.5]  0.040   0.040 / 0.105  [20, 40] [10]   2
+            #
+            # for lattice[1]:
+            # path       scores      path_p    normalized    hyps    refs  wers
+            # 10->30  [0.1 0.3 0.5]  0.015   0.015 / 0.105  [10, 30] [50]   2
+            # 10->40  [0.1 0.4 0.5]  0.020   0.020 / 0.105  [10, 40] [50]   2
+            # 20->30  [0.2 0.3 0.5]  0.030   0.030 / 0.105  [20, 30] [50]   2
+            # 20->40  [0.2 0.4 0.5]  0.040   0.040 / 0.105  [20, 40] [50]   2
+
+            # path_i_j is short path i from lattice j.
+            path_0_0_logp = logp[0] + logp[3] + logp[5]
+            path_1_0_logp = logp[0] + logp[4] + logp[5]
+            path_2_0_logp = logp[2] + logp[3] + logp[5]
+            path_3_0_logp = logp[2] + logp[4] + logp[5]
+            path_0_1_logp = logp[6] + logp[9] + logp[11]
+            path_1_1_logp = logp[6] + logp[10] + logp[11]
+            path_2_1_logp = logp[8] + logp[9] + logp[11]
+            path_3_1_logp = logp[8] + logp[10] + logp[11]
+            path_0_0_logp.retain_grad()
+            path_1_0_logp.retain_grad()
+
+            den_0_logp = torch.logsumexp(torch.stack([path_0_0_logp,
+                                                      path_1_0_logp,
+                                                      path_2_0_logp,
+                                                      path_3_0_logp,
+                                                      ]), dim=0)
+            den_1_logp = torch.logsumexp(torch.stack([path_0_1_logp,
+                                                      path_1_1_logp,
+                                                      path_2_1_logp,
+                                                      path_3_1_logp,
+                                                      ]), dim=0)
+
+            prob_0_0 = (path_0_0_logp - den_0_logp).exp()
+            prob_1_0 = (path_1_0_logp - den_0_logp).exp()
+            prob_2_0 = (path_2_0_logp - den_0_logp).exp()
+            prob_3_0 = (path_3_0_logp - den_0_logp).exp()
+            prob_0_1 = (path_0_1_logp - den_1_logp).exp()
+            prob_1_1 = (path_1_1_logp - den_1_logp).exp()
+            prob_2_1 = (path_2_1_logp - den_1_logp).exp()
+            prob_3_1 = (path_3_1_logp - den_1_logp).exp()
+
+            prob_normalized = torch.stack([prob_0_0, prob_1_0,
+                                           prob_2_0, prob_3_0,
+                                           prob_0_1, prob_1_1,
+                                           prob_2_1, prob_3_1])
+            wers = torch.tensor([1, 1, 2, 2, 2, 2, 2, 2])
+            loss_expected = (prob_normalized * wers).sum()
+            assert torch.isclose(loss, loss_expected.to(loss.dtype))
+            loss.backward()
+            loss_expected.backward()
+            assert torch.allclose(prob.grad, prob_lattice.grad, atol=1e-5)


### PR DESCRIPTION
MWER computation part of https://github.com/k2-fsa/k2/pull/1094.

https://github.com/k2-fsa/k2/pull/1094 mixed two parts together:
Part 1. make lattice generated by [fast_beam_search](https://github.com/k2-fsa/icefall/blob/c30b8d3a1c095671d89321323390f8858722bcd1/egs/librispeech/ASR/transducer_stateless/beam_search.py#L226) tracked by autograd.
Part 2.  Compute MWER based on a lattice and corresponding ref_texts. (What this pr does)

For part 1, modifications of [fast_beam_search](https://github.com/k2-fsa/icefall/blob/c30b8d3a1c095671d89321323390f8858722bcd1/egs/librispeech/ASR/transducer_stateless/beam_search.py#L226) still needs some time to be compatible with others use cases that do not require gradient, i.e. pure decoding processes during evaluation.   

For part 2, It is an independent work and not necessarily used together with part 1, i.e. an RNN-T decoding method. 
It's moved here so users working with ctc trained pipeline could use it immediately.
Because k2.intersect_dense_pruned is already based on `torch.autograd.Function`.

An example usage pipeline could be:
``` 
lattice = k2.intersect_dense_pruned(*correct arguments*)
mwer_loss = k2.mwer_loss(lattice, ref_texts, nbest_scale, num_paths, temperature) 
loss = other_losses + mwer_loss
loss.backward()
```
