### PR TITLE
Remove the constraint that k2 CUDA toolkit version has to match the torch CUDA toolkit version

### DIFF
--- a/cmake/torch.cmake
+++ b/cmake/torch.cmake
@@ -52,7 +52,7 @@ if(K2_WITH_CUDA)
   message(STATUS "PyTorch cuda version: ${TORCH_CUDA_VERSION}")
 
   if(NOT CUDA_VERSION VERSION_EQUAL TORCH_CUDA_VERSION)
-    message(FATAL_ERROR
+    message(WARNING
       "PyTorch ${TORCH_VERSION} is compiled with CUDA ${TORCH_CUDA_VERSION}.\n"
       "But you are using CUDA ${CUDA_VERSION} to compile k2.\n"
       "Please try to use the same CUDA version for PyTorch and k2.\n"

--- a/k2/python/k2/__init__.py
+++ b/k2/python/k2/__init__.py
@@ -10,16 +10,6 @@ if torch.__version__.split("+")[0] != k2_torch_version.split("+")[0]:
         f"But you are using PyTorch {torch.__version__} to run it"
     )
 
-if (
-    k2_torch_cuda_version != ""
-    and torch.version.cuda is not None
-    and torch.version.cuda != k2_torch_cuda_version
-):
-    raise ImportError(
-        f"k2 was built using CUDA {k2_torch_cuda_version}\n"
-        f"But you are using CUDA {torch.version.cuda} to run it."
-    )
-
 from _k2 import DeterminizeWeightPushingType
 from _k2 import simple_ragged_index_select
 from _k2 import swoosh_l


### PR DESCRIPTION
The following combination has been tested.
| Pytorch Version | Pytorch Cuda Version | k2 Cuda Version | 
| - | - | - |
| 2.0.1 | 11.8 | 11.6 |
| 2.0.1 | 11.7 | 11.6 |
| 1.12.1 | 10.2 | 11.6 |