### PR TITLE
Fix building cuda version of k2 on Windows

### DIFF
--- a/k2/csrc/log.h
+++ b/k2/csrc/log.h
@@ -83,12 +83,21 @@ enum class LogLevel {
 //  K2_LOG(TRACE) << "some message";
 //  K2_LOG(DEBUG) << "some message";
 //
+#ifndef _MSC_VER
 constexpr LogLevel TRACE = LogLevel::kTrace;
 constexpr LogLevel DEBUG = LogLevel::kDebug;
 constexpr LogLevel INFO = LogLevel::kInfo;
 constexpr LogLevel WARNING = LogLevel::kWarning;
 constexpr LogLevel ERROR = LogLevel::kError;
 constexpr LogLevel FATAL = LogLevel::kFatal;
+#else
+#define TRACE LogLevel::kTrace
+#define DEBUG LogLevel::kDebug
+#define INFO LogLevel::kInfo
+#define WARNING LogLevel::kWarning
+#define ERROR LogLevel::kError
+#define FATAL LogLevel::kFatal
+#endif
 
 std::string GetStackTrace();
 
@@ -110,9 +119,8 @@ K2_CUDA_HOSTDEV LogLevel GetCurrentLogLevel();
 inline bool EnableAbort() {
   static std::once_flag init_flag;
   static bool enable_abort = false;
-  std::call_once(init_flag, []() {
-    enable_abort = (std::getenv("K2_ABORT") != nullptr);
-  });
+  std::call_once(init_flag,
+                 []() { enable_abort = (std::getenv("K2_ABORT") != nullptr); });
   return enable_abort;
 }
 
@@ -274,7 +282,7 @@ class Logger {
 
 class Voidifier {
  public:
-  K2_CUDA_HOSTDEV void operator&(const Logger &)const {}
+  K2_CUDA_HOSTDEV void operator&(const Logger &) const {}
 };
 
 inline bool EnableCudaDeviceSync() {


### PR DESCRIPTION
See https://github.com/k2-fsa/k2/issues/1256#issuecomment-1783762489
and
https://gist.github.com/mc-marcocheng/badc1cbaee2ceaa05a6c304439899e29

```
      C:/Users/Mc/AppData/Local/Temp/pip-req-build-y_nc_tt1\k2/csrc/log.h(90): error : expected an identifier [C:\Users\Mc\AppData\Local\Temp\pip-req-build-y_nc_tt1\build\temp.win-amd64-cpython-310\Release\k2\csrc\context.vcxproj]
          constexpr LogLevel 0 = LogLevel::kError;
                             ^

      C:/Users/Mc/AppData/Local/Temp/pip-req-build-y_nc_tt1\k2/csrc/log.h(141): error : this constant expression has type "int" instead of the required "k2::internal::LogLevel" type [C:\Users\Mc\AppData\Local\Temp\pip-req-build-y_nc_tt1\build\temp.win-amd64-cpython-310\Release\k2\csrc\context.vcxproj]
                case 0:
                     ^

      C:/Users/Mc/AppData/Local/Temp/pip-req-build-y_nc_tt1\k2/csrc/log.h(142): error : no operator "<=" matches these operands [C:\Users\Mc\AppData\Local\Temp\pip-req-build-y_nc_tt1\build\temp.win-amd64-cpython-310\Release\k2\csrc\context.vcxproj]
                    operand types are: k2::internal::LogLevel <= int
                  if (cur_level_ <= 0) printf("[E] ");
```