### PR TITLE
fix a comment error

### DIFF
--- a/k2/csrc/ragged_ops.h
+++ b/k2/csrc/ragged_ops.h
@@ -180,7 +180,7 @@ void OrPerSublist(const Ragged<T> &src, T initial_value, Array1<T> *or_values) {
 
 /*
   Stack a list of RaggedShape to create a RaggedShape with one more axis.
-  Similar to TF/PyTorch's Stack. The result will have Dim0 == src_size.
+  Similar to TF/PyTorch's Stack. The dimension of the new axis equals src_size.
   All the source RaggedShapes must have the same NumAxes().
 
      @param [in] axis   The new axis whose dimension will equal src_size.


### PR DESCRIPTION
It seems that the original comment only suitable for `axis==0`. 
If `axis > 0` then result of Dim0 is the same with `src[i]`.