### PR TITLE
[Ready]fix potential illegal memory access

### DIFF
--- a/k2/csrc/intersect_dense.cu
+++ b/k2/csrc/intersect_dense.cu
@@ -525,10 +525,14 @@ class MultiGraphDenseIntersect {
           CompressedArc carc = carcs_data[a_fsas_arc_idx012];
           K2_CHECK_EQ(a_fsas_state_idx1, (int32_t)carc.src_state);
           int32_t a_fsas_dest_state_idx1 = carc.dest_state;
-          arc_map_a_data[arc_idx_out] = a_fsas_arc_idx012;
+          if (arc_map_a_data) {
+            arc_map_a_data[arc_idx_out] = a_fsas_arc_idx012;
+          }
           int32_t scores_index = fsa_info.scores_offset +
                                  (scores_stride * t_idx1) + carc.label_plus_one;
-          arc_map_b_data[arc_idx_out] = scores_index;
+          if (arc_map_b_data) {
+            arc_map_b_data[arc_idx_out] = scores_index;
+          }
 
           float arc_score = carc.score + scores_data[scores_index];
 


### PR DESCRIPTION
The original version could trigger illegal memory access if arc_map_a/arc_map_b is nullptr.

Related code in original version:
arc_map_a_data/arc_map_b_data could be nullptr
https://github.com/k2-fsa/k2/blob/6df2d56bd9097bba8d8af12d6c1ef8cb66bf9c17/k2/csrc/intersect_dense.cu#L491-L501

While no check before assigning:
https://github.com/k2-fsa/k2/blob/6df2d56bd9097bba8d8af12d6c1ef8cb66bf9c17/k2/csrc/intersect_dense.cu#L528-L531