### PR TITLE
Allow zero length references for rnnt loss

### DIFF
--- a/k2/python/k2/rnnt_loss.py
+++ b/k2/python/k2/rnnt_loss.py
@@ -190,7 +190,9 @@ def get_rnnt_logprobs(
             dim=2,
         )  # now: [B][S][T+1], index [:,:,T] has -inf..
 
-    px_lm = torch.gather(lm[:, :S], dim=2, index=symbols.unsqueeze(-1))  # [B][S][1]
+    px_lm = torch.gather(
+        lm[:, :S], dim=2, index=symbols.unsqueeze(-1)
+    )  # [B][S][1]
 
     px = px_am + px_lm  # [B][S][T+1], last slice with indexes out of
     # boundary is  -inf
@@ -299,9 +301,9 @@ def rnnt_loss_simple(
             ).expand(B, 1, 1)
         else:
             offset = (boundary[:, 3] - 1) / 2
-        penalty = offset.reshape(B, 1, 1) - torch.arange(T0, device=px.device).reshape(
-            1, 1, T0
-        )
+        penalty = offset.reshape(B, 1, 1) - torch.arange(
+            T0, device=px.device
+        ).reshape(1, 1, T0)
         penalty = penalty * delay_penalty
         px += penalty.to(px.dtype)
 
@@ -412,14 +414,18 @@ def get_rnnt_logprobs_joint(
         px = torch.cat(
             (
                 px,
-                torch.full((B, S, 1), float("-inf"), device=px.device, dtype=px.dtype),
+                torch.full(
+                    (B, S, 1), float("-inf"), device=px.device, dtype=px.dtype
+                ),
             ),
             dim=2,
         )  # now: [B][S][T+1], index [:,:,T] has -inf..
 
     px[:, :, :T] -= normalizers[:, :S, :]
 
-    py = logits[:, :, :, termination_symbol].permute((0, 2, 1)).clone()  # [B][S+1][T]
+    py = (
+        logits[:, :, :, termination_symbol].permute((0, 2, 1)).clone()
+    )  # [B][S+1][T]
     py -= normalizers
 
     if rnnt_type == "regular":
@@ -504,9 +510,9 @@ def rnnt_loss(
             ).expand(B, 1, 1)
         else:
             offset = (boundary[:, 3] - 1) / 2
-        penalty = offset.reshape(B, 1, 1) - torch.arange(T0, device=px.device).reshape(
-            1, 1, T0
-        )
+        penalty = offset.reshape(B, 1, 1) - torch.arange(
+            T0, device=px.device
+        ).reshape(1, 1, T0)
         penalty = penalty * delay_penalty
         px += penalty.to(px.dtype)
 
@@ -560,7 +566,9 @@ def _monotonic_lower_bound(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def _adjust_pruning_lower_bound(s_begin: torch.Tensor, s_range: int) -> torch.Tensor:
+def _adjust_pruning_lower_bound(
+    s_begin: torch.Tensor, s_range: int
+) -> torch.Tensor:
     """Adjust s_begin (pruning lower bounds) to make it satisfy the following
     constraints
 
@@ -597,13 +605,17 @@ def _adjust_pruning_lower_bound(s_begin: torch.Tensor, s_range: int) -> torch.Te
     (B, T) = s_begin.shape
     s_begin = _monotonic_lower_bound(s_begin)
     # do the magic transformation
-    s_begin = -(s_begin - (s_range - 1) * torch.arange(0, T, device=s_begin.device))
+    s_begin = -(
+        s_begin - (s_range - 1) * torch.arange(0, T, device=s_begin.device)
+    )
     # make the transformed tensor to be non-decreasing
     s_begin = _monotonic_lower_bound(s_begin)
     # make start symbol to be zero.
     s_begin = torch.clamp(s_begin, min=0)
     # do the magic transformation again to recover s_begin
-    s_begin = -(s_begin - (s_range - 1) * torch.arange(0, T, device=s_begin.device))
+    s_begin = -(
+        s_begin - (s_range - 1) * torch.arange(0, T, device=s_begin.device)
+    )
     return s_begin
 
 
@@ -810,13 +822,19 @@ def get_rnnt_prune_ranges_deprecated(
         than 2, or no valid paths could survive pruning. Given {s_range}"""
 
     px_pad = torch.zeros((B, 1, T1), dtype=px_grad.dtype, device=px_grad.device)
-    py_pad = torch.zeros((B, S + 1, 1), dtype=py_grad.dtype, device=py_grad.device)
+    py_pad = torch.zeros(
+        (B, S + 1, 1), dtype=py_grad.dtype, device=py_grad.device
+    )
     py_grad_padded = py_grad if T1 == T else torch.cat((py_grad, py_pad), dim=2)
-    tot_grad = torch.cat((px_grad, px_pad), dim=1) + py_grad_padded  # (B, S + 1, T1)
+    tot_grad = (
+        torch.cat((px_grad, px_pad), dim=1) + py_grad_padded
+    )  # (B, S + 1, T1)
 
     tot_grad = torch.cat(
         (
-            torch.zeros((B, 1, T1), dtype=tot_grad.dtype, device=tot_grad.device),
+            torch.zeros(
+                (B, 1, T1), dtype=tot_grad.dtype, device=tot_grad.device
+            ),
             tot_grad,
         ),
         dim=1,
@@ -897,7 +915,9 @@ def do_rnnt_pruning(
     lm_pruned = torch.gather(
         lm.unsqueeze(1).expand((B, T, S + 1, decoder_dim)),
         dim=2,
-        index=ranges.reshape((B, T, s_range, 1)).expand((B, T, s_range, decoder_dim)),
+        index=ranges.reshape((B, T, s_range, 1)).expand(
+            (B, T, s_range, decoder_dim)
+        ),
     )
     return am_pruned, lm_pruned
 
@@ -928,7 +948,10 @@ def _roll_by_shifts(src: torch.Tensor, shifts: torch.LongTensor):
     assert shifts.shape == (B, T), (shifts.shape, B, T)
 
     index = (
-        torch.arange(S, device=src.device).view((1, S)).repeat((T, 1)).repeat((B, 1, 1))
+        torch.arange(S, device=src.device)
+        .view((1, S))
+        .repeat((T, 1))
+        .repeat((B, 1, 1))
     )
     index = (index - shifts.reshape(B, T, 1)) % S
     return torch.gather(src, 2, index)
@@ -1071,7 +1094,9 @@ def get_rnnt_logprobs_pruned(
         px = torch.cat(
             (
                 px,
-                torch.full((B, S, 1), float("-inf"), device=px.device, dtype=px.dtype),
+                torch.full(
+                    (B, S, 1), float("-inf"), device=px.device, dtype=px.dtype
+                ),
             ),
             dim=2,
         )  # now: [B][S][T+1], index [:,:,T] has -inf..
@@ -1190,9 +1215,9 @@ def rnnt_loss_pruned(
             ).expand(B, 1, 1)
         else:
             offset = (boundary[:, 3] - 1) / 2
-        penalty = offset.reshape(B, 1, 1) - torch.arange(T0, device=px.device).reshape(
-            1, 1, T0
-        )
+        penalty = offset.reshape(B, 1, 1) - torch.arange(
+            T0, device=px.device
+        ).reshape(1, 1, T0)
         penalty = penalty * delay_penalty
         px += penalty.to(px.dtype)
 
@@ -1357,7 +1382,9 @@ def get_rnnt_logprobs_smoothed(
         + torch.finfo(lm_probs.dtype).tiny
     )  # [1][1][C]
     amonly_normalizers = (
-        torch.mv(am_probs.reshape(-1, C), unigram_lm.reshape(C)).reshape(B, T, 1).log()
+        torch.mv(am_probs.reshape(-1, C), unigram_lm.reshape(C))
+        .reshape(B, T, 1)
+        .log()
         + am_max
     )  # [B][T][1]
     amonly_normalizers = amonly_normalizers.transpose(1, 2)  # [B][1][T]
@@ -1393,7 +1420,9 @@ def get_rnnt_logprobs_smoothed(
             dim=2,
         )  # now: [B][S][T+1], index [:,:,T] has -inf..
 
-    px_lm = torch.gather(lm[:, :S], dim=2, index=symbols.unsqueeze(-1))  # [B][S][1]
+    px_lm = torch.gather(
+        lm[:, :S], dim=2, index=symbols.unsqueeze(-1)
+    )  # [B][S][1]
     px_lm_unigram = torch.gather(
         unigram_lm.expand(B, S, C), dim=2, index=symbols.unsqueeze(-1)
     )  # [B][S][1]
@@ -1426,10 +1455,14 @@ def get_rnnt_logprobs_smoothed(
         am_only_scale = 1.0e-20
 
     px_interp = (
-        px * combined_scale + px_lmonly * lm_only_scale + px_amonly * am_only_scale
+        px * combined_scale
+        + px_lmonly * lm_only_scale
+        + px_amonly * am_only_scale
     )
     py_interp = (
-        py * combined_scale + py_lmonly * lm_only_scale + py_amonly * am_only_scale
+        py * combined_scale
+        + py_lmonly * lm_only_scale
+        + py_amonly * am_only_scale
     )
 
     if rnnt_type == "regular":
@@ -1542,9 +1575,9 @@ def rnnt_loss_smoothed(
             ).expand(B, 1, 1)
         else:
             offset = (boundary[:, 3] - 1) / 2
-        penalty = offset.reshape(B, 1, 1) - torch.arange(T0, device=px.device).reshape(
-            1, 1, T0
-        )
+        penalty = offset.reshape(B, 1, 1) - torch.arange(
+            T0, device=px.device
+        ).reshape(1, 1, T0)
         penalty = penalty * delay_penalty
         px += penalty.to(px.dtype)
 

--- a/k2/python/k2/rnnt_loss.py
+++ b/k2/python/k2/rnnt_loss.py
@@ -145,7 +145,7 @@ def get_rnnt_logprobs(
     (B, T, C) = am.shape
     S = lm.shape[1] - 1
     assert symbols.shape == (B, S), (symbols.shape, B, S)
-    assert S >= 1, S
+    assert S >= 0, S
     assert T >= S, (T, S)
     assert rnnt_type in ["regular", "modified", "constrained"], rnnt_type
 
@@ -394,7 +394,7 @@ def get_rnnt_logprobs_joint(
     (B, T, S1, C) = logits.shape
     S = S1 - 1
     assert symbols.shape == (B, S), (symbols.shape, B, S)
-    assert S >= 1, S
+    assert S >= 0, S
     assert T >= S, (T, S)
     assert rnnt_type in ["regular", "modified", "constrained"], rnnt_type
 
@@ -671,7 +671,7 @@ def get_rnnt_prune_ranges(
     S1 = S + 1
     assert py_grad.shape == (B, S1, T), (py_grad.shape, B, S1, T)
     assert boundary.shape == (B, 4), (boundary.shape, B)
-    assert S >= 1, S
+    assert S >= 0, S
     assert T >= S, (T, S)
 
     # s_range > S means we won't prune out any symbols. To make indexing with
@@ -799,7 +799,7 @@ def get_rnnt_prune_ranges_deprecated(
     assert T1 in [T, T + 1], (T1, T)
     assert py_grad.shape == (B, S + 1, T), (py_grad.shape, B, S, T)
     assert boundary.shape == (B, 4), (boundary.shape, B)
-    assert S >= 1, S
+    assert S >= 0, S
     assert T >= S, (T, S)
 
     # s_range > S means we won't prune out any symbols. To make indexing with
@@ -1036,7 +1036,7 @@ def get_rnnt_logprobs_pruned(
     (B, T, s_range, C) = logits.shape
     assert ranges.shape == (B, T, s_range), (ranges.shape, B, T, s_range)
     (B, S) = symbols.shape
-    assert S >= 1, S
+    assert S >= 0, S
     assert T >= S, (T, S)
     assert rnnt_type in ["regular", "modified", "constrained"], rnnt_type
 
@@ -1346,7 +1346,7 @@ def get_rnnt_logprobs_smoothed(
     (B, T, C) = am.shape
     S = lm.shape[1] - 1
     assert symbols.shape == (B, S), (symbols.shape, B, S)
-    assert S >= 1, S
+    assert S >= 0, S
     assert T >= S, (T, S)
     assert rnnt_type in ["regular", "modified", "constrained"], rnnt_type
 

--- a/k2/python/tests/rnnt_loss_test.py
+++ b/k2/python/tests/rnnt_loss_test.py
@@ -280,15 +280,11 @@ class TestRnntLoss(unittest.TestCase):
                     rnnt_type=rnnt_type,
                 )
                 assert (
-                    px.shape == (B, S, T)
-                    if rnnt_type != "regular"
-                    else (B, S, T + 1)
+                    px.shape == (B, S, T) if rnnt_type != "regular" else (B, S, T + 1)
                 )
                 assert py.shape == (B, S + 1, T)
                 assert symbols.shape == (B, S)
-                m = k2.mutual_information_recursion(
-                    px=px, py=py, boundary=boundary
-                )
+                m = k2.mutual_information_recursion(px=px, py=py, boundary=boundary)
 
                 if device == torch.device("cpu"):
                     expected = -torch.mean(m)
@@ -713,7 +709,9 @@ class TestRnntLoss(unittest.TestCase):
                     s_range=r,
                 )
                 am_pruned, lm_pruned = k2.do_rnnt_pruning(
-                    am=am, lm=lm, ranges=new_ranges,
+                    am=am,
+                    lm=lm,
+                    ranges=new_ranges,
                 )
 
                 logits = am_pruned + lm_pruned
@@ -737,7 +735,9 @@ class TestRnntLoss(unittest.TestCase):
                 )
 
                 am_pruned, lm_pruned = k2.do_rnnt_pruning(
-                    am=am, lm=lm, ranges=old_ranges,
+                    am=am,
+                    lm=lm,
+                    ranges=old_ranges,
                 )
                 logits = am_pruned + lm_pruned
 
@@ -751,6 +751,133 @@ class TestRnntLoss(unittest.TestCase):
                 )
 
                 print(f"Pruned with old ranges {r} : {loss}")
+
+    # Check that training with an empty reference does not cause a crash.
+    def test_rnnt_loss_empty_reference(self):
+        B = 1
+        S = 0
+        T = 4
+        # C = 3
+        for device in self.devices:
+            # lm: [B][S+1][C]
+            lm = torch.tensor(
+                [[[0, 0, 1]]],
+                dtype=torch.float,
+                device=device,
+            )
+            # am: [B][T][C]
+            am = torch.tensor(
+                [[[0, 1, 2], [0, 0, 0], [0, 2, 4], [0, 3, 3]]],
+                dtype=torch.float,
+                device=device,
+            )
+            termination_symbol = 2
+            symbols = torch.tensor([[]], dtype=torch.long, device=device)
+
+            px, py = k2.get_rnnt_logprobs(
+                lm=lm,
+                am=am,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+            )
+            assert px.shape == (B, S, T + 1)
+            assert py.shape == (B, S + 1, T)
+            assert symbols.shape == (B, S)
+            m = k2.mutual_information_recursion(px=px, py=py, boundary=None)
+
+            if device == torch.device("cpu"):
+                expected = -m
+            assert torch.allclose(-m, expected.to(device))
+
+            # test rnnt_loss_simple
+            m = k2.rnnt_loss_simple(
+                lm=lm,
+                am=am,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+                boundary=None,
+                reduction="none",
+            )
+            assert torch.allclose(m, expected.to(device))
+
+            # test rnnt_loss_smoothed
+            m = k2.rnnt_loss_smoothed(
+                lm=lm,
+                am=am,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+                lm_only_scale=0.0,
+                am_only_scale=0.0,
+                boundary=None,
+                reduction="none",
+            )
+            assert torch.allclose(m, expected.to(device))
+
+            logits = am.unsqueeze(2) + lm.unsqueeze(1)
+
+            # test rnnt_loss
+            m = k2.rnnt_loss(
+                logits=logits,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+                boundary=None,
+                reduction="none",
+            )
+            assert torch.allclose(m, expected.to(device))
+
+            # compare with torchaudio rnnt_loss
+            if self.has_torch_rnnt_loss:
+                import torchaudio.functional
+
+                m = torchaudio.functional.rnnt_loss(
+                    logits=logits,
+                    targets=symbols.int(),
+                    logit_lengths=torch.tensor(
+                        [T] * B, dtype=torch.int32, device=device
+                    ),
+                    target_lengths=torch.tensor(
+                        [S] * B, dtype=torch.int32, device=device
+                    ),
+                    blank=termination_symbol,
+                    reduction="none",
+                )
+                assert torch.allclose(m, expected.to(device))
+
+            # should be invariant to adding a constant for any frame.
+            lm += torch.randn(B, S + 1, 1, device=device)
+            am += torch.randn(B, T, 1, device=device)
+
+            m = k2.rnnt_loss_simple(
+                lm=lm,
+                am=am,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+                boundary=None,
+                reduction="none",
+            )
+            assert torch.allclose(m, expected.to(device))
+
+            m = k2.rnnt_loss_smoothed(
+                lm=lm,
+                am=am,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+                lm_only_scale=0.0,
+                am_only_scale=0.0,
+                boundary=None,
+                reduction="none",
+            )
+            assert torch.allclose(m, expected.to(device))
+
+            logits = am.unsqueeze(2) + lm.unsqueeze(1)
+            m = k2.rnnt_loss(
+                logits=logits,
+                symbols=symbols,
+                termination_symbol=termination_symbol,
+                boundary=None,
+                reduction="none",
+            )
+            assert torch.allclose(m, expected.to(device))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on some discussions with @danpovey, it seems the RNNT loss computation itself does not have any inherent requirement of references being non-zero. Allowing this relaxation would be useful for training with possibly empty references, e.g. cases where utterance is just noise or silence, or for multi-talker ASR (e.g. see https://github.com/k2-fsa/icefall/issues/845).