### PR TITLE
Build wheels for torch 2.2.2

### DIFF
--- a/scripts/github_actions/generate_build_matrix.py
+++ b/scripts/github_actions/generate_build_matrix.py
@@ -202,10 +202,16 @@ def generate_build_matrix(
             if not for_windows
             else ["11.8.0", "12.1.0"],
         },
+        "2.2.2": {
+            "python-version": ["3.8", "3.9", "3.10", "3.11", "3.12"],
+            "cuda": ["11.8", "12.1"]  # default 12.1
+            if not for_windows
+            else ["11.8.0", "12.1.0"],
+        },
         # https://github.com/Jimver/cuda-toolkit/blob/master/src/links/windows-links.ts
     }
     if test_only_latest_torch:
-        latest = "2.2.1"
+        latest = "2.2.2"
         matrix = {latest: matrix[latest]}
 
     if for_windows or for_macos:


### PR DESCRIPTION
You can find pre-built wheels at

## CUDA wheels for Linux
https://k2-fsa.github.io/k2/cuda.html
<img width="990" alt="Screenshot 2024-03-29 at 10 08 44" src="https://github.com/k2-fsa/k2/assets/5284924/311fb7ec-1709-482c-8ff2-7a26ce30329b">


## CPU wheels for Linux, macos, Windows
https://k2-fsa.github.io/k2/cpu.html
<img width="887" alt="Screenshot 2024-03-29 at 10 09 24" src="https://github.com/k2-fsa/k2/assets/5284924/5625ae9d-de90-48d2-ad57-2264efccfb98">
