### PR TITLE
Add comment for installing k2 without access to the Internet

### DIFF
--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -27,6 +27,12 @@ function(download_googltest)
   set(googletest_URL  "https://github.com/google/googletest/archive/release-1.10.0.tar.gz")
   set(googletest_HASH "SHA256=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb")
 
+  # If you don't have access to the Internet, please download the file to your
+  # local drive and use the line below (you need to change it accordingly.
+  # I am placing it in /star-fj/fangjun/download/github, but you can place it
+  # anywhere you like)
+  # set(googletest_URL  "file:///star-fj/fangjun/download/github/googletest-release-1.10.0.tar.gz")
+
   set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
   set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
   set(gtest_disable_pthreads ON CACHE BOOL "" FORCE)

--- a/cmake/kaldifeat.cmake
+++ b/cmake/kaldifeat.cmake
@@ -27,6 +27,12 @@ function(download_kaldifeat)
   set(kaldifeat_URL "https://github.com/csukuangfj/kaldifeat/archive/refs/tags/v1.20.tar.gz")
   set(kaldifeat_HASH "SHA256=509110abbb4bf510831a9abbf1f3e7a0768f9e505d7f25defeaf6545566e1aaf")
 
+  # If you don't have access to the Internet, please download the file to your
+  # local drive and use the line below (you need to change it accordingly.
+  # I am placing it in /star-fj/fangjun/download/github, but you can place it
+  # anywhere you like)
+  # set(kaldifeat_URL "file:///star-fj/fangjun/download/github/kaldifeat-1.20.tar.gz")
+
   set(kaldifeat_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
   FetchContent_Declare(kaldifeat

--- a/cmake/moderngpu.cmake
+++ b/cmake/moderngpu.cmake
@@ -24,6 +24,12 @@ function(download_moderngpu)
   set(moderngpu_URL  "https://github.com/moderngpu/moderngpu/archive/8ec9ac0de8672de7217d014917eedec5317f75f3.zip")
   set(moderngpu_HASH "SHA256=1c20ffbb81d6f7bbe6107aaa5ee6d37392677c8a5fc7894935149c3ef0a3c2fb")
 
+  # If you don't have access to the Internet, please download the file to your
+  # local drive and use the line below (you need to change it accordingly.
+  # I am placing it in /star-fj/fangjun/download/github, but you can place it
+  # anywhere you like)
+  # set(moderngpu_URL  "file:///star-fj/fangjun/download/github/moderngpu-8ec9ac0de8672de7217d014917eedec5317f75f3.zip")
+
   FetchContent_Declare(moderngpu
     URL               ${moderngpu_URL}
     URL_HASH          ${moderngpu_HASH}

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -24,6 +24,13 @@ function(download_pybind11)
   set(pybind11_URL  "https://github.com/pybind/pybind11/archive/5bc0943ed96836f46489f53961f6c438d2935357.zip")
   set(pybind11_HASH "SHA256=ff65a1a8c9e6ceec11e7ed9d296f2e22a63e9ff0c4264b3af29c72b4f18f25a0")
 
+  # If you don't have access to the Internet, please download the file to your
+  # local drive and use the line below (you need to change it accordingly.
+  # I am placing it in /star-fj/fangjun/download/github, but you can place it
+  # anywhere you like)
+  # set(pybind11_URL  "file:///star-fj/fangjun/download/github/pybind11-5bc0943ed96836f46489f53961f6c438d2935357.zip")
+
+
   set(double_quotes "\"")
   set(dollar "\$")
   set(semicolon "\;")


### PR DESCRIPTION
We, and some other people, have some problems with downloading files from `https://github.com/` when installing k2 from source.

This PR adds comments to `cmake/*.cmake` describing how to pre-download required files to the local disk so that
we can install k2 without access to the Internet.