### PR TITLE
Build wheels for torch 2.1.1

### DIFF
--- a/.github/workflows/run-tests-cpu.yml
+++ b/.github/workflows/run-tests-cpu.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        torch: ["2.1.0"]
+        torch: ["2.1.1"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         build_type: ["Release", "Debug"]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cuda: ["12.1"]
-        torch: ["2.1.0"]
+        torch: ["2.1.1"]
         python-version: ["3.11"]
 
     steps:

--- a/scripts/github_actions/generate_build_matrix.py
+++ b/scripts/github_actions/generate_build_matrix.py
@@ -166,10 +166,16 @@ def generate_build_matrix(
             if not for_windows
             else ["11.8.0", "12.1.0"],
         },
+        "2.1.1": {
+            "python-version": ["3.8", "3.9", "3.10", "3.11"],
+            "cuda": ["11.8", "12.1"]  # default 12.1
+            if not for_windows
+            else ["11.8.0", "12.1.0"],
+        },
         # https://github.com/Jimver/cuda-toolkit/blob/master/src/links/windows-links.ts
     }
     if test_only_latest_torch:
-        latest = "2.1.0"
+        latest = "2.1.1"
         matrix = {latest: matrix[latest]}
 
     if for_windows or for_macos:


### PR DESCRIPTION
You can find pre-built wheels at


|cpu|cuda|
|---|---|
|https://k2-fsa.github.io/k2/cpu.html|https://k2-fsa.github.io/k2/cuda.html|
|![Screenshot 2023-11-24 at 11 31 17](https://github.com/k2-fsa/k2/assets/5284924/ac6903f7-8516-482c-a63d-dfb5234a5e85)|![Screenshot 2023-11-24 at 11 31 07](https://github.com/k2-fsa/k2/assets/5284924/eb257587-32e1-4863-b6cc-5d974670c663)|
