### PR TITLE
Fix building conda packages for torch 1.13

### DIFF
--- a/.github/workflows/build-conda-cuda-ubuntu.yml
+++ b/.github/workflows/build-conda-cuda-ubuntu.yml
@@ -20,6 +20,8 @@ name: build_conda_cuda_ubuntu
 
 on:
   push:
+    branches:
+      - fix-torch-conda-1.13-1126
     tags:
       - '*'
 
@@ -45,7 +47,7 @@ jobs:
         run: |
           # outputting for debugging purposes
           python scripts/github_actions/generate_build_matrix.py
-          MATRIX=$(python scripts/github_actions/generate_build_matrix.py --enable-cuda)
+          MATRIX=$(python scripts/github_actions/generate_build_matrix.py --enable-cuda --test-only-latest-torch)
           echo "::set-output name=matrix::${MATRIX}"
 
   build_conda_cuda_ubuntu:

--- a/.github/workflows/build-conda-cuda-ubuntu.yml
+++ b/.github/workflows/build-conda-cuda-ubuntu.yml
@@ -98,7 +98,11 @@ jobs:
           conda install -y -q anaconda-client
           conda install -y -q conda-build
           conda install -y -q bs4 requests tqdm
-          conda install -y -q -c pytorch -c conda-forge pytorch=${{ matrix.torch }} cudatoolkit=${{ matrix.cuda }}
+          if [[ ${{ matrix.torch }} == "1.13.0" ]]; then
+            conda install -y -q -c pytorch -c nvidia pytorch=${{ matrix.torch }} pytorch-cuda=${{ matrix.cuda }}
+          else
+            conda install -y -q -c pytorch -c conda-forge pytorch=${{ matrix.torch }} cudatoolkit=${{ matrix.cuda }}
+          fi
 
       - name: Display conda info
         shell: bash -l {0}

--- a/.github/workflows/build-conda-cuda-ubuntu.yml
+++ b/.github/workflows/build-conda-cuda-ubuntu.yml
@@ -20,8 +20,6 @@ name: build_conda_cuda_ubuntu
 
 on:
   push:
-    branches:
-      - fix-torch-conda-1.13-1126
     tags:
       - '*'
 
@@ -47,7 +45,7 @@ jobs:
         run: |
           # outputting for debugging purposes
           python scripts/github_actions/generate_build_matrix.py
-          MATRIX=$(python scripts/github_actions/generate_build_matrix.py --enable-cuda --test-only-latest-torch)
+          MATRIX=$(python scripts/github_actions/generate_build_matrix.py --enable-cuda)
           echo "::set-output name=matrix::${MATRIX}"
 
   build_conda_cuda_ubuntu:

--- a/.github/workflows/wheel-cpu-macos.yml
+++ b/.github/workflows/wheel-cpu-macos.yml
@@ -51,7 +51,7 @@ jobs:
           K2_IS_FOR_PYPI: 1
           K2_IS_STABLE: 1
         run: |
-          tag=$(python3 -c "import sys; print(''.join(sys.version[:3].split('.')))")
+          tag=$(python3 -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
           export K2_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE"
           export K2_MAKE_ARGS="-j2"
           python3 setup.py bdist_wheel --python-tag=py${tag}

--- a/.github/workflows/wheel-cpu-windows.yml
+++ b/.github/workflows/wheel-cpu-windows.yml
@@ -56,7 +56,7 @@ jobs:
           K2_IS_FOR_PYPI: 1
           K2_IS_STABLE: 1
         run: |
-          tag=$(python3 -c "import sys; print(''.join(sys.version[:3].split('.')))")
+          tag=$(python3 -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
           export K2_CMAKE_ARGS="-DK2_WITH_CUDA=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
           python3 setup.py bdist_wheel --python-tag=py${tag}
           ls -lh dist/

--- a/.github/workflows/wheel-cuda-ubuntu.yml
+++ b/.github/workflows/wheel-cuda-ubuntu.yml
@@ -21,10 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cuda: ["10.2"]
+        cuda: ["11.7"]
         gcc: ["7"]
-        torch: ["1.12.1"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        torch: ["1.13.0"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
           K2_IS_FOR_PYPI: 1
           K2_IS_STABLE: 1
         run: |
-          tag=$(python3 -c "import sys; print(''.join(sys.version[:3].split('.')))")
+          tag=$(python3 -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
           export K2_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE"
           export K2_MAKE_ARGS="-j2"
           python3 setup.py bdist_wheel --python-tag=py${tag}

--- a/docs/source/installation/conda.rst
+++ b/docs/source/installation/conda.rst
@@ -15,11 +15,21 @@ All you need is the following line
 
 .. code-block:: bash
 
-  $ conda install -c k2-fsa -c pytorch -c conda-forge k2 python=3.8 cudatoolkit=11.6 pytorch=1.12.1
+  $ conda install -c k2-fsa -c pytorch -c nvidia k2 pytorch=1.13.0 pytorch-cuda=11.7 python=3.8
 
-to install the **latest** k2 with Python 3.8, CUDA 11.6, and PyTorch 1.12.1.
+to install the **latest** k2 with Python 3.8, CUDA 11.7, and PyTorch 1.13.0.
 
-.. HINT::
+.. hint::
+
+  If you want to install PyTorch < 1.13, e.g., PyTorch 1.12.1, please use
+
+  .. code-block:: bash
+
+    $ conda install -c k2-fsa -c pytorch -c conda-forge k2 python=3.8 cudatoolkit=11.6 pytorch=1.12.1
+
+  to install the **latest** k2 with Python 3.8, CUDA 11.6, and PyTorch 1.12.1.
+
+.. hint::
 
    The above command is just an example. You can choose other versions of Python,
    cudatoolkit, and PyTorch as you want. For instance,
@@ -34,7 +44,7 @@ To Install a CPU version, use:
 
 .. code-block:: bash
 
-  conda install -c k2-fsa -c pytorch cpuonly k2 python=3.8 pytorch=1.12.1
+  conda install -c k2-fsa -c pytorch cpuonly k2 python=3.8 pytorch=1.13.0
 
 We provide the following YouTube video showing how to install k2 via conda.
 
@@ -46,24 +56,6 @@ We provide the following YouTube video showing how to install k2 via conda.
       `<https://www.youtube.com/channel/UC_VaumpkmINz1pNkFXAN9mw>`_
 
 ..  youtube:: HerxbUHs-V4
-
-.. HINT::
-
-  If you are using macOS and encounter the following error while
-  running ``python3 -m k2.version`` after installation:
-
-  .. code-block:: bash
-
-    ImportError: dlopen(/Users/fangjun/software/miniconda3/envs/foo/lib/python3.8/site-packages/_k2.cpython-38-darwin.so, 2): Library not loaded: @rpath/libk2context.dylib
-      Referenced from: /Users/fangjun/software/miniconda3/envs/foo/lib/python3.8/site-packages/_k2.cpython-38-darwin.so
-      Reason: image not found
-
-  You can use:
-
-    .. code-block:: bash
-
-      export DYLD_LIBRARY_PATH=$CONDA_PREFIX/lib/python3.8/site-packages:$DYLD_LIBRARY_PATH
-      python3 -m k2.version  # now it should work
 
 .. HINT::
 

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -90,7 +90,10 @@ export K2_BUILD_TYPE
 
 if [ ! -z $K2_IS_GITHUB_ACTIONS ]; then
   export K2_IS_GITHUB_ACTIONS
-  conda remove -q pytorch cudatoolkit
+  conda remove -q pytorch
+  if [ $K2_TORCH_VERSION != "1.13.0" ]; then
+    conda remove -q cudatoolkit
+  fi
   conda clean -q -a
 else
   export K2_IS_GITHUB_ACTIONS=0
@@ -98,7 +101,7 @@ fi
 
 if [ -z $K2_CONDA_TOKEN ]; then
   echo "Auto upload to anaconda.org is disabled since K2_CONDA_TOKEN is not set"
-  if [ $K2_TORCH_VERSION == "1.13" ]; then
+  if [ $K2_TORCH_VERSION == "1.13.0" ]; then
     # From torch 1.13, the command to install torch is
     # conda install pytorch torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
     conda build --no-test --no-anaconda-upload -c pytorch -c nvidia ./scripts/conda-torch-ge-1.13/k2
@@ -106,7 +109,7 @@ if [ -z $K2_CONDA_TOKEN ]; then
     conda build --no-test --no-anaconda-upload -c pytorch -c conda-forge ./scripts/conda/k2
   fi
 else
-  if [ $K2_TORCH_VERSION == "1.13" ]; then
+  if [ $K2_TORCH_VERSION == "1.13.0" ]; then
     # From torch 1.13, the command to install torch is
     # conda install pytorch torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
     conda build --no-test -c pytorch -c nvidia ./scripts/conda-torch-ge-1.13/k2

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -98,7 +98,19 @@ fi
 
 if [ -z $K2_CONDA_TOKEN ]; then
   echo "Auto upload to anaconda.org is disabled since K2_CONDA_TOKEN is not set"
-  conda build --no-test --no-anaconda-upload -c pytorch -c conda-forge ./scripts/conda/k2
+  if [ $K2_TORCH_VERSION == "1.13" ]; then
+    # From torch 1.13, the command to install torch is
+    # conda install pytorch torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
+    conda build --no-test --no-anaconda-upload -c pytorch -c nvidia ./scripts/conda-torch-ge-1.13/k2
+  else
+    conda build --no-test --no-anaconda-upload -c pytorch -c conda-forge ./scripts/conda/k2
+  fi
 else
-  conda build --no-test -c pytorch -c conda-forge --token $K2_CONDA_TOKEN ./scripts/conda/k2
+  if [ $K2_TORCH_VERSION == "1.13" ]; then
+    # From torch 1.13, the command to install torch is
+    # conda install pytorch torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
+    conda build --no-test -c pytorch -c nvidia ./scripts/conda-torch-ge-1.13/k2
+  else
+    conda build --no-test -c pytorch -c conda-forge --token $K2_CONDA_TOKEN ./scripts/conda/k2
+  fi
 fi

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -112,7 +112,7 @@ else
   if [ $K2_TORCH_VERSION == "1.13.0" ]; then
     # From torch 1.13, the command to install torch is
     # conda install pytorch torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
-    conda build --no-test -c pytorch -c nvidia ./scripts/conda-torch-ge-1.13/k2
+    conda build --no-test -c pytorch -c nvidia --token $K2_CONDA_TOKEN ./scripts/conda-torch-ge-1.13/k2
   else
     conda build --no-test -c pytorch -c conda-forge --token $K2_CONDA_TOKEN ./scripts/conda/k2
   fi

--- a/scripts/conda-torch-ge-1.13/k2/build.sh
+++ b/scripts/conda-torch-ge-1.13/k2/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright      2021  Xiaomi Corp.       (author: Fangjun Kuang)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+CONDA_ENV_DIR=$CONDA_PREFIX
+
+echo "K2_PYTHON_VERSION: $K2_PYTHON_VERSION"
+echo "K2_TORCH_VERSION: $K2_TORCH_VERSION"
+echo "K2_CUDA_VERSION: $K2_CUDA_VERSION"
+echo "K2_BUILD_TYPE: $K2_BUILD_TYPE"
+echo "K2_BUILD_VERSION: $K2_BUILD_VERSION"
+python3 --version
+
+echo "CC is: $CC"
+echo "GCC is: $GCC"
+echo "which nvcc: $(which nvcc)"
+echo "gcc version: $($CC --version)"
+echo "nvcc version: $(nvcc --version)"
+
+export K2_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=${K2_BUILD_TYPE}"
+export K2_MAKE_ARGS="-j2"
+
+python3 setup.py install --single-version-externally-managed --record=record.txt

--- a/scripts/conda-torch-ge-1.13/k2/meta.yaml
+++ b/scripts/conda-torch-ge-1.13/k2/meta.yaml
@@ -1,0 +1,46 @@
+package:
+  name: k2
+  version: "{{ environ.get('K2_BUILD_VERSION') }}"
+
+source:
+  path: "{{ environ.get('K2_ROOT_DIR') }}"
+
+build:
+  number: 0
+  string: cuda{{ environ.get('K2_CUDA_VERSION') }}_py{{ environ.get('K2_PYTHON_VERSION') }}_torch{{ environ.get('K2_TORCH_VERSION') }}
+  script_env:
+    - K2_IS_GITHUB_ACTIONS
+    - K2_CUDA_VERSION
+    - K2_TORCH_VERSION
+    - K2_PYTHON_VERSION
+    - K2_BUILD_TYPE
+    - K2_BUILD_VERSION
+    - K2_IS_FOR_CONDA
+
+requirements:
+  host:
+    - cmake=3.18
+    - python
+    - pytorch={{ environ.get('K2_TORCH_VERSION') }}
+    - pytorch-cuda={{ environ.get('K2_CUDA_VERSION') }}
+    - gcc_linux-64=7
+  run:
+    - python
+    - pytorch={{ environ.get('K2_TORCH_VERSION') }}
+    - pytorch-cuda={{ environ.get('K2_CUDA_VERSION') }}
+
+about:
+  home: https://github.com/k2-fsa/k2
+  doc_url: https://k2.readthedocs.io/en/latest/
+  license: Apache V2
+  license_file: LICENSE
+  summary: FSA/FST algorithms, differentiable, with PyTorch compatibility
+  description: |
+    The vision of k2 is to be able to seamlessly integrate Finite State Automaton
+    (FSA) and Finite State Transducer (FST) algorithms into autograd-based machine
+    learning toolkits like PyTorch and TensorFlow.  For speech recognition
+    applications, this should make it easy to interpolate and combine various
+    training objectives such as cross-entropy, CTC and MMI and to jointly optimize a
+    speech recognition system with multiple decoding passes including lattice
+    rescoring and confidence estimation.  We hope k2 will have many other
+    applications as well.


### PR DESCRIPTION
It turns out the way to install PyTorch using conda has been changed since PyTorch >= 1.13.0

## Before PyTorch 1.13.0
```bash
conda install -c pytorch -c conda-forge pytorch=1.12.1 cudatoolkit=11.6

```

## Since PyTorch 1.13.0
```
conda install -c pytorch -c nvidia pytorch=1.13 pytorch-cuda=11.6
```

The main differences are:
- (1) It uses `pytorch-cuda` to replace `cudatoolkit`
- (2) the channel `nvidia` replaces `conda-forge`


---

Note: The way to install a CPU version of PyTorch is still the same.