### PR TITLE
Removing inplace grad multiplication to allow `retain_graph` in backprop

### DIFF
--- a/k2/python/k2/mutual_information.py
+++ b/k2/python/k2/mutual_information.py
@@ -177,8 +177,8 @@ class MutualInformationRecursionFunction(torch.autograd.Function):
         (px_grad, py_grad) = ctx.saved_tensors
         (B,) = ans_grad.shape
         ans_grad = ans_grad.reshape(B, 1, 1)  # (B, 1, 1)
-        px_grad *= ans_grad
-        py_grad *= ans_grad
+        px_grad = px_grad * ans_grad
+        py_grad = py_grad * ans_grad
         return (px_grad, py_grad, None, None, None)
 
 


### PR DESCRIPTION
I noticed that it is not possible to use `loss.backward(retain_graph=True)` with any of the rnn-t losses (which is useful when training with multiple optimizers).
It fails because of the in-place multiplication on gradients, saying:
```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.FloatTensor [2, 8, 17]] is at version 1; expected version 0 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

This PR fixes the issue.