### PR TITLE
fix lattice length

### DIFF
--- a/k2/python/csrc/torch/rnnt_decode.cu
+++ b/k2/python/csrc/torch/rnnt_decode.cu
@@ -152,6 +152,22 @@ static void PybindRnntDecodingStreams(py::module &m) {
                 torch::Tensor out_map_tensor = ToTorch<int32_t>(out_map);
                 return std::make_pair(ofsa, out_map_tensor);
               });
+
+  streams.def("format_output",
+              [](PyClass &self, std::vector<int32_t> &num_frames,
+                 bool allow_partial, bool is_final)
+              -> std::pair<FsaVec, torch::Tensor> {
+                DeviceGuard guard(self.Context());
+                FsaVec ofsa;
+                Array1<int32_t> out_map;
+                self.FormatOutput(num_frames,
+                                  allow_partial,
+                                  is_final,
+                                  &ofsa,
+                                  &out_map);
+                torch::Tensor out_map_tensor = ToTorch<int32_t>(out_map);
+                return std::make_pair(ofsa, out_map_tensor);
+              });
 }
 
 }  // namespace k2

--- a/k2/python/k2/rnnt_decode.py
+++ b/k2/python/k2/rnnt_decode.py
@@ -149,7 +149,8 @@ class RnntDecodingStreams(object):
     def format_output(
             self,
             num_frames: List[int],
-            allow_partial: bool = False
+            allow_partial: bool = False,
+            is_final: bool = False,
     ) -> Fsa:
         """
         Generate the lattice Fsa currently got.
@@ -173,6 +174,11 @@ class RnntDecodingStreams(object):
             If false, we only care about the real final state in the
             decoding graph on the last frame when generating lattice.
             Default False.
+          is_final:
+            If true, function GetFinalArcs() will be called.
+            See detail of the problem solved by GetFinalArcs() at
+            https://github.com/k2-fsa/k2/pull/1089
+
 
         Returns:
           Return the lattice Fsa with all the attributes propagated.
@@ -181,7 +187,7 @@ class RnntDecodingStreams(object):
         assert len(num_frames) == self.num_streams
 
         ragged_arcs, out_map = self.streams.format_output(
-            num_frames, allow_partial
+            num_frames, allow_partial, is_final,
         )
         fsa = Fsa(ragged_arcs)
 


### PR DESCRIPTION
A faster version of https://github.com/k2-fsa/k2/pull/1089

Also fix issue of results different with allow_partial=True/False with [yfyeung](https://github.com/yfyeung)'s blank skipping model.
Results with  [yfyeung](https://github.com/yfyeung)'s  model epoch-30-avg-10:

<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div data-zone-id="0" data-line-index="0" style="white-space: pre;">

 fast_beam_search | allow_partial | test-clean | test-other
-- | -- | -- | --
Master code | False | 15.68 | 26.13
Master code |True | 7.65 | 17.34
Master code |True(with one extra dummy frame) | 5.65 | 15.15
This pr | False | 5.65 | 15.08
This pr |True | 5.65 | 15.08

</div>
