### PR TITLE
Fix building wheels for torch 2.2.0.

### DIFF
--- a/.github/workflows/macos-cpu-wheels.yml
+++ b/.github/workflows/macos-cpu-wheels.yml
@@ -25,11 +25,11 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          # python ./scripts/github_actions/generate_build_matrix.py --for-macos
-          # MATRIX=$(python ./scripts/github_actions/generate_build_matrix.py --for-macos)
+          python ./scripts/github_actions/generate_build_matrix.py --for-macos
+          MATRIX=$(python ./scripts/github_actions/generate_build_matrix.py --for-macos)
 
-          python ./scripts/github_actions/generate_build_matrix.py --for-macos --test-only-latest-torch
-          MATRIX=$(python ./scripts/github_actions/generate_build_matrix.py --for-macos --test-only-latest-torch)
+          # python ./scripts/github_actions/generate_build_matrix.py --for-macos --test-only-latest-torch
+          # MATRIX=$(python ./scripts/github_actions/generate_build_matrix.py --for-macos --test-only-latest-torch)
           echo "::set-output name=matrix::${MATRIX}"
 
   build_wheels_macos_cpu:

--- a/scripts/github_actions/build-ubuntu-cpu.sh
+++ b/scripts/github_actions/build-ubuntu-cpu.sh
@@ -91,7 +91,7 @@ cd /var/www
 
 export CMAKE_CUDA_COMPILER_LAUNCHER=
 export K2_CMAKE_ARGS=" -DPYTHON_EXECUTABLE=$PYTHON_INSTALL_DIR/bin/python3 "
-export K2_MAKE_ARGS=" -j "
+export K2_MAKE_ARGS=" -j2 "
 
 python3 setup.py bdist_wheel
 

--- a/scripts/github_actions/generate_build_matrix.py
+++ b/scripts/github_actions/generate_build_matrix.py
@@ -5,6 +5,18 @@ import argparse
 import json
 
 
+def version_ge(a, b):
+    a_major, a_minor = list(map(int, a.split(".")))[:2]
+    b_major, b_minor = list(map(int, b.split(".")))[:2]
+    if a_major > b_major:
+        return True
+
+    if a_major == b_major and a_minor >= b_minor:
+        return True
+
+    return False
+
+
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -253,6 +265,14 @@ def generate_build_matrix(
                     ans.append({"torch": torch, "python-version": p})
                 elif for_macos or for_macos_m1:
                     ans.append({"torch": torch, "python-version": p})
+                elif version_ge(torch, "2.2.0"):
+                    ans.append(
+                        {
+                            "torch": torch,
+                            "python-version": p,
+                            "image": "pytorch/manylinux-builder:cpu-2.2",
+                        }
+                    )
                 else:
                     ans.append(
                         {


### PR DESCRIPTION
See also https://github.com/pytorch/pytorch/issues/120020 

We need to use gcc >=9 to build against pytorch 2.2.0

---

This PR fixes the following issue in icefall
https://github.com/k2-fsa/icefall/actions/runs/7947265916/job/21696348146
```
2024-02-18 08:00:22,637 INFO [train.py:495] device: cpu
2024-02-18 08:00:23,242 INFO [asr_datamodule.py:146] About to get train cuts
2024-02-18 08:00:23,242 INFO [asr_datamodule.py:247] About to get train cuts
2024-02-18 08:00:23,243 INFO [asr_datamodule.py:149] About to create train dataset
2024-02-18 08:00:23,243 INFO [asr_datamodule.py:201] Using SimpleCutSampler.
2024-02-18 08:00:23,243 INFO [asr_datamodule.py:207] About to create train dataloader
2024-02-18 08:00:23,244 INFO [asr_datamodule.py:220] About to get test cuts
2024-02-18 08:00:23,244 INFO [asr_datamodule.py:255] About to get test cuts
Traceback (most recent call last):
  File "./tdnn/train.py", line 575, in <module>
    main()
  File "./tdnn/train.py", line 571, in main
    run(rank=0, world_size=1, args=args)
  File "./tdnn/train.py", line 536, in run
    train_one_epoch(
  File "./tdnn/train.py", line 417, in train_one_epoch
    loss.backward()
  File "/usr/local/lib/python3.8/site-packages/torch/_tensor.py", line 522, in backward
    torch.autograd.backward(
  File "/usr/local/lib/python3.8/site-packages/torch/autograd/__init__.py", line 266, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/usr/local/lib/python3.8/site-packages/torch/autograd/function.py", line 289, in apply
    return user_fn(self, *args)
  File "/usr/local/lib/python3.8/site-packages/k2/autograd.py", line 116, in backward
    scores_grad = bprop_func(fsas.arcs, arc_post, tot_scores_grad)
RuntimeError: Unknown layout
```