### PR TITLE
update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ if(K2_WITH_CUDA)
       string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets ")
   endif()
 
-  if(CUDA_VERSION VERSION_GREATER_EQUAL "11.6")
+  if(CUDA_VERSION VERSION_GREATER_EQUAL "11.8")
     # https://docs.nvidia.com/cuda/archive/11.8.0/pdf/CUDA_Toolkit_Release_Notes.pdf
     # added support for Hopper (90)
     list(APPEND K2_COMPUTE_ARCH_CANDIDATES 90)


### PR DESCRIPTION
- compute capability 90 appeared first in CUDA 11.8, causing error for CUDA 11.7